### PR TITLE
2.12: disable -Xfatal-warnings in Shapeless build

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -203,6 +203,8 @@ build += {
   ${vars.base} {
     name: shapeless
     uri:    "https://github.com/"${vars.shapeless-ref}
+    // optimizer related. Lukas may want to revisit before 2.12 final
+    extra.commands: "set scalacOptions -= \"-Xfatal-warnings\""
   }
 
   ${vars.base} {


### PR DESCRIPTION
build was failing, because new optimizer

passing community build with this change: https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/159/console. failing build without the change was https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-community-build/158/console

review by @lrytz
