### PR TITLE
2.12: jawn, spire: don't use removed -Yinline-warnings flag

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -751,6 +751,10 @@ build += {
     // omitted TODO: play
     // omitted: argonaut, rojoma-v3, rojoma, benchmark
     extra.projects: ["ast", "parser"]
+    // no longer exists in 2.12
+    extra.commands: ${vars.default-commands} [
+      "removeScalacOptions -Yinline-warnings"
+    ]
   }
 
   // note that we don't have MiMa in the JDK6 build.  I tried but it
@@ -840,5 +844,9 @@ build += {
     // [info] [error] Could not run test spire.laws.LawTests:
     // java.lang.ClassFormatError: Duplicate method name&signature in class file spire/std/OrderProductInstances$$anon$228
     extra.run-tests: false
+    // no longer exists in 2.12
+    extra.commands: ${vars.default-commands} [
+      "removeScalacOptions -Yinline-warnings"
+    ]
   }
 ]}


### PR DESCRIPTION
jawn and spire started failing in the 2.12.x build
when `-Yinline-warnings` was removed from 2.12
