### PR TITLE
unfork/upgrade Shapeless in 2.11.x build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.sbt/
 .dbuild/
 .ivy2/
 .m2/

--- a/common.conf
+++ b/common.conf
@@ -175,8 +175,9 @@ build += {
   cross-version: [ disabled, standard ]
   space.from: [ default ]
   space.to: default
-  extraction-version: "2.11.6"
+  extraction-version: "2.11.7"
   sbt-version: ${vars.sbt-version-override}
+
   projects: [
   ${vars.base} {
     name: "parboiled",

--- a/common.conf
+++ b/common.conf
@@ -90,7 +90,7 @@ vars: {
   zeromq-scala-binding-ref     : "valotrading/zeromq-scala-binding.git#062e9438e322ec29d75b9649cb2aafa6ba3198a6"
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
-  shapeless-ref                : "adriaanm/shapeless.git#community-build"
+  shapeless-ref                : "milessabin/shapeless.git"
   scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#1.0.2"
   // change from https://github.com/sbt/sbt/pull/1509 broke building sbt with Scala 2.11
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
@@ -118,7 +118,9 @@ vars: {
   scala-records-ref            : "scala-records/scala-records.git"
 
   // TODO move back to master after adding scalaz-stream to the community build.
-  specs2-ref                   : "etorreborre/specs2.git#8fa92f3f9dac61ba39e169b83c091c4d5b15cb8c"
+  // the fork was necessary because Specs 2.4 uses Shapeless 2.0.0 but we want
+  // to be on 2.2.x, and we hit a small source incompatibility.
+  specs2-ref                   : "SethTisue/specs2.git#specs-24-compat-w-shapeless-22"
 
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"


### PR DESCRIPTION
I was able to prevent this from triggering a cascade of upgrades
through Specs2 by tweaking a bit of Specs2 code

a few other minor changes in here for good measure

green build with these changes:
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/100/
