### PR TITLE
move to newer version of Scala.js

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -115,7 +115,7 @@ vars: {
   scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a"
   scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
+  scala-js-ref                 : "scala-js/scala-js.git#v0.6.5"
 
   // version settings
   sbt-version-override         : "0.13.9"


### PR DESCRIPTION
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/163/console
shows only the same failures we were getting from 0.6.4
