### PR TITLE
Fix Zinc breakage

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -164,13 +164,13 @@ build += {
   space.from: [ default, sbtplugins ]
   space.to: default
   extraction-version: "2.11.0-RC1"
+  sbt-version: ${vars.sbt-version-override}
   projects: [
   ${vars.base} {
     name: "parboiled",
     uri: "https://github.com/"${vars.parboiled-ref},
     extra: ${vars.base.extra} {
       projects: ["parboiled-scala"]
-      sbt-version: ${vars.sbt-version-override}
       // tests do not compile due to source incompatible change in scalatest
       // TestNGSuite became a class but was a trait
       run-tests: false
@@ -181,14 +181,12 @@ build += {
     name: "json4s",
     uri: "https://github.com/"${vars.json4s-ref}
     extra.projects: ["json4s-native", "json4s-jackson"]
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: "lift-json",
     uri: "https://github.com/"${vars.lift-framework-ref}
     extra.projects: ["lift-json"]
-    extra.sbt-version: ${vars.sbt-version-override}
     // test failure:
     //[info] [info] ! Either can't be deserialized with type hints
     //[info] [error]  ClassNotFoundException: : scala.util.Left  (Formats.scala:223)
@@ -200,20 +198,17 @@ build += {
     name: "spray-twirl",
     uri: "https://github.com/"${vars.twirl-ref}
     extra.projects: ["twirl-api"]
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: "spray-json",
-    uri: "https://github.com/"${vars.spray-json-ref},
-    extra.sbt-version: ${vars.sbt-version-override}
+    uri: "https://github.com/"${vars.spray-json-ref}
   }
 
   ${vars.base} {
     name: "spray",
     uri: "https://github.com/"${vars.spray-ref},
     extra: ${vars.base.extra} {
-      sbt-version: ${vars.sbt-version-override}
       // disable running sphinx, it would be great if dbuild
       // oferred a mechanism for excluding particular project (e.g. docs)
       commands += "set SphinxSupport.sphinxCompile in docs := Seq.empty"
@@ -234,13 +229,11 @@ build += {
         // and we get double definition error
       commands += "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
     }
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: "scala-io"
     uri: "https://github.com/"${vars.scala-io-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     extra: ${vars.base.extra} {
       projects: ["core", "file"]
       // one of the tests fail for some reason
@@ -251,13 +244,11 @@ build += {
   ${vars.base} {
     name: "scala-arm"
     uri: "https://github.com/"${vars.scala-arm-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }  
 
   ${vars.base} {
     name: "scala-partest-interface",
     uri: "https://github.com/"${vars.scala-partest-interface-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   //
@@ -270,40 +261,34 @@ build += {
     uri:    "https://github.com/"${vars.scala-stm-ref}
     // a minor incompatibility with recent versions of scalatest, therefore:
     extra.run-tests: false
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: shapeless
     uri:    "https://github.com/"${vars.shapeless-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
 
   }
 
   ${vars.base} {
     name: specs2
     uri: "https://github.com/"${vars.specs2-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     extra.run-tests: false // at least SnippetsTest is failing.
   }
 
   ${vars.base} {
     name: sbinary
     uri:    "https://github.com/"${vars.sbinary-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: scalaz
     uri: "https://github.com/"${vars.scalaz-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: "zeromq-scala-binding"
     uri: "https://github.com/"${vars.zeromq-scala-binding-ref}
     extra: ${vars.base.extra} { run-tests: false }
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
@@ -313,20 +298,17 @@ build += {
       projects: ["scalatest"]
       commands += "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
       run-tests: false
-      sbt-version: ${vars.sbt-version-override}
     }
   }
 
   ${vars.base} {
     name: "discipline"
     uri: "https://github.com/"${vars.discipline-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name: "spire"
     uri: "https://github.com/"${vars.spire-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     // tests crash with:
     // [info] [error] Could not run test spire.laws.LawTests:
     // java.lang.ClassFormatError: Duplicate method name&signature in class file spire/std/OrderProductInstances$$anon$228
@@ -337,14 +319,12 @@ build += {
     name:   "genjavadoc-plugin",
     uri:    "https://github.com/"${vars.genjavadoc-ref}
     extra.projects: genjavadoc-plugin
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name:   "genjavadoc",
     uri:    "https://github.com/"${vars.genjavadoc-ref}
     extra: ${vars.base.extra} {
-      sbt-version: ${vars.sbt-version-override}
       projects: ["tests","javaOut"]
       run-tests: false
     }
@@ -359,7 +339,6 @@ build += {
       projects: ["akka-scala-nightly"]
       run-tests: false
     }
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   //
@@ -368,20 +347,17 @@ build += {
   ${vars.base} {
     name: "async"
     uri: "https://github.com/"${vars.async-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     extra.run-tests: false // ToolBox based tests report missing JARs. Probably some poor assumption in the async tests.
   }
 
   ${vars.base} {
     name: "slick"
     uri:  "https://github.com/"${vars.slick-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name:   "browse",
     uri:    "https://github.com/"${vars.browse-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     extra.commands += "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
     extra.exclude: ["test", "testLink"]
   }
@@ -389,7 +365,6 @@ build += {
   ${vars.base} {
     name:   "sbt",
     uri:    "https://github.com/"${vars.sbt-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     extra: ${vars.base.extra} {
       run-tests: false
       exclude: ["root","launch-test"]
@@ -400,7 +375,6 @@ build += {
     name: "scoverage"
     uri:  "https://github.com/"${vars.scoverage-ref}
     extra: ${vars.base.extra} {
-      sbt-version: ${vars.sbt-version-override}
       run-tests: false // [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].
     }
   }
@@ -411,9 +385,6 @@ build += {
 //  ${vars.base} {
 //    name: "scala-logging"
 //    uri:  "https://github.com/typesafehub/scala-logging.git#v2.1.2"
-//    extra: ${vars.base.extra} {
-//      sbt-version: ${vars.sbt-version-override}
-//    }
 //  }
 
   {


### PR DESCRIPTION
Use sbt 0.13 for building zinc.

Let's get rid of override of sbt version when building zinc. Zinc has
already migrated to sbt 0.13 and it doesn't have to be treated specially.

The second commit includes some cleanups related to sbt-version-overrides. W remove sbt-version-overrides in each project. We can override sbt version at the build level which propagates to
all projects defined in given build. It cuts down on boilerplate in the config.
