### PR TITLE
Fix to the last-known-working version of Specs2.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -112,7 +112,10 @@ vars: {
   scala-partest-ref            : "scala/scala-partest.git"
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git"
-  specs2-ref                   : "etorreborre/specs2.git"
+
+  // TODO move back to master after adding scalaz-stream to the community build.
+  specs2-ref                   : "etorreborre/specs2.git#8fa92f3f9dac61ba39e169b83c091c4d5b15cb8c"
+
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-full-library-ref         : "dragos/sbt-full-library.git"


### PR DESCRIPTION
Shortly after this, scalaz-stream was added as a dependency.
We need to add that project to the community build before we
can continue to track Specs2 master.

Review by @gkossakowski
