### PR TITLE
add nyaya et al

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -753,4 +753,10 @@ build += {
     extra.directory: "org.scala-refactoring.library"
   }
 
+  ${vars.base} {
+    name: "nyaya"
+    uri:  ${vars.uris.nyaya-uri}
+    extra.projects: ["testModuleJVM"]  // no Scala.js, no benchmarks
+  }
+
 ]}

--- a/project-refs.conf
+++ b/project-refs.conf
@@ -23,6 +23,7 @@ vars.uris: {
   macro-paradise-uri:           "https://github.com/scalamacros/paradise.git#2.12.1"
   mima-uri:                     "https://github.com/typesafehub/migration-manager.git#scala-2.12"
   monocle-uri:                  "https://github.com/julien-truffaut/Monocle.git"
+  nyaya-uri:                    "https://github.com/japgolly/nyaya.git"
   parboiled-uri:                "https://github.com/sirthias/parboiled.git#community-build-2.12"
   parboiled2-uri:               "https://github.com/sirthias/parboiled2.git#release-2.1"
   play-doc-uri:                 "https://github.com/playframework/play-doc.git#master"


### PR DESCRIPTION
as expected, a test run (https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-community-build/854/consoleFull) fails with:

```
[nyaya:error] java.lang.AssertionError: assertion failed: 
[nyaya:error]   Cannot create ClassBType from non-class symbol type Prop
[nyaya:error]      while compiling: /home/jenkins/workspace/scala-2.12.x-integrate-community-build/target-0.9.5/project-builds/nyaya-28cbf0b1588b601b774ac136cdfe74196f25f395/nyaya-prop/src/test/scala/nyaya/prop/PropTest.scala
[nyaya:error]         during phase: jvm
```

as reported by @japgolly and under discussion at https://github.com/scala/scala-dev/issues/248. so this PR shouldn't be merged until some workaround is in place

fixes #368 
