### PR TITLE
Various fixes to restore the community build

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -65,7 +65,7 @@ vars: {
   spray-twirl-ref              : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
   // fix for matching scalaBinaryVersion that causes issues in dbuild
   play-twirl-ref               : "playframework/twirl.git#pull/45/head"
-  spray-json-ref               : "spray/spray-json.git#v1.3.0"
+  spray-json-ref               : "spray/spray-json.git"
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
   scala-io-ref                 : "jesseeichar/scala-io.git#7704ec7e0f20238376975f89f817dd0d81a4a5d0"
   json4s-ref                   : "json4s/json4s.git#v3.2.10_2.11"
@@ -124,7 +124,7 @@ vars: {
   scala-js-ref                 : "scala-js/scala-js.git"
 
   // version settings
-  sbt-version-override         : "0.13.7"
+  sbt-version-override         : "0.13.8"
 }
 
 vars {
@@ -143,6 +143,10 @@ options.resolvers: {
   0: "local"
   1: "proxy-ch-maven: https://proxy-ch.typesafe.com:8082/artifactory/repo"
   2: "proxy-ch-ivy: https://proxy-ch.typesafe.com:8082/artifactory/repo"${vars.ivyPat}
+
+  // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
+  // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046
+  3: "bintray-eed3si9n-sbt-plugins: https://dl.bintray.com/eed3si9n/sbt-plugins"${vars.ivyPat}
 
 //
 // proxy-ch is proxying:
@@ -271,6 +275,8 @@ build += {
     uri:    "https://github.com/"${vars.scala-stm-ref}
     // a minor incompatibility with recent versions of scalatest, therefore:
     extra.run-tests: false
+    // 0.13.8 chockes on the build definition, see https://github.com/nbronson/scala-stm/pull/45
+    extra.sbt-version: "0.13.7"
   }
 
   ${vars.base} {
@@ -506,6 +512,7 @@ projects:[
 }
 {
   name: spray-json-210
+  // The revision of sbt-js-engine that we currently build depends on this older version where JSArray takes a List (new version: a Vector)
   uri: "git://github.com/spray/spray-json.git#v1.2.6"
 }
 // compiling spray from source entails a few problems,
@@ -649,7 +656,13 @@ projects:[
 }
 {
   name: sbt-js-engine
-  uri:  "https://github.com/sbt/sbt-js-engine.git"
+  // the next revision adds the bintray publishing sbt plugin, which currently fails the community build. see
+  // https://github.com/sbt/sbt-js-engine/commit/f28889c9c2a6581d1d7a1e530cb5cd71cb0e7d9c#commitcomment-10833306
+  // Note: when switching to a newer revision, you also need to update the spray-json-210 dependency in this file,
+  // the commit that adds the bintray plugin also switches to spray-json v1.3.
+  uri:  "https://github.com/sbt/sbt-js-engine.git#bfca660fbe5e4a06667bae39577c71259399a678"
+  // 0.13.8 breaks while building the sub-project "default-sbt-project" with: Modules were resolved with conflicting cross-version suffixes: org.scalamacros:quasiquotes <none>, _2.10
+  extra.sbt-version: "0.13.7"
 }
 {
   name: sbt-webdriver
@@ -695,6 +708,8 @@ projects:[
   // The code makes assumptions on the scalaBinaryVersion, and
   // will not compiler unless it is set to "2.10". Hence:
   cross-version: standard
+  // 0.13.8 breaks while building the sub-project "plugin" with: Modules were resolved with conflicting cross-version suffixes: org.scalamacros:quasiquotes <none>, _2.10
+  extra.sbt-version: "0.13.7"
 }
 
 {


### PR DESCRIPTION
Upgrade sbt to 0.13.8. This fixes a recent update to the npm build
definition:
https://github.com/typesafehub/npm/commit/16c2a559b1d003efc298356941915b19b2ff1d38#commitcomment-10754486

For some projects we have to use 0.13.7 for now, comments in the file.

Adds a temporary repository to the resolvers to enable the fix for
https://github.com/sbt/sbt-web/pull/107/files

Use a fixed reference for sbt-js-engine to avoid issues with the
bintray publishing sbt plugin.
https://github.com/sbt/sbt-js-engine/commit/f28889c9c2a6581d1d7a1e530cb5cd71cb0e7d9c#commitcomment-10833306
