### PR TITLE
add scalachess

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1331,4 +1331,19 @@ build += {
     extra.projects: ["core", "numbers"]
   }
 
+  // dependency of scalachess
+  ${vars.base} {
+    name: "scalalib"
+    uri:  ${vars.uris.scalalib-uri}
+    extra.sbt-version: "1.0.3"
+    extra.commands: []  // default commands don't work with sbt 1.0
+  }
+
+  ${vars.base} {
+    name: "scalachess"
+    uri:  ${vars.uris.scalachess-uri}
+    extra.sbt-version: "1.0.3"
+    extra.commands: []  // default commands don't work with sbt 1.0
+  }
+
 ]}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -87,6 +87,8 @@ vars.uris: {
   scalacheck-uri:               "https://github.com/rickynils/scalacheck.git#9b71bb3dfe186c03292faa59976487af2ee23caa"
   scalafix-uri:                 "https://github.com/scalacommunitybuild/scalafix.git#community-build-2.12"
   scalaj-http-uri:              "https://github.com/scalaj/scalaj-http.git"
+  scalachess-uri:               "https://github.com/ornicar/scalachess.git"
+  scalalib-uri:                 "https://github.com/ornicar/scalalib.git"
   scalameta-uri:                "https://github.com/scalacommunitybuild/scalameta.git#community-build-2.12"
   scalameter-uri:               "https://github.com/scalameter/scalameter.git"
   scalamock-uri:                "https://github.com/paulbutcher/ScalaMock.git"


### PR DESCRIPTION
no special reason, just thought it would be neat to have (it's part of
Lichess)

Project scalachess
  depends on: kind-projector, macro-compat, macro-paradise, pcplod, scala, scala-parser-combinators, scalacheck, scalalib, scalatest, scalaz, shapeless, specs2