### PR TITLE
run Akka tests

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -567,8 +567,6 @@ build += {
         "akka-actor"  // because we already built it in "akka"
         "akka-bench-jmh"  // we'd have to add a resolver to get the JMH dependency - ST 8/17/15
       ]
-      // TODO wip on this at https://github.com/scala/community-builds/pull/317
-      test-tasks: ["compile"]
       // Scaladoc generation failure reported upstream at https://github.com/akka/akka/issues/21543
       commands: ${vars.default-commands} [
         "set sources in doc in Compile in httpCore := List()"


### PR DESCRIPTION
running the Akka test suite as part of the Scala community build has
been disabled for a long long time now, maybe never was enabled in the
first place?

recently we moved the 2.12 community build to a much newer Akka commit
and we added akka-http and akka-stream, so the time is right: we
should at least try to enable running tests, and if something goes
wrong, at least try to fix it

we can always exclude particular subprojects if needed, if they have
tests that are flaky or very slow or whatever

/cc @patriknw @ktoso
