### PR TITLE
An attempt to globally configure all builds to use `-Ydelambdafy:method` and `-Ybackend:GenBCode`.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -117,6 +117,17 @@ vars: {
   sbt-version-override         : "0.13.5-RC2"
 }
 
+vars {
+  scalac-opts                  : ""
+  scalac-opts                  : ${?scalac_opts}   // allows additional compiler options using the scala_ref environment
+}
+
+vars.base {
+  // See https://gist.github.com/retronym/e16746e3ef5b554825f6
+  extra.commands += "set commands += {\n  def appendScalacOptions(s: State, args: Seq[String]): State = {\n    val extracted = Project extract s\n    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y\n    import extracted._\n    val r = Project.relation(extracted.structure, true)\n    val allDefs = r._1s.toSeq\n    val projectScope = Load.projectScope(currentRef)\n    val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct\n    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))\n    val session = extracted.session.appendRaw(redefined)\n    BuiltinCommands.reapply(session, structure, s)  \n  }\n  Command.args(\"appendScalacOptions\", \"<option>\")(appendScalacOptions)\n}"
+  extra.commands += "appendScalacOptions "${vars.scalac-opts}
+}
+
 vars.ivyPat: ", [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
 options.resolvers: {
   0: "local"


### PR DESCRIPTION
Unfortunately this fails pretty quickly with:

```
[info] [error] Cyclic reference involving
[info] [error]    {file:/Users/jason/code/community-builds/target-0.8.1/extraction/7f33a0a4fdb97adf988ba940c3ec7b135ab51338/projects/556be960de41f6008705036c884135862fecf3d9/}json4s/*:scalacOptions
[info] [error]    */*:scalacOptions
[info] [error] Use 'last' for the full log.
[error] java.lang.RuntimeException:
[error]     at scala.sys.package$.error(package.scala:27)
```

Sadly, `set every` is prone to this sort of issue.

An alternative approach will be to simply create a branch of
scala/scala in which these new backend components are enabled
by default.

This commit also did not bootstrap the compiler under the
new backend options. I removed the previous config to do this
(which had grown stale) in e2546846. From the config I removed:

```
name:  "scala",
system: "scala",
uri:    "git://github.com/scala/scala.git#master"
extra: {
  build-options: ["-Dscalac.args=\"-Ybackend:GenBCode\""]
}
```
