### PR TITLE
patch acyclic to work with current utest

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -83,7 +83,8 @@ vars: {
   pimpathon-ref                : "stacycurl/pimpathon.git#d2354dd92f5481610f4610edba3574880b07263e"
   sbt-testng-interface-ref     : "SethTisue/sbt-testng-interface.git#no-bintray"
   utest-ref                    : "lihaoyi/utest.git"
-  acyclic-ref                  : "lihaoyi/acyclic.git"
+  # until https://github.com/lihaoyi/acyclic/pull/13 is merged
+  acyclic-ref                  : "SethTisue/acyclic.git#use-latest-utest"
   sourcecode-ref               : "lihaoyi/sourcecode.git"
   fastparse-ref                : "lihaoyi/fastparse.git"
   breeze-ref                   : "scalanlp/breeze.git#releases/v0.12"


### PR DESCRIPTION
as a workaround until https://github.com/lihaoyi/acyclic/pull/13
is merged; see also https://github.com/scala/scala-dev/issues/108
