### PR TITLE
Upgrade to the latest scoverage release.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -90,10 +90,7 @@ vars: {
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
   shapeless-ref                : "milessabin/shapeless.git#shapeless-2.0.0"
-  // TODO: Scoverage added sbt plugins, which broke the community build.
-  // Commit: https://github.com/scoverage/scalac-scoverage-plugin/commit/dbc28b18bf87a96c9372844e9d892adc7737d80f
-  // Failing build: https://jenkins-dbuild.typesafe.com:8499/job/Community-2.11.x/218/console
-  scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#4c4fd3672658e48e52e884c9003d25b9f8b83bd5"
+  scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#1.0.1"
   // change from https://github.com/sbt/sbt/pull/1509 broke building sbt with Scala 2.11
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
   // for now, we stick to fixed sha1 of sbt right before the merge of #1509


### PR DESCRIPTION
Scoverage's tests are still disabled because they fail with:

```
[scoverage] [info] - scoverage should instrument default arguments with methods *** FAILED ***
[scoverage] [info]   java.io.FileNotFoundException: Could not locate [/home/jenkinsdbuild/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.4.jar].
[scoverage] [info]   at scoverage.ScoverageCompiler$.scoverage$ScoverageCompiler$$findIvyJar(compiler.scala:60)
[scoverage] [info]   at scoverage.ScoverageCompiler$.scoverage$ScoverageCompiler$$findScalaJar(compiler.scala:52)
[scoverage] [info]   at scoverage.ScoverageCompiler$$anonfun$getScalaJars$1.apply(compiler.scala:40)
[scoverage] [info]   at scoverage.ScoverageCompiler$$anonfun$getScalaJars$1.apply(compiler.scala:40)
[scoverage] [info]   at scala.collection.immutable.List.map(List.scala:273)
[scoverage] [info]   at scoverage.ScoverageCompiler$.getScalaJars(compiler.scala:40)
[scoverage] [info]   at scoverage.ScoverageCompiler$.classPath(compiler.scala:17)
[scoverage] [info]   at scoverage.ScoverageCompiler$.settings(compiler.scala:24)
[scoverage] [info]   at scoverage.ScoverageCompiler$.default(compiler.scala:29)
[scoverage] [info]   at scoverage.PluginCoverageTest$$anonfun$1.apply$mcV$sp(PluginCoverageTest.scala:14)
[scoverage] [info]   ...
```