### PR TITLE
build ScalaTest tests separately (and actually run them)

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -208,16 +208,30 @@ build += {
     ]
   }
 
+  // see also scalatest-tests
   ${vars.base} {
     name: "scalatest"
     uri:  ${vars.uris.scalatest-uri}
+    extra.projects: ["scalatest", "scalactic"]
+  }
+
+  // this is almost 1M lines of code, but it needn't be green (or be compiled at all)
+  // for dependent projects to proceed, so let's keep it separate.  forked (December 2017)
+  // because of trouble with scalacticMacro -- the latter has publishing disabled
+  ${vars.base} {
+    name: "scalatest-tests"
+    uri:  ${vars.uris.scalatest-uri}
     extra.exclude: [
+      // we already built these above
+      "scalatest", "scalactic", "scalacticMacro"
       // no Scala.js plz
       "commonTestJS", "examplesJS", "scalacticJS", "scalacticMacroJS", "scalacticTestJS"
       "scalatestAppJS", "scalatestJS", "scalatestTestJS"
+      // [scalatest-tests] [info] *** 5 SUITES ABORTED ***
+      // [scalatest-tests] [info] *** 29 TESTS FAILED ***
+      "examples"
     ]
-    extra.test-tasks: ["compile"] // TODO run tests -- need to exclude browser-based tests somehow
-    // scalatest-test project won't compile without extra heap
+    // needs extra heap to even compile
     extra.options: ["-Xmx3072m"]
   }
 

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -117,7 +117,7 @@ vars.uris: {
   scalariform-uri:              "https://github.com/scala-ide/scalariform.git"
   scalastyle-uri:               "https://github.com/scalastyle/scalastyle.git"
   scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"
-  scalatest-uri:                "https://github.com/scalatest/scalatest.git#3.0.x"
+  scalatest-uri:                "https://github.com/scalacommunitybuild/scalatest.git#community-build-2.12"  # was scalatest, 3.0.x
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"
   scalaz-uri:                   "https://github.com/scalaz/scalaz.git#series/7.2.x"
   scalikejdbc-uri:              "https://github.com/scalikejdbc/scalikejdbc.git"


### PR DESCRIPTION
followup to #652. I would have done it this way earlier, if the idea had occurred to me.

prompted because in the 2.13 build I noticed that the main projects compile okay but the tests fail to compile. we don't want all downstream projects blocked when that occurs