### PR TITLE
remove some sbt-related cruft from common.conf

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -127,7 +127,7 @@ vars: {
   scala-gopher-ref             : "rssh/scala-gopher.git#community-build"
 
   // version settings
-  sbt-version-override         : "0.13.11"
+  sbt-version                  : "0.13.11"
 }
 
 vars {
@@ -204,7 +204,7 @@ build += {
   space.from: [ default ]
   space.to: default
   extraction-version: "2.11.7"
-  sbt-version: ${vars.sbt-version-override}
+  sbt-version: ${vars.sbt-version}
 
   projects: [
   ${vars.base} {
@@ -284,7 +284,7 @@ build += {
         "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
       ]
       // details: https://github.com/scala/community-builds/pull/227
-      options: ["-Dplay.sbt.version="${vars.sbt-version-override}]
+      options: ["-Dplay.sbt.version="${vars.sbt-version}]
     }
   }
 
@@ -468,7 +468,6 @@ build += {
   ${vars.base} {
     name:   "ensime",
     uri:    "https://github.com/"${vars.ensime-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     // scaladoc fails with
     // [ensime] [info] Compiling 73 Scala sources to .../target/scala-2.11/classes...
     // [ensime] [info] Main Scala API documentation to .../target/scala-2.11/api...
@@ -483,13 +482,11 @@ build += {
   ${vars.base} {
     name:   "pimpathon",
     uri:    "https://github.com/"${vars.pimpathon-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name:   "scalariform",
     uri:    "https://github.com/"${vars.scalariform-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     // avoid building misc subproject that depends on Swing (and is not needed by any other project)
     extra.projects: ["scalariform"]
   }
@@ -497,13 +494,11 @@ build += {
   ${vars.base} {
     name:   "scalamock",
     uri:    "https://github.com/"${vars.scalamock-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {
     name:   "spray-json-shapeless",
     uri:    "https://github.com/"${vars.spray-json-shapeless-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
   }
 
   ${vars.base} {

--- a/community.dbuild
+++ b/community.dbuild
@@ -15,7 +15,7 @@ include file("common.conf")
 build += {
   extraction-version: "2.11.7"
   cross-version: disabled
-  sbt-version: ${vars.sbt-version-override}
+  sbt-version: ${vars.sbt-version}
   projects: [
   // Scala 2.11.x
   {
@@ -23,7 +23,7 @@ build += {
     system: assemble
     extra.parts: {
       cross-version: standard
-      sbt-version: ${vars.sbt-version-override}
+      sbt-version: ${vars.sbt-version}
       extraction-version: "2.11.7"
       cross-version: disabled
     }
@@ -54,7 +54,6 @@ build += {
   ${vars.base} {
     name: "scala-continuations"
     uri: "https://github.com/"${vars.scala-continuations-ref}
-    extra.sbt-version: ${vars.sbt-version-override}
     // Trying to avoid unexplained error on Toolbox based tests: "bad option: -P:continuations:enable"
     // This is reproducible outside of dbuild, but hard to pin down.
     // Example: https://gist.github.com/retronym/9122414


### PR DESCRIPTION
review by me -- here's a test run I'll scrutinize to make sure
we still always get the sbt version we want:
https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/239/
(temporarily 404 while Jenkins catches up)
