### PR TITLE
add silencer, pascal, and scalaz 8

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1548,6 +1548,27 @@ build += {
     extra.projects: ["coreJVM", "examplesJVM", "tests"]
   }
 
+  ${vars.base} {
+    name: "silencer"
+    uri:  ${vars.uris.silencer-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
+  }
+
+  ${vars.base} {
+    name: "pascal"
+    uri:  ${vars.uris.pascal-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
+  }
+
+  // doesn't publish any of the same artifacts as scalaz 7, so it doesn't need
+  // to be confined to its own space
+  ${vars.base} {
+    name: "scalaz8"
+    uri:  ${vars.uris.scalaz8-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
+    extra.projects: ["baseJVM", "effectJVM", "metaJVM"]
+  }
+
 ]}
 
 //// space: jawn_0_10

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -79,6 +79,7 @@ vars.uris: {
   paradox-uri:                  "https://github.com/scalacommunitybuild/paradox.git#community-build-2.12"  # was lightbend, master
   parboiled-uri:                "https://github.com/sirthias/parboiled.git#community-build-2.12"
   parboiled2-uri:               "https://github.com/sirthias/parboiled2.git#release-2.1"
+  pascal-uri:                   "https://github.com/TomasMikula/pascal.git"
   pcplod-uri:                   "https://github.com/ensime/pcplod.git"
   play-core-uri:                "https://github.com/playframework/playframework.git"
   play-doc-uri:                 "https://github.com/playframework/play-doc.git"
@@ -136,6 +137,7 @@ vars.uris: {
   scalatest-uri:                "https://github.com/scalacommunitybuild/scalatest.git#community-build-2.12"  # was scalatest, 3.0.x
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"
   scalaz-uri:                   "https://github.com/scalaz/scalaz.git#series/7.2.x"
+  scalaz8-uri:                  "https://github.com/scalaz/scalaz.git#series/8.0.x"
   scalikejdbc-uri:              "https://github.com/scalikejdbc/scalikejdbc.git"
   scallop-uri:                  "https://github.com/scallop/scallop.git#develop"
   scapegoat-uri:                "https://github.com/scalacommunitybuild/scapegoat.git#community-build-2.12"  # was sksamuel, master
@@ -145,6 +147,7 @@ vars.uris: {
   scoverage-uri:                "https://github.com/scoverage/scalac-scoverage-plugin.git"
   semanticdb-sbt-uri:           "https://github.com/scalacommunitybuild/semanticdb-sbt.git#community-build-2.12"
   shapeless-uri:                "https://github.com/milessabin/shapeless.git"
+  silencer-uri:                 "https://github.com/ghik/silencer.git"
   simulacrum-uri:               "https://github.com/mpilquist/simulacrum.git"
   singleton-ops-uri:            "https://github.com/fthomas/singleton-ops.git"
   sjson-new-uri:                "https://github.com/eed3si9n/sjson-new.git"


### PR DESCRIPTION
easy adds with few relatively few dependencies. (well, scalaz 8's list isn't that short, but they're pretty de-facto-standard stuff)

```
[info] Project scalaz8
[info]   depends on: cloc-plugin, kind-projector, macro-compat, macro-paradise, scala, scala-js-stubs, scala-parser-combinators, scalacheck, scalatest, shapeless, silencer, specs2
[info] Project silencer
[info]   depends on: cloc-plugin, scala, scalacheck, scalatest
[info] Project pascal
[info]   depends on: cloc-plugin, kind-projector, scala, scalacheck, scalatest
```

already green in local testing. fyi @xuwei-k