### PR TITLE
scala-js: disable -Xfatal-warnings in Scaladoc generation;

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -121,10 +121,14 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  scala-js-ref                 : "scala-js/scala-js.git"
   slick-ref                    : "slick/slick.git#3.1"   // stay here; master wants Java 8
   scalamock-ref                : "paulbutcher/scalamock.git"
   scalariform-ref              : "daniel-trinh/scalariform.git"
+
+  // disable -Xfatal-warnings in Scaladoc generation;
+  // https://github.com/scala/community-builds/issues/149
+  // (should be possible without forking, but I ran out of time to mess with it)
+  scala-js-ref                 : "SethTisue/scala-js.git#community-build"
 
   // master depends on Akka HTTP and Akka Stream, which are tricky to depend on
   // (they are built only a special branch). so freeze right over the dependency was added.


### PR DESCRIPTION
works around #149 for now
