### PR TITLE
Bump version to SBT 0.13.5-RC2

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -115,7 +115,7 @@ vars: {
   discipline-ref               : "typelevel/discipline.git#v0.2"
 
   // version settings
-  sbt-version-override         : "0.13.2-M1"
+  sbt-version-override         : "0.13.5-RC2"
 }
 
 vars.ivyPat: ", [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"


### PR DESCRIPTION
> On Sat, May 10, 2014 at 1:06 PM, Grzegorz Kossakowski grek@typesafe.com wrote:
> I reproduced the problem. It's due to the fact that we are using
> sbt 0.13.2-M1 in dbuild which doesn't include a bug fix for the
> issue we ran into.
> 
> Upgrading to sbt 0.13.5-RC2 restores dbuild stability.
