### PR TITLE
Add ermine-legacy and scalaparsers.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -121,6 +121,8 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
+  ermine-legacy-ref            : "ermine-language/ermine-legacy.git"
+  scala-parsers-ref            : "ermine-language/ermine-parser.git"
 
   // version settings
   sbt-version-override         : "0.13.7"
@@ -362,6 +364,16 @@ build += {
     extra: ${vars.base.extra} {
       directory: "org.scala-refactoring.library"
     }
+  }
+
+  ${vars.base} {
+    name:   "ermine-legacy",
+    uri:    "https://github.com/"${vars.ermine-legacy-ref}
+  }
+
+  ${vars.base} {
+    name:   "scala-parsers",
+    uri:    "https://github.com/"${vars.scala-parsers-ref}
   }
 
   //


### PR DESCRIPTION
This adds ermine-language/ermine-legacy and ermine-language/ermine-parser to the community build, per [SI-8962](https://issues.scala-lang.org/browse/SI-8962)'s request.
