### PR TITLE
Switch to Akka master branch for 2.12.x

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -78,12 +78,13 @@ vars: {
   sbt-testng-interface-ref     : "SethTisue/sbt-testng-interface.git#no-bintray"
 
   // tracking upstream (the ideal)
-  akka-ref                     : "adriaanm/akka.git#sam240"
+  akka-ref                     : "akka/akka.git#master"
   async-ref                    : "scala/async.git"
   scala-continuations-ref      : "scala/scala-continuations.git"
   scala-parser-combinators-ref : "scala/scala-parser-combinators.git"
   scala-partest-ref            : "scala/scala-partest.git"
   scala-partest-interface-ref  : "scala/scala-partest-interface.git"
+  scala-java8-compat-ref       : "szeiger/scala-java8-compat.git#wip/scala-2.12.0-rc1-compat"
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "adriaanm/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
@@ -207,7 +208,7 @@ options.cleanup: {
 }
 
 // Topological sort of projects:
-// No deps: browse, slick, genjavadoc-plugin, scala-js, scala-swing, scala-partest-interface, async, scalacheck, shapeless
+// No deps: browse, slick, genjavadoc-plugin, scala-js, scala-swing, scala-partest-interface, async, scalacheck, shapeless, scala-java8-compat
 //
 // *depends* on scalacheck: scalaz, sbinary, scala-partest, scalatest
 // *depends* on scalatest: scodec-bits, scala-records, genjavadoc, scala-stm
@@ -248,6 +249,14 @@ build += {
     // optimizer related. Lukas may want to revisit before 2.12 final
     extra.commands: ${vars.default-commands} [ "removeScalacOptions -Xfatal-warnings" ]
     extra.run-tests: false // TODO enable tests
+  }
+
+  ${vars.base} {
+    name: "scala-java8-compat",
+    uri: "https://github.com/"${vars.scala-java8-compat-ref}
+    // For some reason dbuild includes test sources in the javadocs, which trips up javadoc because
+    // we use "assert" as an identifier there. We disable doc building to avoid that.
+    extra.commands: ${vars.default-commands} [ "set publishArtifact in packageDoc := false" ]
   }
 
   ${vars.base} {
@@ -348,6 +357,16 @@ build += {
      // to get the JMH dependency. - ST 8/17/15
      projects: ["akka-actor", "akka-testkit", "akka-slf4j", "akka-kernel", "akka-actor-tests", "akka-typed-experimental", "akka-remote", "akka-multi-node-testkit", "akka-remote-tests", "akka-cluster", "akka-distributed-data-experimental", "akka-cluster-metrics", "akka-cluster-tools", "akka-camel", "akka-persistence", "akka-cluster-sharding", "akka-persistence-tck", "akka-contrib", "akka-osgi"]
      run-tests: false // TODO re-enable tests (they've long been disabled in 2.11 as well) - ST 8/27/15
+     commands: ${vars.default-commands} [
+       // Don't build akka-remote-tests/test scope because it requires ScalaTest 3.0
+       "set sources in (LocalProject(\"akka-remote-tests\"), Test) := Nil"
+       // Don't build akka-persistence-tck because it requires Scalactic (which comes as a dependency of ScalaTest 3.0)
+       "set sources in (LocalProject(\"akka-persistence-tck\"), Compile) := Nil"
+       "set sources in (LocalProject(\"akka-persistence-tck\"), Test) := Nil"
+       // Don't build multi-jvm tests because they require akka-remote-tests and ScalaTest 3.0
+       "set sources in (LocalProject(\"akka-remote-tests\"), config(\"multi-jvm\")) := Nil"
+       "set sources in (LocalProject(\"akka-cluster\"), config(\"multi-jvm\")) := Nil"
+     ]
    }
   }
 


### PR DESCRIPTION
First build attempt failed due to missing new dependency scala-java8-compat: https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-community-build/502/console
