### PR TITLE
remove scalafmt workarounds

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -767,13 +767,6 @@ build += {
   ${vars.base} {
     name: "scala-json-ast"
     uri:  ${vars.uris.scala-json-ast-uri}
-    // but why does scalafmt turn up in libraryDependencies at all?
-    // see https://github.com/olafurpg/scalafmt/issues/485#issuecomment-253601375
-    check-missing: false
-    deps.ignore: [
-      "com.geirsson#scalafmt-cli"
-      "com.geirsson#scalafmt"
-    ]
     // no Scala.js please, and no benchmarks either
     extra.projects: ["scalaJsonASTJVM"]
   }
@@ -853,18 +846,7 @@ build += {
   ${vars.base} {
     name: "akka-sse"
     uri:  ${vars.uris.akka-sse-uri}
-    extra.exclude: ["akka-sse-jmh"]  // no benchmarking stuff plz
-    // disable scalafmt
-    extra.commands: ${vars.default-commands} [
-      "set every scalafmt := {}"
-    ]
-    // but why does scalafmt turn up in libraryDependencies at all?
-    // see https://github.com/olafurpg/scalafmt/issues/485#issuecomment-253601375
-    check-missing: false
-    deps.ignore: [
-      "com.geirsson#scalafmt-cli"
-      "com.geirsson#scalafmt"
-    ]
+    extra.exclude: ["jmh"]  // no benchmarking stuff plz
   }
 
   // this was added because conductr-lib's Play integration depended on it,


### PR DESCRIPTION
latest scalafmt versions are more dbuild-friendly.

scala-json-ast already upgraded scalafmt themselves.

akka-sse was still on an old version.  we are already forking akka-sse,
so I refreshed the fork and added a new commit with the scalafmt upgrade.
I also separately submitted that commit as a PR.  (even if it's accepted,
we'll still need to stay forked, because sbt-bintray.)