### PR TITLE
upgrade ScalaTest

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -82,7 +82,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.11.6"
-  scalatest-ref                : "scalatest/scalatest.git#scala-2.11-M8"
+  scalatest-ref                : "scalatest/scalatest.git#2.2.x-for-scala-2.12.0-M2"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
   // therefore (which has a broken libdep of scalatest, however (cross full)):


### PR DESCRIPTION
known to work because
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/104/
