### PR TITLE
upgrade to dbuild 0.9.12

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -137,7 +137,7 @@ fi
 cat $project_refs_conf > .dbuild/project-refs.conf
 
 # Set dbuild version and config file
-DBUILDVERSION=0.9.11
+DBUILDVERSION=0.9.12
 echo "dbuild version: $DBUILDVERSION"
 
 DBUILDCONFIG=$dbuild_file


### PR DESCRIPTION
fixes #716 

test runs:
* ~~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/2805/ (queued; 404 for now)~~
* https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/2810/ ~~(queued; 404 for now)~~