### PR TITLE
make Scala library sources available to Scala.js

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -109,6 +109,7 @@ build += {
         name:   scala-library
         system: aether
         uri:   "aether:org.scala-lang#scala-library;"${vars.scala-version}
+        extra.sources: true  // Scala.js wants this
       }
       {
         set-version: ${vars.scala-version}


### PR DESCRIPTION
reference: https://github.com/scala-js/scala-js/pull/2606
