### PR TITLE
Testing a combination of flags that should help with permgen errors

### DIFF
--- a/community-2.11.x.dbuild
+++ b/community-2.11.x.dbuild
@@ -5,7 +5,9 @@
 //
 
 
-vars.base: {}
+vars.base: {
+  extra.options += "-XX:+UseConcMarkSweepGC"
+}
 include file("common-2.11.x.conf")
 
 //

--- a/community-bootstrap-2.11.x.dbuild
+++ b/community-bootstrap-2.11.x.dbuild
@@ -23,8 +23,7 @@ vars: {
   base: {
     deps.inject: [ "org.scala-lang.modules#scala-xml",
                    "org.scala-lang.modules#scala-parser-combinators" ]
-    // if you want to test optimized builds for all projects, just add:
-    // options += "-optimise"
+    extra.options += "-XX:+UseConcMarkSweepGC" 
   }
 }
 


### PR DESCRIPTION
There must be a permgen leak in sbt that is somehow exercised by
dbuild; I could get permgen errors in sbt alone, although over a
much longer test.

While launching sbt, dbuild uses "-XX:+CMSClassUnloadingEnabled";
however, that option is not effective unless the additional
option "-XX:+UseConcMarkSweepGC" is also used. This commit adds
that option manually, as a test: in theory, the combination of
the two should have a beneficial effect on PermGen troubles.

If that works, I will add it as a default option in dbuild.
