### PR TITLE
Remove references to now-removed akka sub projects.

### DIFF
--- a/community-2.11.x.dbuild
+++ b/community-2.11.x.dbuild
@@ -45,9 +45,8 @@ vars: {
   //
   // these subprojects do compile successfully at the moment
   //
-  akka-ko: [ akka-sbt-plugin, akka-channels-experimental, akka-channels-tests,
-             akka-multi-node-testkit, akka-remote-tests, akka-sample-multi-node,
-             akka-cluster, akka-contrib, akka-sample-cluster,
+  akka-ko: [ akka-multi-node-testkit, akka-remote-tests, akka-sample-multi-node,
+             akka-cluster, akka-contrib,
              akka-sample-osgi-dining-hakkers-core, akka-docs,
              akka-sample-osgi-dining-hakkers-integration, all-tests, atmos ]
 


### PR DESCRIPTION
[info] [error] These subprojects were not found: "akka-channels-tests", "akka-sbt-plugin", "akka-sample-cluster", "akka-channels-experimental".
    [info] [error] Use 'last' for the full log.
