### PR TITLE
Revert to last-known-working version of paradise-2.10

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -541,7 +541,13 @@ projects:[
   name:   paradise-210
   // macro-paradise is used by SPECS2-2.2.2
   //
-  uri: "git://github.com/scalamacros/paradise.git#2.10.x"
+  uri: "git://github.com/scalamacros/paradise.git#5308dad52bfedc6109f58460a3a71ec1b6a64eb4"
+  
+  // was #2.10.x, but recent changes to paradise now result in
+  // 903a36eaa63ca388975b323aa079de30c8cb67f9/quasiquotes/target/scala-2.10.5-dbuildx96605c425eb3e786a0c5812d9145153138eb23bf/api...
+  // [paradise-210] java.lang.AbstractMethodError
+  // [paradise-210]  at scala.tools.nsc.typechecker.Macros$class.$init$(Macros.scala:911)
+  // [paradise-210]  at org.scalamacros.paradise.Plugin$$anon$1.<init>(Plugin.scala:25)
 }
 {
   name: parboiled-210


### PR DESCRIPTION
Not sure what is going wrong here, but I suspect it is related to
one of:

https://github.com/scalamacros/paradise/commit/ede29e7f9d6820f063391e045e62063c4893152d
https://github.com/scalamacros/paradise/commit/d1284c776cac657b91a2e63f59bdbd8fd7dba50b

Here's the failure:

https://jenkins-dbuild.typesafe.com:8499/view/Shared/job/Community-2.11.x/279/consoleFull

Review by @gkossakowski
