### PR TITLE
[nomerge] freeze twitter-util

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -79,7 +79,7 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-  twitter-util-ref             : "twitter/util.git#develop"
+  twitter-util-ref             : "twitter/util.git#302235a473d20735e5327d785e19b0f489b4a59f"  // freeze at November 2016 commit before move to ScalaTest 3.0
   jawn-ref                     : "non/jawn.git"
   mima-ref                     : "typesafehub/migration-manager.git"
   macro-paradise-ref           : "scalamacros/paradise.git#2.11.x"


### PR DESCRIPTION
because they've moved to ScalaTest 3.0, which we only support
in the 2.12.x community build