### PR TITLE
Upgrade to Scalaz 7.1.x series.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -120,7 +120,7 @@ vars: {
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-full-library-ref         : "dragos/sbt-full-library.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
-  scalaz-ref                   : "scalaz/scalaz.git#series/7.0.x"
+  scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
 
   // version settings


### PR DESCRIPTION
This is the latest stable release of Scalaz. We upgrade it only in the
default space. There's another scalaz defined as "scalaz-210" and is used
for building sbt plugins. We keep it at 7.0.x to avoid problems with
sbteclipse. Once sbteclipse upgrades to latest scalaz, we should move
that version in our config too.
