### PR TITLE
Add pimpathon, scalariform, ScalaMock and ensime

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -399,6 +399,13 @@ build += {
     name:   "ensime",
     uri:    "https://github.com/"${vars.ensime-ref}
     extra.sbt-version: ${vars.sbt-version-override}
+    // scaladoc fails with
+    // [ensime] [info] Compiling 73 Scala sources to .../target/scala-2.11/classes...
+    // [ensime] [info] Main Scala API documentation to .../target/scala-2.11/api...
+    // [ensime] [error] .../src/main/scala/org/ensime/indexer/SourceResolver.scala:55: value toMultiMap is not a member of scala.collection.immutable.Set[(org.ensime.indexer.PackageName, org.apache.commons.vfs2.FileObject)]
+    // [ensime] [error] possible cause: maybe a semicolon is missing before `value toMultiMap'?
+    // [ensime] [error]   }.toMultiMap[Set]
+    extra.commands: "set every sources in doc in Compile := List()"
   }
 
   ${vars.base} {

--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -97,7 +97,8 @@ vars: {
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
   // ensime uses a rolling release to simplify distribution and launching from emacs
   ensime-ref                   : "ensime/ensime-server.git#d73a6212e12d2f82c9daca3e5c60f8f9c4f31899"
-  pimpathon-ref                : "stacycurl/pimpathon.git#1.2.0"
+  // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
+  pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"

--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -99,6 +99,7 @@ vars: {
   ensime-ref                   : "ensime/ensime-server.git#d73a6212e12d2f82c9daca3e5c60f8f9c4f31899"
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
+  scalariform-ref              : "daniel-trinh/scalariform.git#pull/42/head"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -403,6 +404,14 @@ build += {
     name:   "pimpathon",
     uri:    "https://github.com/"${vars.pimpathon-ref}
     extra.sbt-version: ${vars.sbt-version-override}
+  }
+
+  ${vars.base} {
+    name:   "scalariform",
+    uri:    "https://github.com/"${vars.scalariform-ref}
+    extra.sbt-version: ${vars.sbt-version-override}
+    // avoid building misc subproject that depends on Swing (and is not needed by any other project)
+    extra.projects: ["scalariform"]
   }
 
   ${vars.base} {

--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -95,6 +95,9 @@ vars: {
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
   // for now, we stick to fixed sha1 of sbt right before the merge of #1509
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
+  // ensime uses a rolling release to simplify distribution and launching from emacs
+  ensime-ref                   : "ensime/ensime-server.git#d73a6212e12d2f82c9daca3e5c60f8f9c4f31899"
+  pimpathon-ref                : "stacycurl/pimpathon.git#1.2.0"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -387,6 +390,18 @@ build += {
       run-tests: false
       exclude: ["root","launch-test"]
     }
+  }
+
+  ${vars.base} {
+    name:   "ensime",
+    uri:    "https://github.com/"${vars.ensime-ref}
+    extra.sbt-version: ${vars.sbt-version-override}
+  }
+
+  ${vars.base} {
+    name:   "pimpathon",
+    uri:    "https://github.com/"${vars.pimpathon-ref}
+    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {

--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -100,6 +100,7 @@ vars: {
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
   scalariform-ref              : "daniel-trinh/scalariform.git#pull/42/head"
+  scalamock-ref                : "paulbutcher/ScalaMock.git#v3.2.1_2.11"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -412,6 +413,12 @@ build += {
     extra.sbt-version: ${vars.sbt-version-override}
     // avoid building misc subproject that depends on Swing (and is not needed by any other project)
     extra.projects: ["scalariform"]
+  }
+
+  ${vars.base} {
+    name:   "scalamock",
+    uri:    "https://github.com/"${vars.scalamock-ref}
+    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {


### PR DESCRIPTION
The main driver behind this PR was adding ensime. The rest of projects got pulled in as transitive dependency. We welcome all of them to the family!

This PR supersedes #52.

I'd like highlight that ScalaMock has a stellar sbt build definition. I added it to community build in 30 seconds with just one attempt and with no workarounds That's rare.

//cc @fommil, @stacycurl, @pawel-wiejacha, @paulbutcher, @daniel-trinh.