### PR TITLE
fix appendScalacOptions, unfork scala-js

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -108,14 +108,10 @@ vars: {
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
+  scala-js-ref                 : "scala-js/scala-js.git"
   slick-ref                    : "slick/slick.git#3.1"   // stay here; master wants Java 8
   scalamock-ref                : "paulbutcher/scalamock.git"
   scalariform-ref              : "daniel-trinh/scalariform.git"
-
-  // disable -Xfatal-warnings in Scaladoc generation;
-  // https://github.com/scala/community-builds/issues/149
-  // (should be possible without forking, but I ran out of time to mess with it)
-  scala-js-ref                 : "SethTisue/scala-js.git#community-build"
 
   // master depends on Akka HTTP and Akka Stream, which are tricky to depend on
   // (they are built only a special branch). so freeze right over the dependency was added.
@@ -140,7 +136,7 @@ vars {
 // appendScalacOptions and removeScalacOptions
 // let us work around https://github.com/typesafehub/dbuild/issues/144
 vars.default-commands += """
-set commands += {
+set commands ++= {
   def alterScalacOptions(s: State, fn: Seq[String] => Seq[String]): State = {
     val extracted = Project extract s
     import extracted._
@@ -547,9 +543,11 @@ build += {
     uri:    "http://github.com/"${vars.scala-js-ref}
     extra: ${vars.base.extra} {
       projects: [ tools, testSuite, stubs ]
-      // - Disable compiler/test because it is very fragile.
       commands: ${vars.default-commands} [
-        "set test in (Build.compiler, Test) := {}"
+        // - Disable compiler/test because it is very fragile.
+        "set test in (Build.compiler, Test) := {}",
+        // - Disable fatal Scaladoc warnings, also fragile
+        "removeScalacOptions -Xfatal-warnings"
       ]
     }
   }

--- a/common.conf
+++ b/common.conf
@@ -1,32 +1,16 @@
 // Note: the Typesafe Config library is a bit picky with suffixes;
 // the common files included via the "include" directive should
 // have a ".conf" suffix.
-//
+
 // Each project is prefixed by ${vars.base} { ...
 // so that common options or settings can be set by the
 // configuration that includes this common file.
 //
-// If you use extra.options or commands in a project, or extend
-// its "extra" description in other ways, please use the form:
-//
-//      extra.options += "opt1"
-//      extra.options += "opt2"
-//      extra.options += "opt3"
-//      ...(one at a time)...
-//
-//  = or = the form:
-//
-//     extra: ${vars.base.extra} {
-//       options += "opt1"
-//       options += "opt2"
-//       options += "opt3"
-//      ...(one at a time)...
-//     }
-//
-// so that any "extra" definitions that may come from vars.base are prepended.
-// It is necessary to add the options one at a time due to a
-// limitation of the Typesafe Config library.
-//
+// Note however that += won't work inside vars.base.
+// It's https://github.com/typesafehub/config/issues/160.
+// That's why if you override extra.commands you must
+// explicitly include default-commands.
+
 ///////////////////////////////////////////////////////////////////////
 
 //
@@ -150,12 +134,11 @@ vars: {
 vars {
   scalac-opts                  : ""
   scalac-opts                  : ${?scalac_opts}   // allows additional compiler options using the scalac_opts environment
+  default-commands             : []
 }
 
-// NB: vars.base and vars.base.extra need to be defined using +=, in order to include the
-// definitions in community-2.xx.x.dbuild
-// The appendScalacOptions command is needed as a workaround for https://github.com/typesafehub/dbuild/issues/144
-vars.base.extra.commands += """
+// appendScalacOptions works around https://github.com/typesafehub/dbuild/issues/144
+vars.default-commands += """
 set commands += {
   def appendScalacOptions(s: State, args: Seq[String]): State = {
     val extracted = Project extract s
@@ -172,7 +155,8 @@ set commands += {
   Command.args("appendScalacOptions", "<option>")(appendScalacOptions)
 }
 """
-vars.base.extra.commands += "appendScalacOptions "${vars.scalac-opts}
+vars.default-commands += "appendScalacOptions "${vars.scalac-opts}
+vars.base.extra.commands = ${vars.default-commands}
 
 vars.ivyPat: ", [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]"
 options.resolvers: {
@@ -269,10 +253,12 @@ build += {
       exclude: ["spray-routing", "spray-routing-tests"]
       // disable running sphinx, it would be great if dbuild
       // offered a mechanism for excluding particular project (e.g. docs)
-      commands += "set SphinxSupport.sphinxCompile in docs := Seq.empty"
+      commands: ${vars.default-commands} [
+        "set SphinxSupport.sphinxCompile in docs := Seq.empty"
+      ]
       // disable parallel execution of tests as a work around for non-deterministic
       // failures, see: https://github.com/scala/community-builds/pull/69#issuecomment-63324597
-      settings += "parallelExecution in GlobalScope in Test := false"
+      settings: ["parallelExecution in GlobalScope in Test := false"]
     }
   }
 
@@ -286,7 +272,9 @@ build += {
       run-tests: false
         // workaround for the problem with PlayVersion.scala file is being passed twice to Scala compiler
         // and we get double definition error
-      commands += "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
+      commands: ${vars.default-commands} [
+        "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
+      ]
     }
   }
 
@@ -361,7 +349,9 @@ build += {
     uri: "https://github.com/"${vars.scalatest-ref}
     extra: ${vars.base.extra} {
       projects: ["scalatest"]
-      commands += "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
+      commands: ${vars.default-commands} [
+        "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
+      ]
       run-tests: false
     }
   }
@@ -445,7 +435,9 @@ build += {
   ${vars.base} {
     name:   "browse",
     uri:    "https://github.com/"${vars.browse-ref}
-    extra.commands += "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
+    extra.commands: ${vars.default-commands} [
+      "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
+    ]
     extra.exclude: ["test", "testLink"]
   }
 
@@ -468,7 +460,9 @@ build += {
     // [ensime] [error] .../src/main/scala/org/ensime/indexer/SourceResolver.scala:55: value toMultiMap is not a member of scala.collection.immutable.Set[(org.ensime.indexer.PackageName, org.apache.commons.vfs2.FileObject)]
     // [ensime] [error] possible cause: maybe a semicolon is missing before `value toMultiMap'?
     // [ensime] [error]   }.toMultiMap[Set]
-    extra.commands += "set every sources in doc in Compile := List()"
+    extra.commands: ${vars.default-commands} [
+      "set every sources in doc in Compile := List()"
+    ]
   }
 
   ${vars.base} {
@@ -545,7 +539,9 @@ build += {
     extra: ${vars.base.extra} {
       projects: [ tools, testSuite, stubs ]
       // - Disable compiler/test because it is very fragile.
-      commands += "set test in (Build.compiler, Test) := {}"
+      commands: ${vars.default-commands} [
+        "set test in (Build.compiler, Test) := {}"
+      ]
     }
   }
 

--- a/common.conf
+++ b/common.conf
@@ -137,22 +137,31 @@ vars {
   default-commands             : []
 }
 
-// appendScalacOptions works around https://github.com/typesafehub/dbuild/issues/144
+// appendScalacOptions and removeScalacOptions
+// let us work around https://github.com/typesafehub/dbuild/issues/144
 vars.default-commands += """
 set commands += {
-  def appendScalacOptions(s: State, args: Seq[String]): State = {
+  def alterScalacOptions(s: State, fn: Seq[String] => Seq[String]): State = {
     val extracted = Project extract s
-    def appendDistinct[A](x: Seq[A], y: Seq[A]) = x.filterNot(y.contains) ++ y
     import extracted._
     val r = Project.relation(extracted.structure, true)
     val allDefs = r._1s.toSeq
     val projectScope = Load.projectScope(currentRef)
     val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct
-    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(orig => appendDistinct(orig, args)))
+    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(fn))
     val session = extracted.session.appendRaw(redefined)
     BuiltinCommands.reapply(session, structure, s)
   }
-  Command.args("appendScalacOptions", "<option>")(appendScalacOptions)
+  def appendScalacOptions(s: State, args: Seq[String]) = {
+    def appendDistinct[A](x: Seq[A], y: Seq[A]) =
+      x.filterNot(y.contains) ++ y
+    alterScalacOptions(s, appendDistinct(_, args))
+  }
+  def removeScalacOptions(s: State, args: Seq[String]) =
+    alterScalacOptions(s, _.filterNot(args.contains))
+  Seq(
+    Command.args("appendScalacOptions", "<option>")(appendScalacOptions),
+    Command.args("removeScalacOptions", "<option>")(removeScalacOptions))
 }
 """
 vars.default-commands += "appendScalacOptions "${vars.scalac-opts}


### PR DESCRIPTION
green run at
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/161/consoleFull

well, it's still running, but scala-js is green, and I see the right
commands in the dump at the top of the run. works for me
