### PR TITLE
fork specs2 to have a 2.13 friendly build

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -532,6 +532,8 @@ build += {
 
   // frozen at a November 2016 commit for now because of some weird issue
   // I don't understand yet; see https://github.com/scala/community-builds/pull/428
+  // and forked in December 2016 (fork point 5f35b86b451b0c6f231b514c84c48c39508bf8cf)
+  // to make build 2.13 friendly. we should contribute upstream at unfreeze time
   ${vars.base} {
     name: "specs2"
     uri:  ${vars.uris.specs2-uri}

--- a/project-refs.conf
+++ b/project-refs.conf
@@ -66,7 +66,7 @@ vars.uris: {
   simulacrum-uri:               "https://github.com/mpilquist/simulacrum.git#2a75226fe59055f72fb5fb2f556edba62e37f6d4"
   slick-uri:                    "https://github.com/slick/slick.git"
   sourcecode-uri:               "https://github.com/lihaoyi/sourcecode.git"
-  specs2-uri:                   "https://github.com/etorreborre/specs2.git#5f35b86b451b0c6f231b514c84c48c39508bf8cf"
+  specs2-uri:                   "https://github.com/scalacommunitybuild/specs2.git#community-build-2.13"
 //  spire-uri:                    "https://github.com/non/spire.git"
   spray-json-uri:               "https://github.com/spray/spray-json.git"
   spray-json-shapeless-uri:     "https://github.com/fommil/spray-json-shapeless.git"


### PR DESCRIPTION
just the usual scalaVersion handling junk

already tested locally