### PR TITLE
upgrade to dbuild 0.9.9

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -131,7 +131,7 @@ fi
 cat $project_refs_conf > .dbuild/project-refs.conf
 
 # Set dbuild version and config file
-DBUILDVERSION=0.9.7
+DBUILDVERSION=0.9.9
 echo "dbuild version: $DBUILDVERSION"
 
 DBUILDCONFIG=$dbuild_file


### PR DESCRIPTION
once this is merged, I should remember to merge it forward onto 2.13.x and then delete all the 0.9.7 cache directories, or we'll run out of disk space