### PR TITLE
unfork macro paradise

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -77,7 +77,7 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git#1.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
-  macro-paradise-ref           : "adriaanm/paradise.git#2.11.9"
+  macro-paradise-ref           : "scalamacros/paradise.git#2.11.10"
   // temporarily frozen at a commit just before the one that introduced the
   // use of CrossVersion.patch; see https://github.com/scala/community-builds/issues/384
   macro-compat-ref             : "milessabin/macro-compat.git#2a857e42f48620c34900e421579404d290286a75"


### PR DESCRIPTION
fixes scala/scala-dev#328

this will need manual merging onto the other branches since
paradise uses per-minor-version branch names