### PR TITLE
Add @retronym's "egrep", to obtain status

### DIFF
--- a/dbuild-runner.sh
+++ b/dbuild-runner.sh
@@ -31,6 +31,8 @@ fi
 cd "dbuild-${DBUILDVERSION}"
 
 bin/dbuild "../$DBUILDCONFIG" 2>&1 | tee dbuild.out
+sleep 1
 set +x
 BUILD_ID="$(grep '^\[info\]  uuid = ' dbuild.out | sed -e 's/\[info\]  uuid = //')"
 echo "The repeatable UUID of this build was: ${BUILD_ID}"
+egrep -q "The dbuild result is.*SUCCESS" dbuild.out


### PR DESCRIPTION
I'm integrating into the dbuild runner some stuff that was added to each jenkins jobs config; dbuild-runner.sh can therefore be called without further additions. /cc @adriaanm, @gkossakowski
