### PR TITLE
(Don't merge) Bump up to sbt 0.13.10-M1 in 2.11.x-jdk8

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -133,7 +133,7 @@ vars: {
   scala-gopher-ref             : "rssh/scala-gopher.git#community-build"
 
   // version settings
-  sbt-version-override         : "0.13.9"
+  sbt-version-override         : "0.13.10-M1"
 }
 
 vars {


### PR DESCRIPTION
This is to test the quality of sbt 0.13.10 release candidates.

2.11.x-jdk8 clone of #210
