### PR TITLE
Restore community build's stability

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -60,7 +60,10 @@ vars: {
   browse-ref                   : "retronym/browse.git#topic/2.11-compat"
   lift-framework-ref           : "lift/framework.git#3.0-M2-release"
   spray-ref                    : "gkossakowski/spray.git#1.3-scala-2.11"
-  twirl-ref                    : "spray/twirl.git#v0.7.0-scala-2.11.0"
+  // only building project twirl-api, fixed sha from master branch that has Scala 2.11 compatiblity patches merged
+  spray-twirl-ref              : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
+  // fix for matching scalaBinaryVersion that causes issues in dbuild
+  play-twirl-ref               : "playframework/twirl.git#pull/45/head"
   spray-json-ref               : "spray/spray-json.git#v1.3.0"
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
   scala-io-ref                 : "jesseeichar/scala-io.git#7704ec7e0f20238376975f89f817dd0d81a4a5d0"
@@ -190,8 +193,13 @@ build += {
 
   ${vars.base} {
     name: "spray-twirl",
-    uri: "https://github.com/"${vars.twirl-ref}
+    uri: "https://github.com/"${vars.spray-twirl-ref}
     extra.projects: ["twirl-api"]
+  }
+
+  ${vars.base} {
+    name: "play-twirl",
+    uri: "https://github.com/"${vars.play-twirl-ref}
   }
 
   ${vars.base} {


### PR DESCRIPTION
The #63 was a bit too eager on cleanups which broke community build.

This PR restores build's stability by:
- switching back to our old fork of spray (see 7c9fba8 for details)
- adding support for new twirl that has been moved to Play (see 0a496fd for details)
