### PR TITLE
Use the executable "nodejs" when testing Scala.js.

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -547,7 +547,10 @@ build += {
         // - Disable compiler/test because it is very fragile.
         "set test in (Build.compiler, Test) := {}",
         // - Disable fatal Scaladoc warnings, also fragile
-        "removeScalacOptions -Xfatal-warnings"
+        "removeScalacOptions -Xfatal-warnings",
+        // - Use Node.js with the executable "nodejs" instead of "node" (environmental in the CI infrastructure)
+        //   We disable source map tests to save ourselves a `npm install source-map-support` on the workers
+        "set jsEnv in testSuite := NodeJSEnv(executable = \"nodejs\").value.withSourceMap(false)"
       ]
     }
   }


### PR DESCRIPTION
Scala.js will change its default runner from Rhino to Node.js in 0.6.13 (see https://github.com/scala-js/scala-js/issues/2579). This commit preemptively tests whether this is going to be a problem for the community build.
