### PR TITLE
[nomerge] freeze scala-gopher at last commit that works on JDK 6

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -111,7 +111,8 @@ vars: {
   // Ensime depends on.  and Ensime is the main reason we're adding this at all
   spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git#v1.1.0"
 
-  scala-gopher-ref             : "rssh/scala-gopher.git#community-build"
+  // frozen at this October 2016 commit because more recent commits on master require Java 8
+  scala-gopher-ref             : "rssh/scala-gopher.git#community-build#861934ae29eda56e592f5208962fde053fc7fa7a"
 
   // version settings
   sbt-version                  : "0.13.13"


### PR DESCRIPTION
this is for the 2.11.x branch only; we won't keep the change on
the 2.11.x-jdk8 or 2.12.x branches

fyi @rssh