### PR TITLE
Revert akka-libs-210 to 49d90828517bd03dbb52e878430c4af47df33992

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -544,7 +544,7 @@ projects:[
 }
 {
   name:  akka-libs-210
-  uri:    "git://github.com/akka/akka.git"
+  uri:    "git://github.com/akka/akka.git#49d90828517bd03dbb52e878430c4af47df33992"
   extra: {
   projects: [akka-actor,akka-contrib,akka-osgi]
   options: ["-Dakka.genjavadoc.enabled=true"]


### PR DESCRIPTION
This is in the same spirit as #77. We fix the following failure:

```
[akka-libs-210:error] /localhome/jenkinsdbuild2/workspace/Community-2.11.x/target-0.9.1/extraction/94fbde165839e00534c4e811d5679de9131de75d/projects/802460bf35a671575eeb16ae328523c194910d7e/build.sbt:1: error: not found: value enablePlugins
[akka-libs-210:error] enablePlugins(akka.RootSettings)
[akka-libs-210:error] ^
[akka-libs-210] [error] Type error in expression
[akka-libs-210] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```

https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x/366/consoleFull

I believe this error is caused by the fact that enablePlugins is available
in sbt 0.13.6 only.
