### PR TITLE
Revert akka to 7a6dab2319b525e479f6bae735d1d1b2f9efb9ff

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -101,7 +101,7 @@ vars: {
   // stick to a revision which is a parent of merge commit in
   // https://github.com/akka/akka/pull/16373
   // see https://github.com/scala/community-builds/issues/75 for details
-  akka-ref                     : "akka/akka.git#338f61886eabfff18ecd01539c8f153ebe7eac0f"
+  akka-ref                     : "akka/akka.git#7a6dab2319b525e479f6bae735d1d1b2f9efb9ff"
 
   // tracking upstream (the ideal)
   async-ref                    : "scala/async.git"


### PR DESCRIPTION
It seems like my original guess in #75 was wrong. Some other change in
akka build must have broken community build. Let's revert to the last
akka revision that is known to work before we figure out what happened.
