### PR TITLE
Remove sbt-library-full from community build

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -118,7 +118,6 @@ vars: {
 
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
-  sbt-full-library-ref         : "dragos/sbt-full-library.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
@@ -432,13 +431,6 @@ build += {
   ${vars.base} {
     name:   "zinc",
     uri:    "https://github.com/"${vars.zinc-ref}
-    extra.sbt-version: "0.12.5-dbuild"
-    space: default // We don't compile plugins, for 0.12/2.9.x
-  }
-
-  ${vars.base} {
-    name:   "sbt-full-library",
-    uri:    "https://github.com/"${vars.sbt-full-library-ref}
     extra.sbt-version: "0.12.5-dbuild"
     space: default // We don't compile plugins, for 0.12/2.9.x
   }


### PR DESCRIPTION
[Quoth @dragos](> https://github.com/dragos/sbt-full-library/pull/3#issuecomment-56634966):

> This project is a failed experiment. I don't think this should be
> in the community build, we're using sbt-republish and dbuild for
> the same purpose (to obtain OSGi-via-maven artifacts).

Review by @cunei
