### PR TITLE
keep builds for a few days longer

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -181,12 +181,12 @@ options.resolvers: {
 // we don't have enough disk space to keep stuff longer
 options.cleanup: {
   extraction: {
-    success: 48
-    failure: 72
+    success: 96
+    failure: 120
   }
   build: {
-    success: 48
-    failure: 72
+    success: 96
+    failure: 120
   }
 }
 


### PR DESCRIPTION
I believe, based on my monitoring of the disk space situation on the
behemoths over the past few months, that this will be fine, and that
it will save us time during maintenance since we won't have to wait as
often for discarded builds to be redone.

I will continue monitoring the disk space to be sure.
