### PR TITLE
[nomerge] freeze scala-gopher at last ScalaTest 2.x compatible commit

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -117,7 +117,9 @@ vars: {
   // Ensime depends on.  and Ensime is the main reason we're adding this at all
   spray-json-shapeless-ref     : "fommil/spray-json-shapeless.git#v1.1.0"
 
-  scala-gopher-ref             : "rssh/scala-gopher.git#community-build"
+  // freeze at an October 2016 commit; subsequent commits use ScalaTest 3.0, which we don't
+  // have here
+  scala-gopher-ref             : "rssh/scala-gopher.git#861934ae29eda56e592f5208962fde053fc7fa7a"
 
   // version settings
   sbt-version                  : "0.13.13"


### PR DESCRIPTION
this change should not be included in 2.12.x since we're on
ScalaTest 3.0 there

fyi @rssh