### PR TITLE
add scalaprops and scalikejdbc

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -577,6 +577,11 @@ build += {
     ${vars.base} {
       name:   "scalikejdbc"
       uri:    "http://github.com/"${vars.scalikejdbc-ref}
+      // Failed tests: scalikejdbc.DBSessionSpec. asked author about it at
+      // https://github.com/scala/community-builds/issues/279#issuecomment-249061125
+      extra.run-tests: false
+      // don't build sbt plugins
+      extra.exclude: ["mapper-generator"]
     }
 
   ]

--- a/common.conf
+++ b/common.conf
@@ -76,6 +76,8 @@ vars: {
   macro-paradise-ref           : "adriaanm/paradise.git#2.12.x-cobu"
   macro-compat-ref             : "milessabin/macro-compat.git"
   scala-logging-ref            : "typesafehub/scala-logging.git"
+  scalaprops-ref               : "scalaprops/scalaprops.git#0.1.x"  // master uses FreeT from scalaz 7.2, we're on 7.1
+  scalikejdbc-ref              : "scalikejdbc/scalikejdbc.git"
 
   specs2-3-ref                 : "adriaanm/specs2.git#community-build-3.6" // "etorreborre/specs2.git#SPECS2-3.6.2"
   specs2-2-ref                 : "adriaanm/specs2.git#community-build-2.4" // "etorreborre/specs2.git#SPECS2-2.4.17"
@@ -500,6 +502,13 @@ build += {
     uri:    "http://github.com/"${vars.scala-logging-ref}
   }
 
+  ${vars.base} {
+    name:   "scalaprops"
+    uri:    "http://github.com/"${vars.scalaprops-ref}
+    // will be needed if we start tracking master. not needed on 0.1.x branch
+    // extra.projects: ["rootJVM"]  // no Scala.js please
+  }
+
 ]
 }
 
@@ -564,6 +573,12 @@ build += {
       extra.projects: ["specs2"] // so that it actually publishes org.specs2 % specs2? -- needed to put some random artifacts in the jar: https://github.com/typesafehub/dbuild/issues/173
       extra.run-tests: false // TODO: at least SnippetsTest is failing.
     }
+
+    ${vars.base} {
+      name:   "scalikejdbc"
+      uri:    "http://github.com/"${vars.scalikejdbc-ref}
+    }
+
   ]
 }
 


### PR DESCRIPTION
fixes #279 (add scalikejdbc). progress towards #282 (add kxbmap/configs;
scalaprops is one of its dependencies)

scalaprops is an older version, since the latest version requires scalaz 7.2 which we don't have yet, we're still on 7.1
