### PR TITLE
add sbt-io back to the 2.13 build

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -923,4 +923,12 @@ build += {
     extra.exclude: ["benchmark"]
   }
 
+  ${vars.base} {
+    name: "sbt-io"
+    uri:  ${vars.uris.sbt-io-uri}
+    extra.sbt-version: "1.0.2"
+    extra.commands: []  // default commands don't work with sbt 1.0
+    extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
+  }
+
 ]}


### PR DESCRIPTION
Dale says this is the only module they've added 2.13 support
yet