### PR TITLE
Remove reference to benchmarks of scala-records

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -304,7 +304,7 @@ build += {
   ${vars.base} {
     name: "scala-records"
     uri: "https://github.com/"${vars.scala-records-ref}
-    extra.exclude: ["coreJS", "benchmarks"]
+    extra.exclude: ["coreJS"]
   }
 
   ${vars.base} {


### PR DESCRIPTION
The "benchmarks" subproject got removed in
scala-records/scala-records#126.
