### PR TITLE
Updates to the community build files

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -114,7 +114,7 @@ vars: {
   discipline-ref               : "typelevel/discipline.git#v0.2"
 
   // version settings
-  sbt-version-override         : "0.13.5-RC2"
+  sbt-version-override         : "0.13.5"
 }
 
 vars {
@@ -122,11 +122,10 @@ vars {
   scalac-opts                  : ${?scalac_opts}   // allows additional compiler options using the scala_ref environment
 }
 
-vars.base {
-  // See https://gist.github.com/retronym/e16746e3ef5b554825f6
-  extra.commands += "set commands += {\n  def appendScalacOptions(s: State, args: Seq[String]): State = {\n    val extracted = Project extract s\n    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y\n    import extracted._\n    val r = Project.relation(extracted.structure, true)\n    val allDefs = r._1s.toSeq\n    val projectScope = Load.projectScope(currentRef)\n    val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct\n    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))\n    val session = extracted.session.appendRaw(redefined)\n    BuiltinCommands.reapply(session, structure, s)  \n  }\n  Command.args(\"appendScalacOptions\", \"<option>\")(appendScalacOptions)\n}"
-  extra.commands += "appendScalacOptions "${vars.scalac-opts}
-}
+// NB: vars.base and vars.base.extra need to be defined using +=, in order to include the
+// definitions in community-2.xx.x.dbuild
+vars.base.extra.commands += "set commands += {\n  def appendScalacOptions(s: State, args: Seq[String]): State = {\n    val extracted = Project extract s\n    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y\n    import extracted._\n    val r = Project.relation(extracted.structure, true)\n    val allDefs = r._1s.toSeq\n    val projectScope = Load.projectScope(currentRef)\n    val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct\n    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))\n    val session = extracted.session.appendRaw(redefined)\n    BuiltinCommands.reapply(session, structure, s)  \n  }\n  Command.args(\"appendScalacOptions\", \"<option>\")(appendScalacOptions)\n}"
+vars.base.extra.commands += "appendScalacOptions "${vars.scalac-opts}
 
 vars.ivyPat: ", [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
 options.resolvers: {
@@ -147,6 +146,7 @@ options.resolvers: {
 // 08: "sbt-plugin-releases: http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"${vars.ivyPat}
 // 09: "jgit-repo: http://download.eclipse.org/jgit/maven"
 // 10: "spray-repo: http://repo.spray.io"
+// 11: "sbt-plugin-releases-2: http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases"${vars.ivyPat}
 }
 
 build += {
@@ -377,8 +377,40 @@ build += {
     extra.sbt-version: ${vars.sbt-version-override}
     extra: ${vars.base.extra} {
       run-tests: false
-      exclude: ["launch-test"]
+      exclude: ["root","launch-test"]
     }
+  }
+
+  ${vars.base} {
+    name: "scoverage"
+    uri:  "https://github.com/scoverage/scalac-scoverage-plugin.git"
+    extra: ${vars.base.extra} {
+      sbt-version: ${vars.sbt-version-override}
+      run-tests: false // [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].
+    }
+  }
+
+// scala-logging-slf4j is used by scoverage, but:
+// - scala-logging-slf4j v2.1.2 won't compile (not found: value LoggerMacro)
+// - and v3.0.0 changed the artifacts, so we grab v2.1.2 via Ivy instead.
+//  ${vars.base} {
+//    name: "scala-logging"
+//    uri:  "https://github.com/typesafehub/scala-logging.git#v2.1.2"
+//    extra: ${vars.base.extra} {
+//      sbt-version: ${vars.sbt-version-override}
+//    }
+//  }
+
+  {
+    name:   "scala-logging-slf4j"
+    system: "ivy"
+    uri:    "ivy:com.typesafe.scala-logging#scala-logging-slf4j_2.11;2.1.2"
+  }
+
+  {
+    name:   "scala-logging-api"
+    system: "ivy"
+    uri:    "ivy:com.typesafe.scala-logging#scala-logging-api_2.11;2.1.2"
   }
 
   ${vars.base} {


### PR DESCRIPTION
- modified the change of vars.base.extra.commands, so that the
  original definitions of vars.base and vars.base.extra in
  the community*.dbuild files are preserved
- added scoverage, now needed by specs2
- added scala-logging-slf4j and scala-logging-api (v2.1.2),
  needed by scoverage
- updated 0.13.5-RC2 to 0.13.5 final (RC2 has been withdrawn)
- disabled root subproject in sbt, to work around the change
  in publishing mechanism (now using Release)
