### PR TITLE
lots of upgrades to stuff

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -83,7 +83,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.11.6"
-  scalatest-ref                : "scalatest/scalatest.git#2.1.x"
+  scalatest-ref                : "scalatest/scalatest.git#2.2.3-and-greater"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
   // therefore (which has a broken libdep of scalatest, however (cross full)):
@@ -96,14 +96,8 @@ vars: {
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
   // for now, we stick to fixed sha1 of sbt right before the merge of #1509
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
-  // ensime uses a rolling release to simplify distribution and launching from emacs.
-  // but for now we freeze at a rev from before spray-json-shapeless was added as a
-  // dependency, since that would set off a cascade of upgrades
-  ensime-ref                   : "ensime/ensime-server.git#823b947056d263431253aad25f35526aeb7f2888"
   // this is commit corresponding to 1.3.0 release, unfortunely pimpathon doesn't tag its releases
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
-  scalariform-ref              : "adriaanm/scalariform.git#community-build"
-  scalamock-ref                : "adriaanm/scalamock.git#community-build"
   sbt-testng-interface-ref     : "SethTisue/sbt-testng-interface.git#no-bintray"
 
   // tracking upstream (the ideal)
@@ -129,6 +123,18 @@ vars: {
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"
   slick-ref                    : "slick/slick.git#3.1"   // stay here; master wants Java 8
+  scalamock-ref                : "paulbutcher/scalamock.git"
+  scalariform-ref              : "daniel-trinh/scalariform.git"
+
+  // master depends on Akka HTTP and Akka Stream, which are tricky to depend on
+  // (they are built only a special branch). so freeze right over the dependency was added.
+  ensime-ref                   : "ensime/ensime-server.git#f4de40f6ce93afa75fd5bbe153c5f1df73035b1a"
+
+  // master uses Shapeless 2.3 only features, so at this time it doesn't make sense to
+  // track. there is no other branch we can track, so we use a version tag.  at time of
+  // writing (Oct 2015) 1.1.0 is both the latest released version and the version that
+  // Ensime depends on.  and Ensime is the main reason we're adding this at all
+  spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git#v1.1.0"
 
   // version settings
   sbt-version-override         : "0.13.9"
@@ -151,6 +157,7 @@ options.resolvers: {
   02: "maven-cache: https://scala-ci.typesafe.com/artifactory/central/"
   03: "typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly"
   04: "sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/"${vars.ivyPat}
+  05: "old-sbt-plugins: https://repo.typesafe.com/typesafe/ivy-releases/"${vars.ivyPat} // e.g. sbteclipse-plugin 2.x
   09: "dbuild-snapshots: http://repo.typesafe.com/typesafe/temp-distributed-build-snapshots"${vars.ivyPat}
   10: "maven-central"
   11: "old-typesafe-maven-releases: https://repo.typesafe.com/typesafe/maven-releases" // for play 2.3.9's netty-http-pipelining 1.1.2
@@ -158,6 +165,10 @@ options.resolvers: {
   // temporary, enables the fix of https://github.com/sbt/sbt-web/pull/107/files
   // discussion here: https://github.com/sbt/sbt-web/pull/107#issuecomment-94004046
   13: "bintray-eed3si9n-sbt-plugins: https://dl.bintray.com/eed3si9n/sbt-plugins"${vars.ivyPat}
+
+  // for Ensime's netbeans dependency
+  14: "netbeans: http://bits.netbeans.org/nexus/content/groups/netbeans"
+
 }
 
 // we don't have enough disk space to keep stuff longer
@@ -454,6 +465,12 @@ build += {
   ${vars.base} {
     name:   "scalamock",
     uri:    "https://github.com/"${vars.scalamock-ref}
+    extra.sbt-version: ${vars.sbt-version-override}
+  }
+
+  ${vars.base} {
+    name:   "spray-json-shapeless",
+    uri:    "https://github.com/"${vars.spray-json-shapeless-ref}
     extra.sbt-version: ${vars.sbt-version-override}
   }
 

--- a/common.conf
+++ b/common.conf
@@ -83,7 +83,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.11.6"
-  scalatest-ref                : "scalatest/scalatest.git#scala-2.11-M8"
+  scalatest-ref                : "scalatest/scalatest.git#2.1.x"
   // zeromq-scala-binding's master includes this fix (and others), which break akka-zeromq (?):
   // https://github.com/valotrading/zeromq-scala-binding/commit/c2a8a87673a1a3468486d1af9a6460bfed25c7a2
   // therefore (which has a broken libdep of scalatest, however (cross full)):


### PR DESCRIPTION
most of this isn't so important to have in the 2.11.x-jdk6 build,
since the action is in 2.11.x-jdk8 and 2.12.x, but lately I'm favoring
upgrading stuff here first where possible and then merging the changes
forward

green run w/ these changes:
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/114/
