### PR TITLE
Fix to Spray JSON v1.2.6 in the 2.10 space

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -478,7 +478,7 @@ projects:[
 }
 {
   name: spray-json-210
-  uri: "git://github.com/spray/spray-json.git"
+  uri: "git://github.com/spray/spray-json.git#v1.2.6"
 }
 // compiling spray from source entails a few problems,
 // so I am grabbing existing artifacts via Ivy, for now.


### PR DESCRIPTION
Tracking master has led us into this source incompatibility:

https://github.com/spray/spray-json/commit/37af0d4ca
