### PR TITLE
Switch to fixed sha1 of sbt-pgp.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -700,7 +700,7 @@ projects:[
 
 {
   name: sbt-pgp
-  uri: "git://github.com/sbt/sbt-pgp.git"
+  uri: "git://github.com/sbt/sbt-pgp.git#f657f3640e67913bec3f441e8c4e671cd3e9b511"
 }
 {
   name: dispatch-http-210


### PR DESCRIPTION
The latest sbt-pgp breaks community build:

```
[sbt-pgp:error] /localhome/jenkinsdbuild3/workspace/Community-2.11.x/target-0.9.1/extraction/339159ea2e9fa8b3beb4289cbd915661e0b05139/projects/19c0b8b27033f64bd4818d752178a911efec4e19/build.sbt:0: error: '.' expected but eof found.
[sbt-pgp:error] import _root_.sbt.plugins.IvyPlugin, _root_.sbt.plugins.JvmPlugin, _root_.sbt.plugins.CorePlugin, _root_.sbt.plugins.JUnitXmlReportPlugin, PgpCommonSettings
[sbt-pgp:error]                                                                                                                                                             ^
[sbt-pgp] sbt.compiler.EvalException: Error parsing imports for expression.
```

Let's switch to the latest sha1 of sbt-pgp that is known to be working properly.
