### PR TITLE
Revert "Do not track specs2 master, use latest tag instead"

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -80,9 +80,6 @@ vars: {
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
 
-  // trakcing upstream, tagged release
-  specs2-ref                   : "etorreborre/specs2.git#SPECS2-2.3.10"
-
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
   async-ref                    : "scala/async.git"
@@ -92,6 +89,7 @@ vars: {
   scala-partest-ref            : "scala/scala-partest.git"
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git"
+  specs2-ref                   : "etorreborre/specs2.git"
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-full-library-ref         : "dragos/sbt-full-library.git"


### PR DESCRIPTION
See https://github.com/etorreborre/specs2/pull/248 for more information.
