### PR TITLE
Get 2.11.x passing again

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -59,8 +59,7 @@ vars: {
   // TODO: merge required changes upstream to get rid of our forks, maintaining our one won't scale
   browse-ref                   : "retronym/browse.git#topic/2.11-compat"
   lift-framework-ref           : "lift/framework.git#3.0-M2-release"
-  // spray's release/1.3 branch just a few commits after v1.3.2 which fixed some problems with the community build
-  spray-ref                    : "adriaanm/spray.git#community-build"
+  spray-ref                    : "spray/spray.git#v1.3.3"
   // only building project twirl-api, fixed sha from master branch that has Scala 2.11 compatiblity patches merged
   spray-twirl-ref              : "spray/twirl.git#102978cb508684aee0cfa09d71027965cdcd77b4"
   // - fix for matching scalaBinaryVersion that causes issues in dbuild
@@ -224,6 +223,8 @@ build += {
     name: "spray",
     uri: "https://github.com/"${vars.spray-ref},
     extra: ${vars.base.extra} {
+      // skip tests for now; see https://github.com/scala/community-builds/issues/110
+      run-tests: false
       // disable subprojects depending on shapeless 1
       exclude: ["spray-routing", "spray-routing-tests"]
       // disable running sphinx, it would be great if dbuild

--- a/common.conf
+++ b/common.conf
@@ -149,6 +149,7 @@ options.resolvers: {
   04: "sbt-plugin-releases: https://dl.bintray.com/sbt/sbt-plugin-releases/"${vars.ivyPat}
   09: "dbuild-snapshots: http://typesafe.artifactoryonline.com/typesafe/temp-distributed-build-snapshots"${vars.ivyPat}
   10: "maven-central"
+  11: "old-typesafe-maven-releases: https://dl.bintray.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2
 
   // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
   // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046


### PR DESCRIPTION
these are Adriaan's commits (I just squashed them and edited the commit messages), and we've already been over the details, and https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/35/console already passed, so I'm going to go ahead and merge
