### PR TITLE
drop scala-debugger

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1292,7 +1292,9 @@ build += {
   }
 
   // dependency of scala-debugger. we track the develop branch, since
-  // master seems neglected/outdated
+  // master seems neglected/outdated.
+  // note that scala-debugger has been pulled from the build (perhaps
+  // not permanently), so if this causes trouble, we might drop it too.
   ${vars.base} {
     name: "scallop"
     uri:  ${vars.uris.scallop-uri}
@@ -1779,21 +1781,6 @@ build += {
       // reported upstream: https://github.com/lihaoyi/Ammonite/issues/743
       "set executeTests in amm in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
     ]
-  }
-
-  // depends on ammonite
-  ${vars.base} {
-    name: "scala-debugger"
-    uri:  ${vars.uris.scala-debugger-uri}
-    extra.exclude: [
-      // no sbt plugins plz!
-      "sbtScalaDebuggerPlugin"
-      // Missing dependency: the library org.senkbeil#grus-layouts
-      "scalaDebuggerDocs"
-    ]
-    // java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: GC overhead limit exceeded
-    // perhaps only the -Xmx is really necessary, but let's try it with all of the repo's own .jvmopts:
-    extra.options: ["-Xms1g", "-Xmx4g", "-Xss2m", "-XX:MaxMetaspaceSize=256m"]
   }
 
 ]}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -104,7 +104,6 @@ vars.uris: {
   scala-collection-compat-uri:  "https://github.com/scala/scala-collection-compat.git"
   scala-collections-laws-uri:   "https://github.com/Ichoran/scala-collections-laws.git#upgrade-to-2.12.2"
   scala-continuations-uri:      "https://github.com/scala/scala-continuations.git"
-  scala-debugger-uri:           "https://github.com/ensime/scala-debugger.git"
   scala-gopher-uri:             "https://github.com/rssh/scala-gopher.git"
   scala-java8-compat-uri:       "https://github.com/scala/scala-java8-compat.git"
   scala-js-stubs-uri:           "https://github.com/scala-js/scala-js.git#313da6a532"


### PR DESCRIPTION
because its build definition doesn't compile on JDK 9, and we don't want
to maintain separate JDK 8 and 9 config files

reference: https://github.com/scala/community-builds/issues/609