### PR TITLE
newer scala-logging, newer scoverage, unfreeze Shapeless, unfork Scala.js

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -71,9 +71,8 @@ vars: {
   scalatest-ref                : "SethTisue/scalatest.git#3.0.x-community-build"
   // fixed sha/tag (a compromise), the sha points at master that supports Scala 2.11
   spire-ref                    : "non/spire.git#3d2a41e91a1f6946fac63660f6157d4a6e4a281d"
-  # before adding the scoverage 1.3.5 dependency
-  shapeless-ref                : "milessabin/shapeless.git#a719bba5bf74f5e4225d51a66b3b5f468ba49f02"
-  scoverage-ref                : "scoverage/scalac-scoverage-plugin.git#1.0.2"
+  shapeless-ref                : "milessabin/shapeless.git"
+  scoverage-ref                : "SethTisue/scalac-scoverage-plugin.git#newer-scala-logging"
   kind-projector-ref           : "non/kind-projector.git#v0.7.1"
   sbt-ref                      : "adriaanm/sbt.git#community-build" // 0.13.7-M2 + drop ListBuffer.readOnly (after 0.13.7-M2, new dependencies were added --> TODO: add them here as well)
 
@@ -102,6 +101,7 @@ vars: {
   fastparse-ref                : "lihaoyi/fastparse.git"
   macro-paradise-ref           : "adriaanm/paradise.git#2.12.x-cobu"
   macro-compat-ref             : "milessabin/macro-compat.git"
+  scala-logging-ref            : "typesafehub/scala-logging.git"
 
   specs2-3-ref                 : "adriaanm/specs2.git#community-build-3.6" // "etorreborre/specs2.git#SPECS2-3.6.2"
   specs2-2-ref                 : "adriaanm/specs2.git#community-build-2.4" // "etorreborre/specs2.git#SPECS2-2.4.17"
@@ -268,6 +268,15 @@ build += {
     // optimizer related. Lukas may want to revisit before 2.12 final
     extra.commands: ${vars.default-commands} [ "removeScalacOptions -Xfatal-warnings" ]
     extra.run-tests: false // TODO enable tests
+  }
+
+  ${vars.base} {
+    name: "scoverage"
+    uri:  "https://github.com/"${vars.scoverage-ref}
+    extra: ${vars.base.extra} {
+      exclude: ["scalac-scoverage-runtimeJS"] // no Scala.js please
+      run-tests: false // TODO: [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].
+    }
   }
 
   ${vars.base} {
@@ -520,12 +529,15 @@ build += {
     extra.projects: ["testJVM"]
   }
 
+  ${vars.base} {
+    name:   "scala-logging"
+    uri:    "http://github.com/"${vars.scala-logging-ref}
+  }
+
 ]
 }
 
-// no deps: scala-logging-api
-// scala-logging-slf4j depends on: scala-logging-api
-// scoverage depends on: scala-logging-slf4j, scalacheck, scalatest
+// scoverage depends on: scala-logging, scalacheck, scalatest
 // specs2 depends on: scalacheck, scalatest, scalaz, scalaz-stream, scodec-bits, shapeless, scoverage
 build += {
   check-missing: [ true, false ]
@@ -546,35 +558,6 @@ build += {
   ${vars.base} {
     name: "discipline"
     uri: "https://github.com/"${vars.discipline-ref}
-  }
-
-  ${vars.base} {
-    name: "scoverage"
-    uri:  "https://github.com/"${vars.scoverage-ref}
-    extra: ${vars.base.extra} {
-      run-tests: false // TODO: [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].
-    }
-  }
-
-
-// scala-logging-slf4j is used by scoverage, but:
-// - scala-logging-slf4j v2.1.2 won't compile (not found: value LoggerMacro)
-// - and v3.0.0 changed the artifacts, so we grab v2.1.2 via Ivy instead.
-//  ${vars.base} {
-//    name: "scala-logging"
-//    uri:  "https://github.com/typesafehub/scala-logging.git#v2.1.2"
-//  }
-
-  {
-    name:   "scala-logging-slf4j"
-    system: "ivy"
-    uri:    "ivy:com.typesafe.scala-logging#scala-logging-slf4j_2.11;2.1.2"
-  }
-
-  {
-    name:   "scala-logging-api"
-    system: "ivy"
-    uri:    "ivy:com.typesafe.scala-logging#scala-logging-api_2.11;2.1.2"
   }
 
   // in this space because it depends on scoverage


### PR DESCRIPTION
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/587/consoleFull (404 til Jenkins catches up)
