### PR TITLE
get MiMa extracting again

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -91,7 +91,7 @@ vars: {
   slick-ref                    : "adriaanm/slick.git#master"
   twitter-util-ref             : "adriaanm/util.git#develop"
   jawn-ref                     : "non/jawn.git"
-  mima-ref                     : "lrytz/migration-manager.git#2.12-compat"
+  mima-ref                     : "SethTisue/migration-manager.git#2.12-compat"
   utest-ref                    : "lihaoyi/utest.git#0.4.3"
   acyclic-ref                  : "lihaoyi/acyclic.git"
   sourcecode-ref               : "lihaoyi/sourcecode.git"


### PR DESCRIPTION
lrytz's fork didn't have the fix for
https://github.com/scala/community-builds/issues/259
(sbt 0.13.12 compatibility)
