### PR TITLE
unfreeze play-ws

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -797,8 +797,6 @@ build += {
     extra.projects: ["play-jsonJVM"]  // no Scala.js plz
   }
 
-  // frozen (April 2018) at a February 2018 commit before a change
-  // broke play-core; see #704
   ${vars.base} {
     name: "play-ws"
     uri:  ${vars.uris.play-ws-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -90,7 +90,7 @@ vars.uris: {
   play-doc-uri:                 "https://github.com/playframework/play-doc.git"
   play-json-uri:                "https://github.com/playframework/play-json.git"
   play-webgoat-uri:             "https://github.com/playframework/play-webgoat.git"
-  play-ws-uri:                  "https://github.com/playframework/play-ws.git#78fa8126d36a"  # was master
+  play-ws-uri:                  "https://github.com/playframework/play-ws.git"
   pprint-uri:                   "https://github.com/lihaoyi/pprint.git"
   pureconfig-uri:               "https://github.com/scalacommunitybuild/pureconfig.git#community-build-2.12"  # was pureconfig, master
   refined-uri:                  "https://github.com/fthomas/refined.git"


### PR DESCRIPTION
prompted by it starting to fail with a missing joda-time dependency

previously: #564 