### PR TITLE
unfreeze utest

### DIFF
--- a/project-refs.conf
+++ b/project-refs.conf
@@ -96,5 +96,5 @@ vars.uris: {
   twitter-util-uri:             "https://github.com/twitter/util.git#develop"
   unfiltered-uri:               "https://github.com/unfiltered/unfiltered.git#0.9.0"
   upickle-pprint-uri:           "https://github.com/scalacommunitybuild/upickle-pprint.git#community-build-2.12"
-  utest-uri:                    "https://github.com/lihaoyi/utest.git#0.4.3"
+  utest-uri:                    "https://github.com/lihaoyi/utest.git"
 }


### PR DESCRIPTION
(Lukas had frozen it in June 2016, not sure why, presumably some thing
involving utest not having 2.12 support fully in place yet, since
addressed)