### PR TITLE
2.11.x failing due to missing spray-json-shapeless dependency for ensime-server

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -113,7 +113,7 @@ vars: {
   scala-partest-interface-ref  : "scala/scala-partest-interface.git"
   scala-partest-ref            : "scala/scala-partest.git"
   scala-xml-ref                : "scala/scala-xml.git"
-  scala-swing-ref              : "scala/scala-swing.git#1.0.x"
+  scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
 
   // TODO move back to master after adding scalaz-stream to the community build.

--- a/common.conf
+++ b/common.conf
@@ -191,6 +191,7 @@ build += {
   ${vars.base} {
     name: "scalacheck",
     uri: "https://github.com/"${vars.scalacheck-ref}
+    extra.projects: ["jvm"]
   }
 
   ${vars.base} {

--- a/common.conf
+++ b/common.conf
@@ -120,7 +120,7 @@ vars: {
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
-  scalaz-stream-ref            : "scalaz/scalaz-stream.git"
+  scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a" // incompatible changes on master break specs2
   scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"

--- a/common.conf
+++ b/common.conf
@@ -119,7 +119,7 @@ vars: {
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck from 1.1.x to 1.2.x
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
-  scalaz-ref                   : "scalaz/scalaz.git#series/7.2.x"
+  scalaz-ref                   : "SethTisue/scalaz.git#community-build"
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a" // incompatible changes on master break specs2
   scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"

--- a/common.conf
+++ b/common.conf
@@ -84,7 +84,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.12.2"  # version specs2 uses. could also try later 1.12.x or even master
-  scalatest-ref                : "scalatest/scalatest.git#scala-2.11-M8"
+  scalatest-ref                : "scalatest/scalatest.git#2.2.x"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
   // therefore (which has a broken libdep of scalatest, however (cross full)):

--- a/common.conf
+++ b/common.conf
@@ -102,7 +102,7 @@ vars: {
   spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git" // ensime depends on a SNAPSHOT
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
-  scalariform-ref              : "adriaanm/scalariform.git#community-build"
+  scalariform-ref              : "daniel-trinh/scalariform.git"
   scalamock-ref                : "adriaanm/scalamock.git#community-build"
 
   // tracking upstream (the ideal)

--- a/common.conf
+++ b/common.conf
@@ -71,8 +71,7 @@ vars: {
   // fixed sha from 2.10.x branch that has Scala 2.11 compatiblity patches merged
   scala-io-ref                 : "adriaanm/scala-io.git#community-build"
   json4s-ref                   : "json4s/json4s.git#v3.2.10_2.11"
-  // 2.4.x requires JDK 8, so here we stay on 2.3.x
-  playframework-ref            : "playframework/playframework.git#2.3.x"
+  playframework-ref            : "playframework/playframework.git#2.4.x"
   // fixed sha from master that has Scala 2.11 patches merged
   parboiled-ref                : "sirthias/parboiled.git#c53e650212f222c9b1f75fa1ab13d7cab9db164e"
   // This pull request supports the fully-cross-versioned continuations plugin, shipped with 2.11+

--- a/common.conf
+++ b/common.conf
@@ -152,7 +152,6 @@ options.resolvers: {
   11: "old-typesafe-maven-releases: https://repo.typesafe.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2
   12: "ambiata-oss: https://ambiata-oss.s3.amazonaws.com/"${vars.ivyPat} // specs2's project plugins
   14: "Era7 maven releases: http://releases.era7.com.s3.amazonaws.com" // specs2's project plugins
-  15: "bintray/non: http://dl.bintray.com/non/maven"  // for scalaz's use of kind-projector 0.6.1
 
   // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
   // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046

--- a/common.conf
+++ b/common.conf
@@ -119,7 +119,7 @@ vars: {
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck from 1.1.x to 1.2.x
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
-  scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
+  scalaz-ref                   : "scalaz/scalaz.git#series/7.2.x"
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a" // incompatible changes on master break specs2
   scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"

--- a/common.conf
+++ b/common.conf
@@ -102,7 +102,7 @@ vars: {
   spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git" // ensime depends on a SNAPSHOT
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
-  scalariform-ref              : "daniel-trinh/scalariform.git"
+  scalariform-ref              : "SethTisue/scalariform.git#community-build" // problem with old sbteclipse-plugin
   scalamock-ref                : "adriaanm/scalamock.git#community-build"
 
   // tracking upstream (the ideal)

--- a/common.conf
+++ b/common.conf
@@ -402,6 +402,7 @@ build += {
     extra: ${vars.base.extra} {
       run-tests: false
       exclude: ["root","launch-test"]
+      commands += "set every javaVersionPrefix in javaVersionCheck := Some(\"1.8\")"
     }
   }
 

--- a/common.conf
+++ b/common.conf
@@ -149,6 +149,8 @@ options.resolvers: {
   09: "dbuild-snapshots: http://repo.typesafe.com/typesafe/temp-distributed-build-snapshots"${vars.ivyPat}
   10: "maven-central"
   11: "old-typesafe-maven-releases: https://repo.typesafe.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2
+  12: "ambiata-oss: https://ambiata-oss.s3.amazonaws.com/"${vars.ivyPat} // specs2's project plugins
+  14: "Era7 maven releases: http://releases.era7.com.s3.amazonaws.com" // specs2's project plugins
 
   // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
   // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046

--- a/common.conf
+++ b/common.conf
@@ -112,7 +112,7 @@ vars: {
   scala-parser-combinators-ref : "scala/scala-parser-combinators.git"
   scala-partest-interface-ref  : "scala/scala-partest-interface.git"
   scala-partest-ref            : "scala/scala-partest.git"
-  scala-xml-ref                : "scala/scala-xml.git"
+  scala-xml-ref                : "scala/scala-xml.git#v1.0.4" // TODO move to 1.0.5, sort out JDK 6 vs. 8 confusion
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
   specs2-ref                   : "etorreborre/specs2.git"

--- a/common.conf
+++ b/common.conf
@@ -84,7 +84,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.12.2"  # version specs2 uses. could also try later 1.12.x or even master
-  scalatest-ref                : "scalatest/scalatest.git#2.2.x"
+  scalatest-ref                : "scalatest/scalatest.git#release-2.2.4-for-scala-2.11-and-2.10"  # 2.2.5 removes some deprecated stuff scalariform still uses
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
   // therefore (which has a broken libdep of scalatest, however (cross full)):

--- a/common.conf
+++ b/common.conf
@@ -115,7 +115,7 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git#v1.0.4" // TODO move to 1.0.5, sort out JDK 6 vs. 8 confusion
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-  specs2-ref                   : "etorreborre/specs2.git"
+  specs2-ref                   : "SethTisue/specs2.git#community-build" // adds explicit parser-combinators dependency
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck from 1.1.x to 1.2.x
   sbt-republish-ref            : "typesafehub/sbt-republish.git"

--- a/common.conf
+++ b/common.conf
@@ -302,7 +302,6 @@ build += {
   ${vars.base} {
     name: specs2
     uri: "https://github.com/"${vars.specs2-ref}
-    extra.run-tests: false // at least SnippetsTest is failing.
   }
 
   ${vars.base} {

--- a/common.conf
+++ b/common.conf
@@ -124,6 +124,7 @@ vars: {
   scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
+  kind-projector-ref           : "non/kind-projector.git"
 
   // version settings
   sbt-version-override         : "0.13.8"
@@ -512,6 +513,11 @@ build += {
       // - Disable compiler/test because it is very fragile.
       commands: ["set test in (Build.compiler, Test) := {}"]
     }
+  }
+
+  ${vars.base} {
+    name:   "kind-projector",
+    uri:    "http://github.com/"${vars.kind-projector-ref}
   }
 ]
 }

--- a/common.conf
+++ b/common.conf
@@ -83,7 +83,7 @@ vars: {
   scala-refactoring-ref        : "scala-ide/scala-refactoring.git#44dca8b74808528693f884cfd3c5c9d3ed13e519"
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
-  scalacheck-ref               : "rickynils/scalacheck.git#1.11.3"
+  scalacheck-ref               : "rickynils/scalacheck.git#1.12.2"  # version specs2 uses. could also try later 1.12.x or even master
   scalatest-ref                : "scalatest/scalatest.git#scala-2.11-M8"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
@@ -186,6 +186,11 @@ build += {
       // TestNGSuite became a class but was a trait
       run-tests: false
     }
+  }
+
+  ${vars.base} {
+    name: "scalacheck",
+    uri: "https://github.com/"${vars.scalacheck-ref}
   }
 
   ${vars.base} {

--- a/common.conf
+++ b/common.conf
@@ -117,7 +117,7 @@ vars: {
   scala-records-ref            : "scala-records/scala-records.git"
   specs2-ref                   : "etorreborre/specs2.git"
   zinc-ref                     : "typesafehub/zinc.git"
-  sbinary-ref                  : "harrah/sbinary.git"
+  sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck from 1.1.x to 1.2.x
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a" // incompatible changes on master break specs2

--- a/common.conf
+++ b/common.conf
@@ -91,7 +91,7 @@ vars: {
   zeromq-scala-binding-ref     : "valotrading/zeromq-scala-binding.git#062e9438e322ec29d75b9649cb2aafa6ba3198a6"
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
-  shapeless-ref                : "adriaanm/shapeless.git#community-build"
+  shapeless-ref                : "milessabin/shapeless.git"
   scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#1.0.2"
   // change from https://github.com/sbt/sbt/pull/1509 broke building sbt with Scala 2.11
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
@@ -99,6 +99,7 @@ vars: {
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
   // ensime uses a rolling release to simplify distribution and launching from emacs
   ensime-ref                   : "ensime/ensime-server.git" //"#d73a6212e12d2f82c9daca3e5c60f8f9c4f31899"
+  spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git" // ensime depends on a SNAPSHOT
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
   scalariform-ref              : "adriaanm/scalariform.git#community-build"
@@ -114,14 +115,13 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-
-  // TODO move back to master after adding scalaz-stream to the community build.
-  specs2-ref                   : "etorreborre/specs2.git#8fa92f3f9dac61ba39e169b83c091c4d5b15cb8c"
-
+  specs2-ref                   : "etorreborre/specs2.git"
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
+  scalaz-stream-ref            : "scalaz/scalaz-stream.git"
+  scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
 
@@ -307,6 +307,18 @@ build += {
   }
 
   ${vars.base} {
+    name: scalaz-stream
+    uri: "https://github.com/"${vars.scalaz-stream-ref}
+    extra.run-tests: false // test don't compile because they use ScalaCheck 1.2's `protect`
+  }
+
+  ${vars.base} {
+    name: scodec-bits
+    uri: "https://github.com/"${vars.scodec-bits-ref}
+    extra.projects: ["coreJVM"]
+  }
+
+  ${vars.base} {
     name: "scala-records"
     uri: "https://github.com/"${vars.scala-records-ref}
     extra.exclude: ["coreJS", "benchmarks"]
@@ -417,6 +429,11 @@ build += {
     // [ensime] [error] possible cause: maybe a semicolon is missing before `value toMultiMap'?
     // [ensime] [error]   }.toMultiMap[Set]
     extra.commands: "set every sources in doc in Compile := List()"
+  }
+
+  ${vars.base} {
+    name:   "spray-json-shapeless",
+    uri:    "https://github.com/"${vars.spray-json-shapeless-ref}
   }
 
   ${vars.base} {

--- a/common.conf
+++ b/common.conf
@@ -151,6 +151,7 @@ options.resolvers: {
   11: "old-typesafe-maven-releases: https://repo.typesafe.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2
   12: "ambiata-oss: https://ambiata-oss.s3.amazonaws.com/"${vars.ivyPat} // specs2's project plugins
   14: "Era7 maven releases: http://releases.era7.com.s3.amazonaws.com" // specs2's project plugins
+  15: "bintray/non: http://dl.bintray.com/non/maven"  // for scalaz's use of kind-projector 0.6.1
 
   // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
   // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046

--- a/common.conf
+++ b/common.conf
@@ -115,11 +115,11 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git#v1.0.4" // TODO move to 1.0.5, sort out JDK 6 vs. 8 confusion
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-  specs2-ref                   : "SethTisue/specs2.git#community-build" // adds explicit parser-combinators dependency
+  specs2-ref                   : "SethTisue/specs2.git#community-build" // adds explicit scala modules dependencies
   zinc-ref                     : "typesafehub/zinc.git"
-  sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck from 1.1.x to 1.2.x
+  sbinary-ref                  : "SethTisue/sbinary.git#community-build" // upgrades ScalaCheck, 1.11 -> 1.12
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
-  scalaz-ref                   : "SethTisue/scalaz.git#community-build"
+  scalaz-ref                   : "SethTisue/scalaz.git#community-build-7.1.x"  // upgrades ScalaCheck, 1.11 -> 1.12
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a" // incompatible changes on master break specs2
   scodec-bits-ref              : "scodec/scodec-bits.git"
   discipline-ref               : "typelevel/discipline.git#v0.2"

--- a/community.dbuild
+++ b/community.dbuild
@@ -63,12 +63,6 @@ build += {
   }
 
   ${vars.base} {
-    name: scalacheck
-    uri:    "https://github.com/"${vars.scalacheck-ref}
-    extra.run-tests: false
-  }
-
-  ${vars.base} {
     name: "scala-swing"
     uri: "https://github.com/"${vars.scala-swing-ref}
   }


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/49/console shows the failure:

> Missing dependency: the library com.github.fommil#spray-json-shapeless is not provided (in space "default") by any project in this configuration file`

the cause is https://github.com/ensime/ensime-server/commit/88cd6e33e946c472e1a1c3477942425211ac6974 

perhaps it will be straightforward to just add the dependency? we'll see. spray-json-shapeless's dependencies are here: https://github.com/fommil/spray-json-shapeless/blob/master/build.sbt
