### PR TITLE
use cloc to count lines of code compiled

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -80,6 +80,11 @@ set commands ++= {
 vars.default-commands += "appendScalacOptions "${vars.scalac-opts}
 vars.base.extra.commands = ${vars.default-commands}
 
+//// count lines of code
+
+vars.base.extra.settings = ["""libraryDependencies in ThisBuild += compilerPlugin("com.lightbend" %% "cloc-plugin" % "0")"""]
+vars.base.deps.inject: ["com.lightbend#cloc-plugin"]
+
 //// cache
 
 // we don't have enough disk space to keep stuff longer
@@ -104,6 +109,10 @@ build += {
   space: scala
 
   projects: [
+  {
+    name: "cloc-plugin"
+    uri:  "https://github.com/SethTisue/cloc-plugin.git"
+  }
   {
     name:  "scala"
     system: assemble
@@ -382,13 +391,15 @@ build += {
   ${vars.base} {
     name: "slick"
     uri:  ${vars.uris.slick-uri}
-    // without this dbuild doesn't pick up that one of the subprojects has this dependency.
-    // it doesn't even make sense; it seems to me that testNGSettings should not be adding
-    // a dependency of the plugin to the libraryDependencies of the test code.
-    // the line in question is:
-    //   https://github.com/sbt/sbt-testng-interface/blob/ca730f705f48af2139f39bc726b474afec072738/plugin/src/main/scala/de/johoop/testngplugin/TestNGPlugin.scala#L44
-    // I think it's a confusion of levels, but maybe I'm missing something. - ST 8/27/15
-    deps.inject: ["de.johoop#sbt-testng-interface"]
+    deps.inject: ${vars.base.deps.inject} [
+      // without this dbuild doesn't pick up that one of the subprojects has this dependency.
+      // it doesn't even make sense; it seems to me that testNGSettings should not be adding
+      // a dependency of the plugin to the libraryDependencies of the test code.
+      // the line in question is:
+      //   https://github.com/sbt/sbt-testng-interface/blob/ca730f705f48af2139f39bc726b474afec072738/plugin/src/main/scala/de/johoop/testngplugin/TestNGPlugin.scala#L44
+      // I think it's a confusion of levels, but maybe I'm missing something. - ST 8/27/15
+      "de.johoop#sbt-testng-interface"
+    ]
     extra.exclude: [
       // unless we exclude, it looks for an Ornate dependency here
       "root"
@@ -407,14 +418,16 @@ build += {
     ]
   }
 
+  // forked (November 2017, at a September 2017 commit) to remove
+  // fmpp from the build, since it calls `update` during dependency
+  // extraction, so then cloc-plugin isn't found and it fails.
+  // and also to downgrade sbt-houserules for the same reason
   ${vars.base} {
     name: "sbinary"
     uri:  ${vars.uris.sbinary-uri}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
-    extra.commands: ${vars.default-commands} [
-      "set every scalafmtOnCompile := false"
-    ]
-    check-missing: false  // ignore missing scalafmt
+    // compiling examples would require fmpp
+    extra.projects: ["core"]
   }
 
   ${vars.base} {
@@ -805,7 +818,7 @@ build += {
       // this one is unmaintained and doesn't support Scala 2.12...
       "com.decodified#scala-ssh"
     ]
-    deps.inject: [
+    deps.inject: ${vars.base.deps.inject} [
       // ...but this one does
       "com.veact#scala-ssh"
     ]
@@ -1443,8 +1456,10 @@ build += {
   ${vars.base} {
     name: "pureconfig"
     uri:  ${vars.uris.pureconfig-uri}
-    // I guess dbuild is getting confused by the extra _1.13
-    deps.inject: ["com.github.alexarchambault#scalacheck-shapeless_1.13"]
+    deps.inject: ${vars.base.deps.inject} [
+      // I guess dbuild is getting confused by the extra _1.13
+      "com.github.alexarchambault#scalacheck-shapeless_1.13"
+    ]
     check-missing: false
     extra.commands: ${vars.default-commands} [
       // not sure why we get these errors unless we turn them off

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -70,7 +70,7 @@ vars.uris: {
   play-ws-uri:                  "https://github.com/playframework/play-ws.git"
   pprint-uri:                   "https://github.com/lihaoyi/pprint.git"
   pureconfig-uri:               "https://github.com/scalacommunitybuild/pureconfig.git#community-build-2.12"  # was pureconfig, master
-  sbinary-uri:                  "https://github.com/sbt/sbinary.git"
+  sbinary-uri:                  "https://github.com/scalacommunitybuild/sbinary.git#community-build-2.12"  # was sbt, master
   sbt-io-uri:                   "https://github.com/sbt/io.git#v1.0.0"
   sbt-librarymanagement-uri:    "https://github.com/sbt/librarymanagement.git#v1.0.0"
   sbt-testng-uri:               "https://github.com/sbt/sbt-testng.git"

--- a/run.sh
+++ b/run.sh
@@ -185,4 +185,6 @@ echo "dbuild-${DBUILDVERSION}/bin/dbuild"  "$dbuild_args" "$DBUILDCONFIG" "${@}"
 ("dbuild-${DBUILDVERSION}/bin/dbuild"  "$dbuild_args" "$DBUILDCONFIG" "${@}" 2>&1 | tee "dbuild-${DBUILDVERSION}/dbuild.out") || STATUS="$?"
 BUILD_ID="$(grep '^\[info\]  uuid = ' "dbuild-${DBUILDVERSION}/dbuild.out" | sed -e 's/\[info\]  uuid = //')"
 echo "The repeatable UUID of this build was: ${BUILD_ID}"
+echo -n "Total lines of Scala code recompiled during this run: "
+grep -F '** COMMUNITY BUILD ' dbuild-${DBUILDVERSION}/dbuild.out | cut -d: -f2 | paste -sd+ -| bc
 exit $STATUS


### PR DESCRIPTION
fixes #59

fork sbinary because there were two different ways it was calling
`update` during dependency extraction, which fails since cloc-plugin
isn't published anywhere