### PR TITLE
add scala-continuations

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -660,4 +660,9 @@ build += {
     extra.projects: ["platformJVM"]
   }
 
+  ${vars.base} {
+    name: "scala-continuations"
+    uri:  ${vars.uris.scala-continuations-uri}
+  }
+
 ]}

--- a/project-refs.conf
+++ b/project-refs.conf
@@ -27,6 +27,7 @@ vars.uris: {
   play2-core-uri:               "https://github.com/playframework/playframework.git"
   sbinary-uri:                  "https://github.com/SethTisue/sbinary.git#community-build-2.12"
   sbt-testng-interface-uri:     "https://github.com/SethTisue/sbt-testng-interface.git#no-bintray"
+  scala-continuations-uri:      "https://github.com/scala/scala-continuations.git"
   scala-java8-compat-uri:       "https://github.com/scala/scala-java8-compat.git"
   scala-js-uri:                 "https://github.com/scala-js/scala-js.git"
   scala-logging-uri:            "https://github.com/typesafehub/scala-logging.git"


### PR DESCRIPTION
this had been in the 2.11 build, but got dropped. but recently
@danslapman took care of making it 2.12 compatible and dbuild friendly
