### PR TITLE
misc updates

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -77,8 +77,6 @@ vars: {
   parboiled-ref                : "sirthias/parboiled.git#c53e650212f222c9b1f75fa1ab13d7cab9db164e"
   // This pull request supports the fully-cross-versioned continuations plugin, shipped with 2.11+
   scala-arm-ref                : "jsuereth/scala-arm.git#pull/31/head"
-  // fixed sha/tag (a compromise)
-  slick-ref                    : "slick/slick.git#pull/686/head"
   genjavadoc-ref               : "typesafehub/genjavadoc.git#v0.5_2.11.0-M8"
   // There's no suitable release yet, so we depend on this commit. Upgrade to the next tagged version once released
   scala-refactoring-ref        : "scala-ide/scala-refactoring.git#44dca8b74808528693f884cfd3c5c9d3ed13e519"
@@ -106,6 +104,7 @@ vars: {
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
   scalariform-ref              : "adriaanm/scalariform.git#community-build"
   scalamock-ref                : "adriaanm/scalamock.git#community-build"
+  sbt-testng-interface-ref     : "SethTisue/sbt-testng-interface.git#no-bintray"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git#release-2.3"
@@ -127,6 +126,7 @@ vars: {
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"
+  slick-ref                    : "slick/slick.git#3.1"   // stay here; master wants Java 8
 
   // version settings
   sbt-version-override         : "0.13.9"
@@ -377,7 +377,7 @@ build += {
   }
 
   //
-  // Typesafe-developed projects: degvelopment branches / master / unstable releases
+  // Typesafe-developed projects: development branches / master / unstable releases
   //
   ${vars.base} {
     name: "async"
@@ -388,6 +388,21 @@ build += {
   ${vars.base} {
     name: "slick"
     uri:  "https://github.com/"${vars.slick-ref}
+    // without this dbuild doesn't pick up that one of the subprojects has this dependency.
+    // it doesn't even make sense; it seems to me that testNGSettings should not be adding
+    // a dependency of the plugin to the libraryDependencies of the test code.
+    // the line in question is:
+    //   https://github.com/sbt/sbt-testng-interface/blob/ca730f705f48af2139f39bc726b474afec072738/plugin/src/main/scala/de/johoop/testngplugin/TestNGPlugin.scala#L44
+    // I think it's a confusion of levels, but maybe I'm missing something. - ST 8/27/15
+    deps.inject: ["de.johoop#sbt-testng-interface"]
+    // disable fragile tests (https://github.com/scala/community-builds/issues/12#issuecomment-149941055)
+    extra.exclude: ["osgitests"]
+  }
+
+  ${vars.base} {
+    name: "sbt-testng-interface",
+    uri: "https://github.com/"${vars.sbt-testng-interface-ref}
+    extra.projects: ["sbt-testng-interface"]  // just the interface, we don't need to build the plugin
   }
 
   ${vars.base} {

--- a/common.conf
+++ b/common.conf
@@ -126,7 +126,7 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  scala-js-ref                 : "scala-js/scala-js.git#v0.6.4"
+  scala-js-ref                 : "scala-js/scala-js.git"
 
   // version settings
   sbt-version-override         : "0.13.9"

--- a/common.conf
+++ b/common.conf
@@ -148,7 +148,7 @@ options.resolvers: {
   01: "local"
   02: "maven-cache: https://scala-ci.typesafe.com/artifactory/central/"
   03: "typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly"
-  04: "sbt-plugin-releases: https://dl.bintray.com/sbt/sbt-plugin-releases/"${vars.ivyPat}
+  04: "sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/"${vars.ivyPat}
   09: "dbuild-snapshots: http://repo.typesafe.com/typesafe/temp-distributed-build-snapshots"${vars.ivyPat}
   10: "maven-central"
   11: "old-typesafe-maven-releases: https://repo.typesafe.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2


### PR DESCRIPTION
green run with these changes:
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/96/consoleFull

not 100% green yet  actually, but the scala-js failure is addressed by
https://github.com/scala-js/scala-js/pull/1965

among other things, this fixes #12
