### PR TITLE
Correctly include the default 'extra' options or command

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -6,12 +6,24 @@
 // so that common options or settings can be set by the
 // configuration that includes this common file.
 //
-// If you use extra.options or commands in a project, please use the form:
-//      options += "opt1"
-//      options += "opt2"
-//      options += "opt3"
+// If you use extra.options or commands in a project, or extend
+// its "extra" description in other ways, please use the form:
+//
+//      extra.options += "opt1"
+//      extra.options += "opt2"
+//      extra.options += "opt3"
 //      ...(one at a time)...
-// so that any options that may come from vars.base are prepended.
+//
+//  = or = the form:
+//
+//     extra: ${vars.base.extra} {
+//       options += "opt1"
+//       options += "opt2"
+//       options += "opt3"
+//      ...(one at a time)...
+//     }
+//
+// so that any "extra" definitions that may come from vars.base are prepended.
 // It is necessary to add the options one at a time due to a
 // limitation of the Typesafe Config library.
 //
@@ -134,7 +146,7 @@ build += {
   ${vars.base} {
     name: "parboiled",
     uri: "https://github.com/"${vars.parboiled-ref},
-    extra: {
+    extra: ${vars.base.extra} {
       projects: ["parboiled-scala"]
       sbt-version: ${vars.sbt-version-override}
       // tests do not compile due to source incompatible change in scalatest
@@ -178,7 +190,7 @@ build += {
   ${vars.base} {
     name: "spray",
     uri: "https://github.com/"${vars.spray-ref},
-    extra: {
+    extra: ${vars.base.extra} {
       sbt-version: ${vars.sbt-version-override}
       // disable running sphinx, it would be great if dbuild
       // oferred a mechanism for excluding particular project (e.g. docs)
@@ -192,7 +204,7 @@ build += {
   ${vars.base} {
     name: "Play2-core",
     uri: "https://github.com/"${vars.playframework-ref},
-    extra: {
+    extra: ${vars.base.extra} {
       projects: ["Play"]
       directory: "framework"
       run-tests: false
@@ -207,7 +219,7 @@ build += {
     name: "scala-io"
     uri: "https://github.com/"${vars.scala-io-ref}
     extra.sbt-version: ${vars.sbt-version-override}
-    extra: {
+    extra: ${vars.base.extra} {
       projects: ["core", "file"]
       // one of the tests fail for some reason
       run-tests: false
@@ -267,13 +279,13 @@ build += {
   ${vars.base} {
     name: "zeromq-scala-binding"
     uri: "https://github.com/"${vars.zeromq-scala-binding-ref}
-    extra: {run-tests: false }
+    extra: ${vars.base.extra} { run-tests: false }
   }
 
   ${vars.base} {
     name: "scalatest"
     uri: "https://github.com/"${vars.scalatest-ref}
-    extra: {
+    extra: ${vars.base.extra} {
       projects: ["scalatest"]
       commands += "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
       run-tests: false
@@ -306,7 +318,7 @@ build += {
   ${vars.base} {
     name:   "genjavadoc",
     uri:    "https://github.com/"${vars.genjavadoc-ref}
-    extra: {
+    extra: ${vars.base.extra} {
       sbt-version: ${vars.sbt-version-override}
       projects: ["tests","javaOut"]
       run-tests: false
@@ -316,7 +328,7 @@ build += {
   ${vars.base} {
     name:"akka"
     uri:    "https://github.com/"${vars.akka-ref}
-    extra: {
+    extra: ${vars.base.extra} {
       options += "-Dakka.genjavadoc.enabled=true"
       options += "-Dakka.scaladoc.diagrams=false"
       projects: ["akka-scala-nightly"]
@@ -353,7 +365,7 @@ build += {
     name:   "sbt",
     uri:    "https://github.com/"${vars.sbt-ref}
     extra.sbt-version: ${vars.sbt-version-override}
-    extra: {
+    extra: ${vars.base.extra} {
       run-tests: false
       exclude: ["launch-test"]
     }


### PR DESCRIPTION
If a project defines "extra.options += ...", the default
values of ${vars.base.extra} are included. However, if
the project defines "extra: {...", the default extra
in ${vars.base} is overridden; in that case,the definition
should really be "extra: ${vars.base.extra} {...", in
order to extend correctly the default extra values defined
in ${vars.base}.
