### PR TITLE
Do not track specs2 master, use latest tag instead

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -80,6 +80,9 @@ vars: {
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
 
+  // trakcing upstream, tagged release
+  specs2-ref                   : "etorreborre/specs2.git#SPECS2-2.3.10"
+
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
   async-ref                    : "scala/async.git"
@@ -89,7 +92,6 @@ vars: {
   scala-partest-ref            : "scala/scala-partest.git"
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git"
-  specs2-ref                   : "etorreborre/specs2.git"
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-full-library-ref         : "dragos/sbt-full-library.git"


### PR DESCRIPTION
Specs2 is currently broken due to issues with macro paradise plugin,
quasiquotes and source incompatibility brought by use of quasiquotes in
Scala 2.10 with quasiquotes in Scala 2.11. Let's stick to stable tag of
specs2 and let specs2 remedy the situation at their own pace.

Discussion of the issue can be found here:
https://github.com/scalamacros/paradise/issues/24#issuecomment-38632494
