### PR TITLE
upgrade dbuild to 0.9.5

### DIFF
--- a/scripts/jobs/integrate/community-build
+++ b/scripts/jobs/integrate/community-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DBUILDVERSION=0.9.1
+DBUILDVERSION=0.9.5
 
 # otherwise these directories just keep growing.
 # see scala/scala-jenkins-infra#115


### PR DESCRIPTION
mainly just to keep current w/ what RP is doing, but also 0.9.5
has multi-JDK support so we should be able to remove some JDK
6 vs. 8 workarounds as this is merged forwards
