### PR TITLE
Added rapture version 2.0.0-M2

### DIFF
--- a/common-2.11.x.conf
+++ b/common-2.11.x.conf
@@ -99,6 +99,8 @@ vars: {
   // this problem is tracked in https://github.com/sbt/sbt/issues/1523
   // for now, we stick to fixed sha1 of sbt right before the merge of #1509
   sbt-ref                      : "sbt/sbt.git#0b2f2ae5a8ab2b082b6e15b196d671a4c18cc9f2"
+  
+  rapture-ref                  : "propensive/rapture.git#7bac4876d5ddaa3d0cf746b21c419f88f2a254c1"
 
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git"
@@ -234,6 +236,11 @@ build += {
         // and we get double definition error
       commands += "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
     }
+  }
+  
+  ${vars.base} {
+    name: rapture
+    uri:    "https://github.com/"${vars.rapture-ref}
   }
 
   ${vars.base} {


### PR DESCRIPTION
This includes Rapture in the community build, pointing to the 2.0.0-M2 release (which, incidentally, excludes scala.js support from the build).
