### PR TITLE
fastparse: disable test failing with OutOfMemoryError

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -641,7 +641,7 @@ build += {
     name:   "fastparse",
     uri:    "http://github.com/"${vars.fastparse-ref}
     // no Scala.js plz
-    extra.projects: ["fastparseJVM", "scalaparseJVM"]
+    extra.projects: ["fastparseJVM"]
   }
 
   ${vars.base} {


### PR DESCRIPTION
reported upstream at https://github.com/lihaoyi/fastparse/issues/76
