### PR TITLE
avoid <<= operator, now deprecated in sbt

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -44,7 +44,7 @@ set commands ++= {
     val allDefs = r._1s.toSeq
     val projectScope = Load.projectScope(currentRef)
     val scopes = allDefs.filter(_.key == scalacOptions.key).map(_.scope).distinct
-    val redefined = scopes.map(scope => scalacOptions in scope <<= (scalacOptions in scope).map(fn))
+    val redefined = scopes.map(scope => scalacOptions in scope ~= fn)
     val session = extracted.session.appendRaw(redefined)
     BuiltinCommands.reapply(session, structure, s)
   }


### PR DESCRIPTION
smoothing the way to upgrading the build to sbt 0.13.13 when
it comes out

review by @dwijnand
