### PR TITLE
upgrade ScalaCheck to 1.11.6

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -82,7 +82,7 @@ vars: {
   scala-refactoring-ref        : "scala-ide/scala-refactoring.git#44dca8b74808528693f884cfd3c5c9d3ed13e519"
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
-  scalacheck-ref               : "rickynils/scalacheck.git#1.11.3"
+  scalacheck-ref               : "rickynils/scalacheck.git#1.11.6"
   scalatest-ref                : "scalatest/scalatest.git#scala-2.11-M8"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2


### PR DESCRIPTION
(because it's the same version Scala 2.11 itself currently uses)

green build (except for unrelated scala-js failure):
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/97/
