### PR TITLE
Use new STARR for scalaVersion override in scala-{xml,parsers}

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -43,12 +43,12 @@ build += {
       {
         name: "scala-xml"
         uri: "https://github.com/"${vars.scala-xml-ref}
-        extra.commands: "set scalaVersion := \"2.12.0-M3\""
+        extra.commands: "set scalaVersion := \"2.12.0-M3-dc9effe\""
       }
       {
         name: "scala-parser-combinators"
         uri: "https://github.com/"${vars.scala-parser-combinators-ref}
-        extra.commands: "set scalaVersion := \"2.12.0-M3\""
+        extra.commands: "set scalaVersion := \"2.12.0-M3-dc9effe\""
         extra.projects: ["scala-parser-combinatorsJVM"]
       }
     ]


### PR DESCRIPTION
This was necessary to get a community build working with the
https://github.com/scala/scala/pull/5003.

It is likely that after this change, people will need to rebase
branches on scala/scala#2.12.x before running them through the
community build. Alternatively, they could trigger the community
build with community-builds/64063200, rather than 64063200#2.12.x.

Review by @adriaanm

Should be merged in concert with https://github.com/scala/scala/pull/5003
