### PR TITLE
upgrade to dbuild 0.9.7

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -718,7 +718,7 @@ build += {
 
   // forked (updated March 2017) because of bintray-sbt errors;
   // see https://github.com/typesafehub/dbuild/issues/158 (fixed in
-  // at least some cases in dbuild 0.9.7-RC1? not in this case)
+  // at least some cases in dbuild 0.9.7? not in this case)
   ${vars.base} {
     name: "scalamock"
     uri:  ${vars.uris.scalamock-uri}

--- a/run.sh
+++ b/run.sh
@@ -131,7 +131,7 @@ fi
 cat $project_refs_conf > .dbuild/project-refs.conf
 
 # Set dbuild version and config file
-DBUILDVERSION=0.9.7-RC1
+DBUILDVERSION=0.9.7
 echo "dbuild version: $DBUILDVERSION"
 
 DBUILDCONFIG=$dbuild_file


### PR DESCRIPTION
test run queued: https://scala-ci.typesafe.com/job/scala-2.12.x-integrate-community-build/1598/consoleFull (404 til Jenkins finishes scratching that really, really hard-to-reach spot, yeah, that one right there, ahh, ahhhh, ahhhhhhhhhhh)

fyi @cunei 