### PR TITLE
move scalaz from 7.1 to 7.2

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -210,10 +210,10 @@ build += {
   }
 
   ${vars.base} {
-    name: scalaz
-    uri: "https://github.com/scalaz/scalaz.git#series/7.1.x"
-    // [scalaz] [error] Could not run test scalaz.NeedTest: java.lang.AssertionError: false !== true
-    extra.run-tests: false // TODO enable tests
+    name: "scalaz"
+    uri: "https://github.com/scalaz/scalaz.git#series/7.2.x"
+    extra.projects: ["rootJVM"]  // no Scala.js please
+    extra.run-tests: false // TODO needs newer ScalaCheck (1.12 or perhaps 1.13)
   }
 
   ${vars.base} {
@@ -402,10 +402,8 @@ build += {
 
   ${vars.base} {
     name:   "scalaprops"
-    // // master uses FreeT from scalaz 7.2, we're on 7.1
-    uri:    "http://github.com/scalaprops/scalaprops.git#0.1.x"
-    // will be needed if we start tracking master. not needed on 0.1.x branch
-    // extra.projects: ["rootJVM"]  // no Scala.js please
+    uri:    "http://github.com/scalaprops/scalaprops.git"
+    extra.projects: ["rootJVM"]  // no Scala.js please
   }
 
   ${vars.base} {


### PR DESCRIPTION
this also permits upgrading scalaprops (master requires scalaz 7.2)

the only other project we had with a direct scalaz dependence was specs2,
and specs2 actually prefers to be on 7.2 these days
(though they also publish a 7.1-based artifact)
