### PR TITLE
use triple quotes to make appendScalacOptions more readable

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -155,7 +155,23 @@ vars {
 // NB: vars.base and vars.base.extra need to be defined using +=, in order to include the
 // definitions in community-2.xx.x.dbuild
 // The appendScalacOptions command is needed as a workaround for https://github.com/typesafehub/dbuild/issues/144
-vars.base.extra.commands += "set commands += {\n  def appendScalacOptions(s: State, args: Seq[String]): State = {\n    val extracted = Project extract s\n    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y\n    import extracted._\n    val r = Project.relation(extracted.structure, true)\n    val allDefs = r._1s.toSeq\n    val projectScope = Load.projectScope(currentRef)\n    val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct\n    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))\n    val session = extracted.session.appendRaw(redefined)\n    BuiltinCommands.reapply(session, structure, s)  \n  }\n  Command.args(\"appendScalacOptions\", \"<option>\")(appendScalacOptions)\n}"
+vars.base.extra.commands += """
+set commands += {
+  def appendScalacOptions(s: State, args: Seq[String]): State = {
+    val extracted = Project extract s
+    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y
+    import extracted._
+    val r = Project.relation(extracted.structure, true)
+    val allDefs = r._1s.toSeq
+    val projectScope = Load.projectScope(currentRef)
+    val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct
+    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))
+    val session = extracted.session.appendRaw(redefined)
+    BuiltinCommands.reapply(session, structure, s)
+  }
+  Command.args(\"appendScalacOptions\", \"<option>\")(appendScalacOptions)
+}
+"""
 vars.base.extra.commands += "appendScalacOptions "${vars.scalac-opts}
 
 vars.ivyPat: ", [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"


### PR DESCRIPTION
it looks like whoever put this in didn't know HOCON supported
triple quotes. neither did I until today.
