### PR TITLE
Revert "Switch to fixed version of Play for Play2-SBT-Plugin."

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -668,7 +668,7 @@ projects:[
     check-missing: false
     // this plugin needs sbt-idea, which needs android-sdk-plugin, which is apparently impossible to compile
     name: Play2-SBT-Plugin
-    uri: "https://github.com/playframework/playframework.git#57801ea2259f14adee8dd5c92f5f07b3750e1a5f"
+    uri: "https://github.com/playframework/playframework.git#2.3.x"
     extra: {
       projects: SBT-Plugin
       directory: framework


### PR DESCRIPTION
This reverts commit 367fd59cb7da4bad831d27584b9d19c3893a492d.

The root cause for workaround in 367fd59cb7da4bad831d27584b9d19c3893a492d
has been fixed upstream in playframework/playframework#3736. We can revert
the workaround now.
