### PR TITLE
make scalaz compile again after SI-8079 fix merged

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -109,7 +109,7 @@ vars: {
   // for details
   sbt-republish-ref            : "typesafehub/sbt-republish.git#9f7109c705175c6d8e7e99c60e53959f9e4c5df0"
 
-  scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
+  scalaz-ref                   : "SethTisue/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
   scodec-bits-ref              : "adriaanm/scodec-bits.git#dbuild-sam"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-2-12-junit-mixin-plugin-ref : "scala-js/scala-2.12-junit-mixin-plugin.git"


### PR DESCRIPTION
the actual commit in my scalaz fork is:
https://github.com/SethTisue/scalaz/commit/4d3ca9a55b1a858e41d97251e7aa1e9950524c85
it adds some @uncheckedVariance annotations.
