### PR TITLE
Switch to sbt's fixed sha1

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -98,6 +98,10 @@ vars: {
   // Commit: https://github.com/scoverage/scalac-scoverage-plugin/commit/dbc28b18bf87a96c9372844e9d892adc7737d80f
   // Failing build: https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x/218/console
   scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#4c4fd3672658e48e52e884c9003d25b9f8b83bd5"
+  // change from https://github.com/sbt/sbt/pull/1509 broke building sbt with Scala 2.11
+  // this problem is tracked in https://github.com/sbt/sbt/issues/1523
+  // for now, we stick to fixed sha1 of sbt right before the merge of #1509
+  sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -113,7 +117,6 @@ vars: {
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-full-library-ref         : "dragos/sbt-full-library.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
-  sbt-ref                      : "sbt/sbt.git#0.13"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
 


### PR DESCRIPTION
Change from sbt/sbt#1509 broke building sbt with Scala 2.11
This problem is tracked in sbt/sbt#1523
For now, we stick to fixed sha1 of sbt right before the merge of
sbt/sbt#1509.
