### PR TITLE
build fastparse with an older sbt version for now

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -637,6 +637,16 @@ build += {
     uri:    "http://github.com/"${vars.fastparse-ref}
     // no Scala.js plz
     extra.projects: ["fastparseJVM"]
+    // with 0.13.11 I got
+    // Running "test" in: fastparseJVM
+    // Compiling 9 Scala sources to [...]/fastparse/jvm/target/scala-2.11/test-classes...
+    // java.lang.IndexOutOfBoundsException: 0
+    //   at scala.collection.LinearSeqOptimized$class.apply(LinearSeqOptimized.scala:65)
+    //   at scala.collection.immutable.List.apply(List.scala:84)
+    //   at xsbt.ExtractAPI.makeParameter$1(ExtractAPI.scala:295)
+    // the issue is reproducible outside of the community build, so it's apparently
+    // an sbt regression. reported at https://github.com/sbt/sbt/issues/2497
+    extra.sbt-version: "0.13.9"
   }
 
   ${vars.base} {


### PR DESCRIPTION
because https://github.com/sbt/sbt/issues/2497

fyi @lihaoyi
