### PR TITLE
disable spray-json-shapeless tests

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -573,6 +573,9 @@ build += {
   ${vars.base} {
     name: "spray-json-shapeless"
     uri:  ${vars.uris.spray-json-shapeless-uri}
+    // tests don't compile, starting circa January 2017 -- see
+    // https://github.com/scala/community-builds/issues/475
+    extra.run-tests: false
   }
 
   ${vars.base} {


### PR DESCRIPTION
since they don't compile

work around #475 cc @fommil 