### PR TITLE
exclude a flaky scalameta subproject

### DIFF
--- a/community.dbuild
+++ b/community.dbuild
@@ -989,8 +989,12 @@ build += {
     uri:  ${vars.uris.scalameta-uri}
     // else, bintray stuff goes boom
     extra.options: ["-Dsbt.prohibit.publish=true"]
-    // requires scalatex-site which requires Scala.js
-    extra.exclude: ["readme"]
+    extra.exclude: [
+      // requires scalatex-site which requires Scala.js
+      "readme"
+      // test failures it doesn't seem worth investigating; pulls down external source trees
+      "contrib"
+    ]
     // use right version-specific source directories regardless of our weird dbuild Scala version numbers
     extra.commands: [
       "set unmanagedSourceDirectories in (common, Compile) += (baseDirectory in common).value / \"src\" / \"main\" / \"scala-2.12\""


### PR DESCRIPTION
tested locally