### PR TITLE
add kxbmap-configs

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -400,6 +400,15 @@ build += {
   }
 
   ${vars.base} {
+    name:   "kxbmap-configs"
+    uri:    "http://github.com/kxbmap/configs.git"
+    extra.exclude: [
+      "docs"  // because we don't have Tut (yet?)
+      "bench" // not really necessary and would pull in a JMH dependency
+    ]
+  }
+
+  ${vars.base} {
     name:   "fs2"
     // current "master" as of Sep 2016
     uri:    "http://github.com/functional-streams-for-scala/fs2.git#series/0.9"


### PR DESCRIPTION
this also permits upgrading scalaprops (master requires scalaz 7.2)

the only other project we had with a direct scalaz dependence was
specs2, and specs2 actually prefers to be on 7.2 these days
(though they also publish a 7.1-based artifact)

fixes #282 
