### PR TITLE
fix regression where zinc failed to extract

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -499,9 +499,6 @@ build += {
   ${vars.base} {
     name:   "zinc"
     uri:    "https://github.com/"${vars.zinc-ref}
-    // with 0.13.9 I got
-    // project/Scriptit.scala:56: method distinctParser in object Defaults cannot be accessed in object sbt.Defaults
-    extra.sbt-version: "0.13.8"
   }
 
   ${vars.base} {


### PR DESCRIPTION
they're officially on sbt 0.13.11 now, so I expect 0.13.13
will work too