### PR TITLE
Fix to the 1.0.x series of scodec

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -118,7 +118,7 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a"
-  scodec-bits-ref              : "scodec/scodec-bits.git"
+  scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
 


### PR DESCRIPTION
A source incompatibility with scalaz-stream was recently introduced
into master, which I presume is now the home for 2.x development.

   https://github.com/scodec/scodec-bits/pull/41

Review by @SethTisue / @mpilquist
