### PR TITLE
add scodec-bits

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -111,6 +111,7 @@ vars: {
   sbinary-ref                  : "harrah/sbinary.git"
   sbt-republish-ref            : "typesafehub/sbt-republish.git"
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
+  scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"
   slick-ref                    : "slick/slick.git"
@@ -342,6 +343,20 @@ build += {
   ${vars.base} {
     name: scalaz
     uri: "https://github.com/"${vars.scalaz-ref}
+  }
+
+  ${vars.base} {
+    name: scodec-bits
+    uri: "https://github.com/"${vars.scodec-bits-ref}
+    extra.projects: ["coreJVM"]
+    extra.commands: ${vars.default-commands} [
+      // too fragile, especially in Scaladoc
+      "removeScalacOptions -Xfatal-warnings"
+    ]
+    // core/shared/src/test/scala/scodec/bits/BitsSuite.scala:9:
+    //   not found: type PropertyCheckConfiguration
+    // looks like probably a ScalaTest 2.x vs 3.0 thing to me
+    extra.run-tests: false
   }
 
   ${vars.base} {


### PR DESCRIPTION
we have it in the 2.12 build, can't see any reason it shouldn't
be in 2.11 as well. adding it to 2.11.x-jdk8 rather than regular
2.11.x because it uses an sbt plugin (namely scodec-build) with
a Java 7+ only dependency (namely JMH)
