### PR TITLE
Use `new NodeJSEnv` instead of `NodeJSEnv().value` in Scala.js config.

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -525,7 +525,7 @@ build += {
         // - We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
         //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
         //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
-        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := NodeJSEnv(executable = \""${vars.node}"\").value.withSourceMap(false))"
+        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := new org.scalajs.jsenv.nodejs.NodeJSEnv(executable = \""${vars.node}"\").withSourceMap(false))"
       ]
     }
   }


### PR DESCRIPTION
The `sbt.Initialize` "constructor" `NodeJSEnv().value` is deprecated in Scala.js. Instead, we should directly instantiate `new org.scalajs.jsenv.nodejs.NodeJSEnv()`.