### PR TITLE
Use updated SBT for paradox and scalameter

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -872,6 +872,7 @@ build += {
   ${vars.base} {
     name: "scalameter"
     uri:  ${vars.uris.scalameter-uri}
+    extra.sbt-version: ${vars.sbt-version}
     check-missing: false
     deps.ignore: [
       // doesn't support 2.12 (yet?)
@@ -1334,6 +1335,7 @@ build += {
   ${vars.base} {
     name: "paradox"
     uri:  ${vars.uris.paradox-uri}
+    extra.sbt-version: ${vars.sbt-version}
     extra.exclude: ["plugin", "themePlugin", "genericTheme"]
   }
 


### PR DESCRIPTION
To avoid:

```
[paradox] [info] 'compiler-interface' not yet compiled for Scala 2.10.6. Compiling...
[paradox:error] error: error while loading package, Missing dependency 'object java.lang.Object in compiler mirror', required by /home/jenkins/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar(scala/package.class)
[paradox:error] error: error while loading package, Missing dependency 'object java.lang.Object in compiler mirror', required by /home/jenkins/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar(scala/runtime/package.class)
[paradox:error] error: scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
[paradox:error]     at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:16)
[paradox:error]     at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:17)
[paradox:error]     at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:48)
[paradox:error]     at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:40)
```