### PR TITLE
Play framework: track 2.3.x, don't freeze at 2.3.9

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -71,7 +71,8 @@ vars: {
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
   scala-io-ref                 : "adriaanm/scala-io.git#community-build"
   json4s-ref                   : "json4s/json4s.git#v3.2.10_2.11"
-  playframework-ref            : "playframework/playframework.git#2.3.9"
+  // 2.4.x requires Scala 2.12, so here we stay on 2.3.x
+  playframework-ref            : "playframework/playframework.git#2.3.x"
   // fixed sha from master that has Scala 2.11 patches merged
   parboiled-ref                : "sirthias/parboiled.git#c53e650212f222c9b1f75fa1ab13d7cab9db164e"
   // This pull request supports the fully-cross-versioned continuations plugin, shipped with 2.11+


### PR DESCRIPTION
I'm going to merge this immediately, since it already passed Jenkins
when run from my fork,
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/42/
