### PR TITLE
re-add scala-gopher (to 2.12)

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1088,4 +1088,9 @@ build += {
     uri:  ${vars.uris.twotails-uri}
   }
 
+  ${vars.base} {
+     name: "scala-gopher"
+     uri:  ${vars.uris.scala-gopher-uri}
+  }
+
 ]}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -57,6 +57,7 @@ vars.uris: {
   sbt-testng-uri:               "https://github.com/scalacommunitybuild/sbt-testng.git#community-build-2.12"
   scala-abide-uri:              "https://github.com/scala/scala-abide.git"
   scala-continuations-uri:      "https://github.com/scala/scala-continuations.git"
+  scala-gopher-uri:             "https://github.com/rssh/scala-gopher.git"
   scala-java8-compat-uri:       "https://github.com/scala/scala-java8-compat.git"
   scala-js-uri:                 "https://github.com/scala-js/scala-js.git"
   scala-json-ast-uri:           "https://github.com/mdedetrich/scala-json-ast.git"


### PR DESCRIPTION
it is in the 2.11 build. I couldn't find the commit where it got
dropped here, perhaps it happened inadvertently?