### PR TITLE
pin sbt-republish to a non-broken SHA

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -106,7 +106,11 @@ vars: {
 
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
-  sbt-republish-ref            : "typesafehub/sbt-republish.git"
+
+  // TODO move back to master; see https://github.com/scala/community-builds/issues/234
+  // for details
+  sbt-republish-ref            : "typesafehub/sbt-republish.git#928074de6976991479b26f2fa6817cedc54ff22d"
+
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"


### PR DESCRIPTION
working around #234 

test run: https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/254/consoleFull
