### PR TITLE
pin sbt-republish to a non-broken SHA

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -106,7 +106,11 @@ vars: {
 
   zinc-ref                     : "typesafehub/zinc.git"
   sbinary-ref                  : "harrah/sbinary.git"
-  sbt-republish-ref            : "typesafehub/sbt-republish.git"
+
+  // TODO move back to master; see https://github.com/scala/community-builds/issues/234
+  // for details
+  sbt-republish-ref            : "typesafehub/sbt-republish.git#9f7109c705175c6d8e7e99c60e53959f9e4c5df0"
+
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-js-ref                 : "scala-js/scala-js.git"


### PR DESCRIPTION
replaces #235 

~~test run: https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/256/consoleFull (404 for now til Jenkins catches up)~~

restarted: https://scala-ci.typesafe.com/job/scala-2.11.x-integrate-community-build/258/consoleFull
