### PR TITLE
update cats entry

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -411,17 +411,15 @@ build += {
     ]
   }
 
+  // forked because of https://github.com/typelevel/cats/issues/1396
   ${vars.base} {
     name: "cats"
     uri:  ${vars.uris.cats-uri}
-    // https://github.com/typelevel/cats/issues/1396, https://github.com/typelevel/cats/issues/1377
     // this is only some of Cats. we should try and add more
     extra.projects: ["coreJVM", "macrosJVM"] // no Scala.js please
     extra.commands: ${vars.default-commands} [
       // too fragile
       "removeScalacOptions -Xfatal-warnings"
-      // no longer exists in 2.12
-      "removeScalacOptions -Yinline-warnings"
     ]
   }
 


### PR DESCRIPTION
now that they merged 2.12 support

note that we are still using a fork, because of the POM issue (see
comment). but I did also bring the fork up to date with their current
master

fyi @non @adelbertc
