### PR TITLE
readme no longer recommends running locally with `-l`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Java 6; 2.12.x, Java 8.
 
 Then run:
 
-    ./scripts/jobs/integrate/community-build -l
+    ./scripts/jobs/integrate/community-build -n
 
 While you wait, make yourself a sandwich.  (If you have time,
 make yourself a sandwich-making machine.)


### PR DESCRIPTION
it seems much better to me to use the resolver list in common.conf
than to use dbuild's built-in default resolver list.  in dbuild
versions 0.9.[123] at least, the default list has bad entries because
of the JFrog->Bintray move, plus common.conf has lots of custom
entries that you will need.

I don't really understand why `-l` was recommended before.
