### PR TITLE
Disable running tests in spire.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -290,6 +290,10 @@ build += {
     name: "spire"
     uri: "https://github.com/"${vars.spire-ref}
     extra.sbt-version: ${vars.sbt-version-override}
+    // tests crash with:
+    // [info] [error] Could not run test spire.laws.LawTests:
+    // java.lang.ClassFormatError: Duplicate method name&signature in class file spire/std/OrderProductInstances$$anon$228
+    extra.run-tests: false
   }
 
   ${vars.base} {


### PR DESCRIPTION
It turns out that we produce broken bytecode for one of the tests so we
need to disable running tests until the issue is fixed.
