### PR TITLE
use Scala 2.11.11 everywhere

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -182,7 +182,7 @@ build += {
   cross-version: [ disabled, standard ]
   space.from: [ default ]
   space.to: default
-  extraction-version: "2.11.7"
+  extraction-version: "2.11.11"
   sbt-version: ${vars.sbt-version}
 
   projects: [

--- a/community.dbuild
+++ b/community.dbuild
@@ -13,7 +13,7 @@ include file("common.conf")
 // And the generation of the artifacts more closely related to the Scala compiler.
 //
 build += {
-  extraction-version: "2.11.8"
+  extraction-version: "2.11.11"
   cross-version: disabled
   sbt-version: ${vars.sbt-version}
   projects: [
@@ -24,7 +24,7 @@ build += {
     extra.parts: {
       cross-version: standard
       sbt-version: ${vars.sbt-version}
-      extraction-version: "2.11.8"
+      extraction-version: "2.11.11"
       cross-version: disabled
     }
     extra.parts.projects: [
@@ -40,13 +40,13 @@ build += {
       {
         name: "scala-xml"
         uri: "https://github.com/"${vars.scala-xml-ref}
-        extra.commands: "set scalaVersion := \"2.11.8\""
+        extra.commands: "set scalaVersion := \"2.11.11\""
         extra.projects: ["xmlJVM"]
       }
       {
         name: "scala-parser-combinators"
         uri: "https://github.com/"${vars.scala-parser-combinators-ref}
-        extra.commands: "set scalaVersion := \"2.11.8\""
+        extra.commands: "set scalaVersion := \"2.11.11\""
         extra.projects: ["scala-parser-combinatorsJVM"]
       }
     ]


### PR DESCRIPTION
instead of 2.11.8, or one place where we even had 2.11.7 for
some reason