### PR TITLE
unfreeze ScalaCheck

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -659,6 +659,8 @@ build += {
     // recommended at https://github.com/twitter/util/issues/173:
     // "We use that when we don't think the tests will be reliable in a ci environment"
     extra.options: ["-DSKIP_FLAKY=true"]
+    // awaiting fix for https://github.com/twitter/util/issues/214
+    extra.run-tests: false
   }
 
   ${vars.base} {
@@ -861,6 +863,8 @@ build += {
     extra.commands: ${vars.default-commands} [
       "set unmanagedSourceDirectories in (argonautJVM, Compile) += baseDirectory.value / \"argonaut\" / \"shared\" / \"src\" / \"main\" / \"scala-2.12\""
     ]
+    // waiting for a fix on https://github.com/argonaut-io/argonaut/issues/298
+    extra.run-tests: false
   }
 
   ${vars.base} {

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -227,9 +227,6 @@ build += {
     ]
   }
 
-  // frozen (June 2017) at an April 2017 commit; newer commits
-  // broke the scalacheck subproject of specs2.  see
-  // https://github.com/scala/community-builds/issues/712
   ${vars.base} {
     name: "scalacheck"
     uri:  ${vars.uris.scalacheck-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -115,7 +115,7 @@ vars.uris: {
   scala-stm-uri:                "https://github.com/nbronson/scala-stm.git"
   scala-swing-uri:              "https://github.com/scala/scala-swing.git#2.0.x"
   scala-xml-quote-uri:          "https://github.com/allanrenucci/scala-xml-quote.git#bintray"
-  scalacheck-uri:               "https://github.com/rickynils/scalacheck.git#9b71bb3dfe186c03292faa59976487af2ee23caa"
+  scalacheck-uri:               "https://github.com/rickynils/scalacheck.git"
   scalacheck-shapeless-uri:     "https://github.com/alexarchambault/scalacheck-shapeless.git"
   scalafix-uri:                 "https://github.com/scalacommunitybuild/scalafix.git#community-build-2.12"
   scalafmt-uri:                 "https://github.com/scalacommunitybuild/scalafmt.git#community-build-2.12"


### PR DESCRIPTION
fixes #712

cc @ashawley @rickynils

test runs:
* ~~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/2806/ (queued; 404 for now)~~
* https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/2808/ ~~(queued; 404 for now)~~