### PR TITLE
Remove fork of spray's twirl

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -50,9 +50,9 @@ vars: {
   lift-framework-ref           : "adriaanm/framework.git#scala-2.11"
   // forked so I could remove problematic sbt plugins
   spray-ref                    : "gkossakowski/spray.git#1.3-scala-2.11"
-  // only building project twirl-api
-  twirl-ref                    : "gkossakowski/twirl.git#scala-2.11"
 
+  // only building project twirl-api, fixed sha from master branch that has Scala 2.11 compatiblity patches merged
+  twirl-ref                    : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
   // fixed sha from master branch that has Scala 2.11 compatiblity patches merged
   spray-json-ref               : "spray/spray-json.git#ac9fd8990c2bb1b259c8f7f80934b188c0b5feaf"
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged


### PR DESCRIPTION
Scala 2.11 patches has been merged upstream.
