### PR TITLE
assorted improvements:

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -86,7 +86,7 @@ vars: {
   scala-partest-interface-ref  : "scala/scala-partest-interface.git"
   scala-java8-compat-ref       : "szeiger/scala-java8-compat.git#wip/scala-2.12.0-rc1-compat"
   scala-xml-ref                : "scala/scala-xml.git"
-  scala-swing-ref              : "adriaanm/scala-swing.git#2.0.x"
+  scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
   slick-ref                    : "adriaanm/slick.git#master"
   twitter-util-ref             : "adriaanm/util.git#develop"

--- a/common.conf
+++ b/common.conf
@@ -64,7 +64,7 @@ vars: {
   // "release-0.7" is a stable branch, used to cut 0.7 against new Scala milestones at this time
   scala-stm-ref                : "nbronson/scala-stm.git#release-0.7"
   scalacheck-ref               : "rickynils/scalacheck.git#1.11.6"
-  scalatest-ref                : "adriaanm/scalatest.git#2.2.3-and-greater-cobu"
+  scalatest-ref                : "SethTisue/scalatest.git#3.0.x-community-build"
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
   # before adding the scoverage 1.3.5 dependency
@@ -317,9 +317,6 @@ build += {
     uri: "https://github.com/"${vars.scalatest-ref}
     extra: ${vars.base.extra} {
       projects: ["scalatest", "scalactic"]
-      commands: ${vars.default-commands} [
-        "set libraryDependencies += \"org.scala-lang.modules\" %% \"scala-xml\" % \"1.0.0-RC6\""
-      ]
       run-tests: false // TODO enable tests
     }
   }

--- a/common.conf
+++ b/common.conf
@@ -109,7 +109,7 @@ vars: {
   // for details
   sbt-republish-ref            : "typesafehub/sbt-republish.git#9f7109c705175c6d8e7e99c60e53959f9e4c5df0"
 
-  scalaz-ref                   : "adriaanm/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
+  scalaz-ref                   : "SethTisue/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
   scodec-bits-ref              : "adriaanm/scodec-bits.git#dbuild-sam"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-2-12-junit-mixin-plugin-ref : "scala-js/scala-2.12-junit-mixin-plugin.git"

--- a/common.conf
+++ b/common.conf
@@ -113,7 +113,7 @@ vars: {
   scodec-bits-ref              : "adriaanm/scodec-bits.git#dbuild-sam"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-2-12-junit-mixin-plugin-ref : "scala-js/scala-2.12-junit-mixin-plugin.git"
-  scala-js-ref                 : "adriaanm/scala-js.git"
+  scala-js-ref                 : "scala-js/scala-js.git"
   scalamock-ref                : "paulbutcher/scalamock.git"
   scalariform-ref              : "daniel-trinh/scalariform.git"
 

--- a/common.conf
+++ b/common.conf
@@ -109,7 +109,7 @@ vars: {
   // for details
   sbt-republish-ref            : "typesafehub/sbt-republish.git#9f7109c705175c6d8e7e99c60e53959f9e4c5df0"
 
-  scalaz-ref                   : "SethTisue/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
+  scalaz-ref                   : "adriaanm/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
   scodec-bits-ref              : "adriaanm/scodec-bits.git#dbuild-sam"
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-2-12-junit-mixin-plugin-ref : "scala-js/scala-2.12-junit-mixin-plugin.git"

--- a/common.conf
+++ b/common.conf
@@ -114,7 +114,7 @@ vars: {
   discipline-ref               : "typelevel/discipline.git#v0.2"
   scala-2-12-junit-mixin-plugin-ref : "scala-js/scala-2.12-junit-mixin-plugin.git"
   scala-js-ref                 : "scala-js/scala-js.git"
-  scalamock-ref                : "paulbutcher/scalamock.git"
+  scalamock-ref                : "dvic/scalamock.git"  // TODO use paulbutcher/ again once https://github.com/paulbutcher/ScalaMock/pull/149 gets merged
   scalariform-ref              : "daniel-trinh/scalariform.git"
 
   // master has a "snapshot-0.7a" version setting which makes a picky regex

--- a/common.conf
+++ b/common.conf
@@ -88,7 +88,7 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-  slick-ref                    : "adriaanm/slick.git#master"
+  slick-ref                    : "slick/slick.git"
   twitter-util-ref             : "adriaanm/util.git#develop"
   jawn-ref                     : "non/jawn.git"
   mima-ref                     : "SethTisue/migration-manager.git#2.12-compat"


### PR DESCRIPTION
- ScalaTest 2.2.x -> 3.0.x
- update and/or unfork Slick, scala-swing, scala-js
- tweak scalaz for recently merged 2.12 PRs
