### PR TITLE
refresh our scalameta fork

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1128,4 +1128,21 @@ build += {
      extra.test-tasks: ["compile"]
   }
 
+  // adding (April 2017) because scalameta now depends on it
+  ${vars.base} {
+     name: "scalapb"
+     uri:  ${vars.uris.scalapb-uri}
+     // just this one for now, since I'm mainly just trying to get
+     // scalameta working again
+     extra.projects: ["runtimeJVM"]
+  }
+
+  // adding (April 2017) because scalameta depends on it
+  // (indirectly via scalapb)
+  ${vars.base} {
+     name: "scalapb-lenses"
+     uri:  ${vars.uris.scalapb-lenses-uri}
+     extra.projects: ["lensesJVM"]  // no Scala.js plz
+  }
+
 ]}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -76,6 +76,8 @@ vars.uris: {
   scalameta-uri:                "https://github.com/scalacommunitybuild/scalameta.git#community-build-2.12"
   scalameter-uri:               "https://github.com/scalameter/scalameter.git"
   scalamock-uri:                "https://github.com/scalacommunitybuild/ScalaMock.git#community-build-2.12"
+  scalapb-uri:                  "https://github.com/scalapb/ScalaPB.git"
+  scalapb-lenses-uri:           "https://github.com/scalapb/Lenses.git"
   scalaprops-uri:               "https://github.com/scalacommunitybuild/scalaprops.git#community-build-2.12"
   scalariform-uri:              "https://github.com/scala-ide/scalariform.git"
   scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"


### PR DESCRIPTION
I brought communitybuild/scalameta#community-build-2.12 up to date
with scalameta/scalameta#master.  this required some tweaks:

```
* b376803 - sigh (2 hours ago) <Seth Tisue>
* 0835877 - oops (4 hours ago) <Seth Tisue>
* 4557ccb - scalameta fix (4 hours ago) <Seth Tisue>
* c420055 - adapt to refreshed fork of scalameta (22 hours ago) <Seth Tisue>
```

sorry for the dirty history.  the diffs are:

```diff
+    extra.projects: ["scalametaJVM"]  // no Scala.js
...
-      "contrib"
+      "contribJVM"
...
-      "set unmanagedSourceDirectories in (common, Compile) += (baseDirectory in common).value / \"src\" / \"main\" / \"scala-2.12\""
-      "set unmanagedSourceDirectories in (dialects, Compile) += (baseDirectory in dialects).value / \"src\" / \"main\" / \"scala-2.12\""
-      "set unmanagedSourceDirectories in (scalameta, Compile) += (baseDirectory in scalameta).value / \"src\" / \"main\" / \"scala-2.12\""
+      "set unmanagedSourceDirectories in (commonJVM, Compile) += (baseDirectory in commonJVM).value / \"src\" / \"main\" / \"scala-2.12\""
+      "set unmanagedSourceDirectories in (dialectsJVM, Compile) += (baseDirectory in dialectsJVM).value / \"src\" / \"main\" / \"scala-2.12\""
+      "set unmanagedSourceDirectories in (scalametaJVM, Compile) += (baseDirectory in scalametaJVM).value / \"src\" / \"main\" / \"scala-2.12\""
```

and then this PR has the final commits that made it green.
(tested locally)

fyi @xeno-by.  I'll throw in a reminder about dependencies --
fortunately the new dependencies on scalapb and scalapb-lenses were
easy to add, but do please be cautious about multiplying dependencies,
since scalameta is becoming so fundamental to the Scala
ecosystem. currently dbuild's view of the sitation is:

```
[info] Project scalameta
[info]   depends on: acyclic, fastparse, macro-paradise, scala, scala-js,
  scala-parser-combinators, scalacheck, scalapb, scalapb-lenses,
  scalatest, sourcecode, utest
```

it isn't out of hand, but the longer this list grows, the harder
various things get (e.g. releasing for coming 2.13 milestones)