### PR TITLE
Remove spray-json fork.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -51,17 +51,13 @@ vars: {
   browse-ref                   : "retronym/browse.git#topic/2.11-compat"
   // forked to make build dbuild friendly (only building lift-json)
   lift-framework-ref           : "adriaanm/framework.git#scala-2.11"
-  // forked so I could remove ls plugin that clashes with dbuild plugin:
-  // https://github.com/typesafehub/distributed-build/issues/107
-  // we couldn't upgrade to sbt 0.13.1 because of regression in boilerplate plugin:
-  // https://github.com/spray/spray-json/issues/96
-  // we our stuck with our own fork for now
-  spray-json-ref               : "gkossakowski/spray-json.git#1.2.5-scala-2.11"
   // forked so I could remove problematic sbt plugins
   spray-ref                    : "gkossakowski/spray.git#1.3-scala-2.11"
   // only building project twirl-api
   twirl-ref                    : "gkossakowski/twirl.git#scala-2.11"
 
+  // fixed sha from master branch that has Scala 2.11 compatiblity patches merged
+  spray-json-ref               : "spray/spray-json.git#ac9fd8990c2bb1b259c8f7f80934b188c0b5feaf"
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
   scala-io-ref                 : "jesseeichar/scala-io.git#7704ec7e0f20238376975f89f817dd0d81a4a5d0"
   // fixed sha from scala_2.10 branch that has Scala 2.11 compatiblity patches merged
@@ -176,7 +172,7 @@ build += {
   ${vars.base} {
     name: "spray-json",
     uri: "https://github.com/"${vars.spray-json-ref},
-    extra.sbt-version: ${vars.sbt-version-override-prev}
+    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {


### PR DESCRIPTION
All Scala 2.11 compatibility patches has been merged upstream. Moreover,
spray-json upgraded to sbt 0.13.x which makes it easier to integrate into
dbuild.
