### PR TITLE
Add typelevel/mouse to build

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -658,6 +658,7 @@ build += {
   ${vars.base} {
     name: "mouse"
     uri:  ${vars.uris.mouse-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["crossJVM"]  // no Scala.js please
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -651,6 +651,12 @@ build += {
     extra.exclude: ["sbtplugin"]
   }
 
+  ${vars.base} {
+    name: "mouse"
+    uri:  ${vars.uris.mouse-uri}
+    extra.projects: ["crossJVM"]  // no Scala.js please
+  }
+
   // forked (January 2018) to remove a couple of failing tests; ticket
   // is https://github.com/etorreborre/specs2/issues/622. note we are
   // using the 3.x branch, even though specs2 4.0 has been out for a while

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -69,6 +69,7 @@ vars.uris: {
   minitest-uri:                 "https://github.com/monix/minitest.git"
   monix-uri:                    "https://github.com/monix/monix.git#9cfa69406"  # was master
   monocle-uri:                  "https://github.com/julien-truffaut/Monocle.git"
+  mouse-uri:                    "https://github.com/typelevel/mouse.git"
   nscala-time-uri:              "https://github.com/nscala-time/nscala-time.git"
   nyaya-uri:                    "https://github.com/japgolly/nyaya.git"
   paiges-uri:                   "https://github.com/typelevel/paiges.git"


### PR DESCRIPTION
Full disclosure: after a week of (re-)trying I havent been able to get the build to run green locally on my laptop at home. Problem seems to be that after 1-3 hours of running transient glitches in my home internet cause the build to fail, eg `fatal: unable to access 'https://github.com/sksamuel/exts.git/': Could not resolve host: github.com`

A quicker "sanity check" build would be useful for checking PRs