### PR TITLE
Scala.js needs more RAM on 2.12 or tests fail

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -419,6 +419,8 @@ build += {
     name:   "scala-js",
     uri:    "http://github.com/"${vars.scala-js-ref}
     extra: ${vars.base.extra} {
+      // memory hungry on 2.12! it's https://github.com/scala-js/scala-js/issues/2044
+      options: ["-Xmx2048m"]
       projects: [ tools, testSuite, stubs ]
       commands: ${vars.default-commands} [
         // - Disable compiler/test because it is very fragile.


### PR DESCRIPTION
fixes, or works around depending on your point of view,
https://github.com/scala-js/scala-js/issues/2044
