### PR TITLE
newer Parboiled

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -32,8 +32,7 @@ vars: {
   scala-io-ref                 : "adriaanm/scala-io.git#community-build"
   json4s-ref                   : "json4s/json4s.git#v3.2.10_2.11"
   playframework-ref            : "playframework/playframework.git"
-  // fixed sha from master that has Scala 2.11 patches merged
-  parboiled-ref                : "sirthias/parboiled.git#c53e650212f222c9b1f75fa1ab13d7cab9db164e"
+  parboiled-ref                : "SethTisue/parboiled.git#community-build-2.12"  // TODO report upstream: version-checking logic, ScalaTest 3.0 compat
   // This pull request supports the fully-cross-versioned continuations plugin, shipped with 2.11+
   scala-arm-ref                : "jsuereth/scala-arm.git#pull/31/head"
   genjavadoc-ref               : "typesafehub/genjavadoc.git#v0.5_2.11.0-M8"
@@ -524,6 +523,13 @@ build += {
     extra.projects: ["coreJVM", "examplesJVM"] // no Scala.js please
   }
 
+  ${vars.base} {
+    name: "parboiled"
+    uri: "https://github.com/"${vars.parboiled-ref}
+    extra.projects: ["parboiled-scala"]
+    extra.run-tests: false // TODO test failures, why?!
+  }
+
 ]
 }
 
@@ -763,17 +769,6 @@ build += {
   extraction-version: ${vars.scala-version}
   sbt-version: ${vars.sbt-version}
   projects: [
-
-  ${vars.base} {
-    name: "parboiled"
-    uri: "https://github.com/"${vars.parboiled-ref}
-    extra: ${vars.base.extra} {
-      projects: ["parboiled-scala"]
-      // TODO: tests do not compile due to source incompatible change in scalatest
-      // TestNGSuite became a class but was a trait
-      run-tests: false
-    }
-  }
 
   //  TODO: does not compile on java 8
   // ${vars.base} {


### PR DESCRIPTION
(this came up because ConductR has a parboiled dependency) /cc @huntc
