### PR TITLE
update to spray 1.3.2

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -59,7 +59,8 @@ vars: {
   // TODO: merge required changes upstream to get rid of our forks, maintaining our one won't scale
   browse-ref                   : "retronym/browse.git#topic/2.11-compat"
   lift-framework-ref           : "lift/framework.git#3.0-M2-release"
-  spray-ref                    : "gkossakowski/spray.git#1.3-scala-2.11"
+  // basically spray 1.3.2 with some build fixes applied
+  spray-ref                    : "spray/spray.git#43d93b255c6a7f9e510111e9272d83e228638304"
   // only building project twirl-api, fixed sha from master branch that has Scala 2.11 compatiblity patches merged
   spray-twirl-ref              : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
   // fix for matching scalaBinaryVersion that causes issues in dbuild
@@ -211,6 +212,8 @@ build += {
     name: "spray",
     uri: "https://github.com/"${vars.spray-ref},
     extra: ${vars.base.extra} {
+      // disable subprojects depending on shapeless 1
+      exclude: ["spray-routing", "spray-routing-tests"]
       // disable running sphinx, it would be great if dbuild
       // oferred a mechanism for excluding particular project (e.g. docs)
       commands += "set SphinxSupport.sphinxCompile in docs := Seq.empty"


### PR DESCRIPTION
This disables legacy subprojects depending on shapeless 1.
