### PR TITLE
Use fixed sha1 for building shapeless 2.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -91,6 +91,10 @@ vars: {
   zeromq-scala-binding-ref     : "valotrading/zeromq-scala-binding.git#062e9438e322ec29d75b9649cb2aafa6ba3198a6"
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
+  // latest commits in scala-2.11.x branch break spray, Miles has been pinged about it
+  // TODO: add shapeless 1.2.4 to dbuild definition which should allow us to switch to
+  // upstream version of spray that depends on shapeless 1.2.4
+  shapeless-ref                : "milessabin/shapeless.git#6dd9ec22b68d6a911ad83d0a537bf2043b748fc2"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -108,7 +112,6 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   sbt-ref                      : "sbt/sbt.git#0.13"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.0.x"
-  shapeless-ref                : "milessabin/shapeless.git#scala-2.11.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
 
   // version settings


### PR DESCRIPTION
The latest commits in scala-2.11.x broke spray. Let's use fixed sha1
until we figure out how to build both shapeless 1.2.4 (dependency of
spray) and shapless 2 in community build.
