### PR TITLE
Fix to an older Twirl version.

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -63,7 +63,10 @@ vars: {
   spray-ref                    : "spray/spray.git#43d93b255c6a7f9e510111e9272d83e228638304"
   // only building project twirl-api, fixed sha from master branch that has Scala 2.11 compatiblity patches merged
   spray-twirl-ref              : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
-  // fix for matching scalaBinaryVersion that causes issues in dbuild
+  // - fix for matching scalaBinaryVersion that causes issues in dbuild
+  // - That has been merged, but master is now unusable in Java 6 due to
+  //   the use of typesafe-config 1.3.0
+  //   https://github.com/playframework/interplay/commit/73f7c9b434be180c27611aebb089d55f6445bcf5#commitcomment-11275807
   play-twirl-ref               : "playframework/twirl.git#pull/45/head"
   spray-json-ref               : "spray/spray-json.git"
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
@@ -704,7 +707,7 @@ projects:[
   name: sbt-twirl-210
 // no: uri: "git://github.com/spray/twirl.git"
 // yes, SBT-Plugin uses this:
-  uri: "git://github.com/playframework/twirl.git"
+  uri: "git://github.com/"${vars.play-twirl-ref}
   // The code makes assumptions on the scalaBinaryVersion, and
   // will not compiler unless it is set to "2.10". Hence:
   cross-version: standard


### PR DESCRIPTION
master has been updated to require Java 8, as part of the bigger
move in this direction by Play 2.4. Akka 2.4 will be going the
same way.

https://github.com/playframework/interplay/commit/73f7c9b434be180c27611aebb089d55f6445bcf5#commitcomment-11276100