### PR TITLE
unfreeze akka and akka-http

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -324,9 +324,6 @@ build += {
     ]
   }
 
-  // frozen (affecting both akka-actor and akka-more) February 2018 at a February
-  // 2018 commit before a test regressed; reported upstream at
-  // https://github.com/akka/akka/pull/24484#issuecomment-369072274
   ${vars.base} {
     name: "akka-actor"
     uri:  ${vars.uris.akka-uri}
@@ -435,9 +432,6 @@ build += {
     ]
   }
 
-  // frozen (December 2017) at December 2017 commit before akka-actor and akka-stream
-  // dependencies were declared as "provided".  that means every downstream project
-  // needs updating. for now let's just freeze
   ${vars.base} {
     name: "akka-http"
     uri:  ${vars.uris.akka-http-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -4,9 +4,9 @@
 
 vars.uris: {
   acyclic-uri:                  "https://github.com/lihaoyi/acyclic.git"
-  akka-uri:                     "https://github.com/akka/akka.git#c15c22622e"  # was master
+  akka-uri:                     "https://github.com/akka/akka.git"
   akka-contrib-extra-uri:       "https://github.com/typesafehub/akka-contrib-extra.git"
-  akka-http-uri:                "https://github.com/akka/akka-http.git#bc849bb03"  # was master
+  akka-http-uri:                "https://github.com/akka/akka-http.git"
   akka-http-cors-uri:           "https://github.com/lomigmegard/akka-http-cors.git"
   akka-http-json-uri:           "https://github.com/hseeberger/akka-http-json.git"
   akka-http-session-uri:        "https://github.com/softwaremill/akka-http-session.git"


### PR DESCRIPTION
two motivations:

* akka-http master has an sbt-api-mappings version bump needed over at https://github.com/scala/community-builds/issues/609
* it's just generally been a while and we don't want to fall too far out of date

possible danger: https://github.com/akka/akka/pull/24484