### PR TITLE
unfork ScalaMock

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -717,9 +717,6 @@ build += {
     uri:  ${vars.uris.jawn-fs2-uri}
   }
 
-  // forked (updated March 2017) because of bintray-sbt errors;
-  // see https://github.com/typesafehub/dbuild/issues/158 (fixed in
-  // at least some cases in dbuild 0.9.7? not in this case)
   ${vars.base} {
     name: "scalamock"
     uri:  ${vars.uris.scalamock-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -81,7 +81,7 @@ vars.uris: {
   scalaj-http-uri:              "https://github.com/scalaj/scalaj-http.git"
   scalameta-uri:                "https://github.com/scalacommunitybuild/scalameta.git#community-build-2.12"
   scalameter-uri:               "https://github.com/scalameter/scalameter.git"
-  scalamock-uri:                "https://github.com/scalacommunitybuild/ScalaMock.git#community-build-2.12"
+  scalamock-uri:                "https://github.com/paulbutcher/ScalaMock.git"
   scalapb-lenses-uri:           "https://github.com/scalapb/Lenses.git"
   scalapb-uri:                  "https://github.com/scalapb/ScalaPB.git#268318c"  # was master
   scalaprops-uri:               "https://github.com/scalaprops/scalaprops.git"


### PR DESCRIPTION
the fork is no longer needed now that they publish to sonatype
rather than bintray

fyi @paulbutcher @barkhorn