### PR TITLE
(Don't merge) Bump up to sbt 0.13.10-M1 in 2.12.x

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -125,7 +125,7 @@ vars: {
   spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git#v1.1.0"
 
   // version settings
-  sbt-version-override         : "0.13.9"
+  sbt-version-override         : "0.13.10-M1"
 }
 
 vars {


### PR DESCRIPTION
This is to test the quality of sbt 0.13.10 release candidates.

2.12 clone of #210
