### PR TITLE
fix scalaz-stream regression by forking

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -101,12 +101,15 @@ vars: {
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
-  scalaz-stream-ref            : "scalaz/scalaz-stream.git#series/0.7a"
   scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"
   scalamock-ref                : "paulbutcher/scalamock.git"
   scalariform-ref              : "daniel-trinh/scalariform.git"
+
+  // master has a "snapshot-0.7a" version setting which makes a picky regex
+  // in dbuild 0.9.4 choke; it's https://github.com/typesafehub/dbuild/issues/182
+  scalaz-stream-ref            : "SethTisue/scalaz-stream.git#community-build-2.12"
 
   // master depends on Akka HTTP and Akka Stream, which are tricky to depend on
   // (they are built only a special branch). so freeze right before the dependency was added.


### PR DESCRIPTION
to work around picky dbuild regex; it's
https://github.com/typesafehub/dbuild/issues/182
