### PR TITLE
disable running scala-gopher tests on 2.11

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -554,6 +554,8 @@ build += {
   ${vars.base} {
      name:  "scala-gopher"
      uri:    "http://github.com/"${vars.scala-gopher-ref}
+     // too many intermittent failures
+     extra.test-tasks: ["compile"]
   }
 
 ]


### PR DESCRIPTION
too many intermittent failures. already disabled on 2.12/2.13
for the same reason