### PR TITLE
detect "node" vs "nodejs" so Scala.js tests can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/scala/community-builds](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scala/community-builds?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This repository contains configuration files that enable us to build and test
-a corpus of Scala open source projects together using Typesafe's
+a corpus of Scala open source projects together using Lightbend's
 [dbuild](https://github.com/typesafehub/dbuild).
 
 **How big is it?**  It's over a million lines of Scala code, total.

--- a/common.conf
+++ b/common.conf
@@ -14,6 +14,8 @@
 vars: {
   scala-ref                    : "scala/scala.git#2.11.x"
   scala-ref                    : ${?scala_ref}   // allow overriding scala-ref using the scala_ref environment variable
+  node                         : "node"
+  node                         : ${?NODE}
 
   // TODO: merge required changes upstream to get rid of our forks, maintaining our one won't scale
   browse-ref                   : "SethTisue/browse.git#topic/2.11-compat"
@@ -515,11 +517,10 @@ build += {
         "set test in (Build.compiler, Test) := {}"
         // - Disable fatal Scaladoc warnings, also fragile
         "removeScalacOptions -Xfatal-warnings"
-        // - Use Node.js with the executable "nodejs" instead of "node" (environmental in the CI infrastructure)
-        //   We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
+        // - We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
         //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
         //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
-        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := NodeJSEnv(executable = \"nodejs\").value.withSourceMap(false))"
+        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := NodeJSEnv(executable = \""${vars.node}"\").value.withSourceMap(false))"
       ]
     }
   }

--- a/scripts/dbuild-runner.sh
+++ b/scripts/dbuild-runner.sh
@@ -61,6 +61,13 @@ then
   sed -i.bak "s/scalasbt.artifactoryonline.com/repo.scala-sbt.org/g" "dbuild-${DBUILDVERSION}/bin/"*.properties
 fi
 
+# sigh, Ubuntu has nodejs but OS X has node
+if hash nodejs 2>/dev/null; then
+    export NODE=nodejs
+else
+    export NODE=node
+fi
+
 echo "dbuild-${DBUILDVERSION}/bin/dbuild" "${@}" "$DBUILDCONFIG"
 "dbuild-${DBUILDVERSION}/bin/dbuild" "${@}" "$DBUILDCONFIG" 2>&1 | tee "dbuild-${DBUILDVERSION}/dbuild.out"
 STATUS="$?"


### PR DESCRIPTION
Ubuntu has "nodejs". looking at you, Ubuntu.
