### PR TITLE
update Scala.js version

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -123,7 +123,7 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  scala-js-ref                 : "sjrd/scala-js.git#scala-2.11.7"
+  scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
 
   // version settings
   sbt-version-override         : "0.13.8"


### PR DESCRIPTION
the branch that we were using in sjrd's fork no longer exists, so
we're forced to do something, but anyway, now that 0.6.4 is out (with
2.11.7 support), we ought to be using it anyway
