### PR TITLE
Add scala-refactoring to the community build.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -77,6 +77,8 @@ vars: {
   // fixed sha/tag (a compromise)
   slick-ref                    : "slick/slick.git#pull/686/head"
   genjavadoc-ref               : "typesafehub/genjavadoc.git#v0.5_2.11.0-M8"
+  // There's no suitable release yet, so we depend on this commit. Upgrade to the next tagged version once released
+  scala-refactoring-ref        : "scala-ide/scala-refactoring.git#bddaf0bc36e0e1cc45965d582fa6fb7abcafc808"
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.11.3"
@@ -337,6 +339,16 @@ build += {
       options += "-Dakka.genjavadoc.enabled=true"
       options += "-Dakka.scaladoc.diagrams=false"
       projects: ["akka-scala-nightly"]
+      run-tests: false
+    }
+  }
+
+  ${vars.base} {
+    name:   "scala-refactoring",
+    uri:    "https://github.com/"${vars.scala-refactoring-ref},
+    extra: ${vars.base.extra} {
+      directory: "org.scala-refactoring.library"
+      // the tests can't be run with SBT
       run-tests: false
     }
   }


### PR DESCRIPTION
I wasn't able to run the script locally (tons of EXTRACTION FAILED). I also just updated the build.sbt in scala-refactoring to build with Scala 2.11, but this isn't in a release yet so I target that specific commit.
