### PR TITLE
Unfork circe

### DIFF
--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -24,7 +24,7 @@ vars.uris: {
   catalysts-uri:                "https://github.com/typelevel/catalysts.git"
   cats-uri:                     "https://github.com/typelevel/cats.git#4d9d333c"  # was master
   cats-effect-uri:              "https://github.com/typelevel/cats-effect.git#542290e22"  # was master
-  circe-uri:                    "https://github.com/scalacommunitybuild/circe.git#community-build-2.12"  # was master
+  circe-uri:                    "https://github.com/circe/circe.git"
   circe-config-uri:             "https://github.com/circe/circe-config.git"
   conductr-lib-uri:             "https://github.com/typesafehub/conductr-lib.git"
   coursier-uri:                 "https://github.com/coursier/coursier.git"


### PR DESCRIPTION
No longer need to use the fork with coursier removed (#629) or sbt-microsite upgraded (47deg/sbt-microsites#248 + circe/circe#803).