### PR TITLE
Downgrade to sbt 0.13.2-M1

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -115,7 +115,7 @@ vars: {
   discipline-ref               : "typelevel/discipline.git#v0.2"
 
   // version settings
-  sbt-version-override         : "0.13.2"
+  sbt-version-override         : "0.13.2-M1"
 }
 
 vars.ivyPat: ", [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"


### PR DESCRIPTION
The sbt 0.13.2 has some Ivy-related regression that makes dbuild fail.
The sbt 0.13.2-M1 appears to work fine and includes name hashing so we
can support projects that switched to name hashing incremental compilation
mode.
