### PR TITLE
Disable parallel execution of tests in spray.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -216,6 +216,9 @@ build += {
       // disable running sphinx, it would be great if dbuild
       // oferred a mechanism for excluding particular project (e.g. docs)
       commands += "set SphinxSupport.sphinxCompile in docs := Seq.empty"
+      // disable parallel execution of tests as a work around for non-deterministic
+      // failures, see: https://github.com/scala/community-builds/pull/69#issuecomment-63324597
+      settings += "parallelExecution in GlobalScope in Test := false"
     }
   }
 


### PR DESCRIPTION
This is a workaround for non-deterministic failures we've observed. See https://github.com/scala/community-builds/pull/69#issuecomment-63324597 for details.
