### PR TITLE
Use "nodejs" in all Scala.js projects that testSuite depends on.

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -549,8 +549,10 @@ build += {
         // - Disable fatal Scaladoc warnings, also fragile
         "removeScalacOptions -Xfatal-warnings",
         // - Use Node.js with the executable "nodejs" instead of "node" (environmental in the CI infrastructure)
-        //   We disable source map tests to save ourselves a `npm install source-map-support` on the workers
-        "set jsEnv in testSuite := NodeJSEnv(executable = \"nodejs\").value.withSourceMap(false)"
+        //   We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
+        //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
+        //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
+        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := NodeJSEnv(executable = \"nodejs\").value.withSourceMap(false))"
       ]
     }
   }


### PR DESCRIPTION
Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
