### PR TITLE
freeze ensime rev for now

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -98,8 +98,10 @@ vars: {
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
   // for now, we stick to fixed sha1 of sbt right before the merge of #1509
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
-  // ensime uses a rolling release to simplify distribution and launching from emacs
-  ensime-ref                   : "ensime/ensime-server.git" //"#d73a6212e12d2f82c9daca3e5c60f8f9c4f31899"
+  // ensime uses a rolling release to simplify distribution and launching from emacs.
+  // but for now we freeze at a rev from before spray-json-shapeless was added as a
+  // dependency, since that would set off a cascade of upgrades
+  ensime-ref                   : "ensime/ensime-server.git#823b947056d263431253aad25f35526aeb7f2888"
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
   scalariform-ref              : "adriaanm/scalariform.git#community-build"


### PR DESCRIPTION
we freeze at a rev from before spray-json-shapeless was added as a
dependency, since that would set off a cascade of upgrades
