### PR TITLE
Remove scala-io fork.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -51,11 +51,6 @@ vars: {
   browse-ref                   : "retronym/browse.git#topic/2.11-compat"
   // forked to make build dbuild friendly (only building lift-json)
   lift-framework-ref           : "adriaanm/framework.git#scala-2.11"
-  // forked to:
-  // 1. disable building of scaladoc docs (due to regression in scaladoc)
-  // 2. add dependency on scala-parser-combinators
-  // 3. remove use of sbteclipse plugin that Artifactory cannot resolve
-  scala-io-ref                 : "gkossakowski/scala-io.git#0.4.2-scala-2.11"
   // forked so I could upgrade to sbt 0.13.1 and remove problematic sbt plugins
   spray-json-ref               : "gkossakowski/spray-json.git#1.2.5-scala-2.11"
   // forked so I could remove problematic sbt plugins
@@ -63,6 +58,8 @@ vars: {
   // only building project twirl-api
   twirl-ref                    : "gkossakowski/twirl.git#scala-2.11"
 
+  // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
+  scala-io-ref                 : "jesseeichar/scala-io.git#7704ec7e0f20238376975f89f817dd0d81a4a5d0"
   // fixed sha from scala_2.10 branch that has Scala 2.11 compatiblity patches merged
   json4s-ref                   : "json4s/json4s.git#2de9633aae136a03f3f654db65e90c66d71826de"
   // fixed sha from master that has Scala 2.11 patches merged
@@ -212,6 +209,11 @@ build += {
     extra.sbt-version: ${vars.sbt-version-override}
     extra: {
       projects: ["core", "file"]
+      // work-around for:
+      // [info] [error] core/src/main/scala/scalax/io/LongTraversableLike.scala:310: not found: type $Coll
+      // [info] [error]    *  @usecase def zipWithIndex: $Coll[(A, Int)]
+      // [info] [error]                                  ^
+      commands += "set sources in (Compile,doc) := Seq.empty"
       // one of the tests fail for some reason
       run-tests: false
     }


### PR DESCRIPTION
Most changes needed to build scala-io with Scala 2.11 has been merged
upstream. The only remaining problem is failing scaladoc that I haven't
investigated yet.
