### PR TITLE
unfork Scala.js

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -116,7 +116,7 @@ vars: {
   scalaz-ref                   : "SethTisue/scalaz.git#community-build-2.12"  // TODO SI-8079 fix + variance of Id
   scodec-bits-ref              : "adriaanm/scodec-bits.git#dbuild-sam"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  scala-js-ref                 : "adriaanm/scala-js.git"  // TODO unfork once https://github.com/scala-js/scala-js/issues/2582 is fixed
+  scala-js-ref                 : "scala-js/scala-js.git"
   scalamock-ref                : "dvic/scalamock.git"  // TODO use paulbutcher/ again once https://github.com/paulbutcher/ScalaMock/pull/149 gets merged
   scalariform-ref              : "daniel-trinh/scalariform.git"
 


### PR DESCRIPTION
now that the necessary changes have been merged upstream (https://github.com/scala-js/scala-js/commit/730d7aba86f6227ea8c1d7a3b7eba56a36f4248f)
