### PR TITLE
Revert "freeze Akka at 2.4.12 for now"

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -247,8 +247,6 @@ build += {
     extra.test-tasks: ["compile"]
   }
 
-  // For now, we have frozen Akka at 2.4.12, since Play doesn't compile with the latest
-  // changes on master.  https://github.com/scala/community-builds/issues/416
   ${vars.base} {
     name: "akka"
     uri:  ${vars.uris.akka-uri}
@@ -539,8 +537,6 @@ build += {
 
   // this is separate from "akka" because there is a circular dependency between
   // the akka and ssl-config repos
-  // For now, we have frozen Akka at 2.4.12, since Play doesn't compile with the latest
-  // changes on master.  https://github.com/scala/community-builds/issues/416
   ${vars.base} {
     name: "akka-more"
     uri:  ${vars.uris.akka-more-uri}

--- a/project-refs.conf
+++ b/project-refs.conf
@@ -1,8 +1,8 @@
 vars.uris: {
   acyclic-uri:                  "https://github.com/lihaoyi/acyclic.git"
   akka-http-uri:                "https://github.com/akka/akka-http.git#3217cbf417817ca03421439af6aa2587dd418e8c"
-  akka-more-uri:                "https://github.com/akka/akka.git#v2.4.12"
-  akka-uri:                     "https://github.com/akka/akka.git#v2.4.12"
+  akka-more-uri:                "https://github.com/akka/akka.git"
+  akka-uri:                     "https://github.com/akka/akka.git"
   argonaut-uri:                 "https://github.com/argonaut-io/argonaut.git#a84800df9b8e919de741bbae46869d9e6dc783b4"
   async-uri:                    "https://github.com/scala/async.git"
 //  breeze-uri:                   "https://github.com/scalanlp/breeze.git"


### PR DESCRIPTION
This reverts commit db2d3a2160caa0897d74e7082777888838209067.

The necessary change to Play was merged upstream.