### PR TITLE
freeze Jawn

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -80,7 +80,8 @@ vars: {
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
   twitter-util-ref             : "twitter/util.git#302235a473d20735e5327d785e19b0f489b4a59f"  // freeze at November 2016 commit before move to ScalaTest 3.0
-  jawn-ref                     : "non/jawn.git"
+  // freeze before December 2016 commit that requires newer json4s (which we have frozen)
+  jawn-ref                     : "non/jawn.git#8534fafa1d8d6930f1187aa1217b2c309b387017"
   mima-ref                     : "typesafehub/migration-manager.git"
   macro-paradise-ref           : "scalamacros/paradise.git#2.11.9"
   // temporarily frozen at a commit just before the one that introduced the


### PR DESCRIPTION
maybe it wouldn't be hard to unfreeze json4s so we wouldn't have
to freeze Jawn, but I'm choosing not to mess with it in a 2.11 context