### PR TITLE
Use the new overload of `new NodeJSEnv` with a `NodeJSEnv.Config`.

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -97,9 +97,7 @@ vars: {
 
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  // frozen at April 2017 commit to avoid breaking utest.
-  // reported upstream at https://github.com/lihaoyi/utest/issues/108
-  scala-js-ref                 : "scala-js/scala-js.git#d6e876381a61f58f122fad0232de53a0b499b720"
+  scala-js-ref                 : "scala-js/scala-js.git"
   slick-ref                    : "slick/slick.git#3.1"   // stay here; master wants Java 8
   scalamock-ref                : "paulbutcher/scalamock.git#cf8aa67cf163682cd52cbb4339e118da47703ae3" // stay here; master wants ScalaTest 3.0
   scalariform-ref              : "daniel-trinh/scalariform.git"

--- a/common.conf
+++ b/common.conf
@@ -530,7 +530,7 @@ build += {
         // - We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
         //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
         //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
-        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := new org.scalajs.jsenv.nodejs.NodeJSEnv(executable = \""${vars.node}"\").withSourceMap(false))"
+        "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withExecutable(\""${vars.node}"\").withSourceMap(false)))"
       ]
     }
   }


### PR DESCRIPTION
The constructor with default parameters is deprecated in Scala.js, because it cannot be evolved in binary compatible ways. Instead, we use the one that takes a `NodeJSEnv.Config` parameter, which can be created using an immutable fluent API.