### PR TITLE
adjust Lagom tests

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1416,12 +1416,18 @@ build += {
     uri:  ${vars.uris.lagom-uri}
     // these pull in a number of dependent projects
     extra.projects: ["server", "testkit-scaladsl"]
-    // we got some test failures here. this is the only way I know to disable
-    // tests being run for particular projects only
+    extra.options: [
+      // hopefully avoid intermittent OutOfMemoryErrors with default heap
+      "-Xmx2g"
+    ]
     extra.commands: ${vars.default-commands} [
-      "set executeTests in `server-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-      "set executeTests in `testkit-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      // tests in these subprojects are too slow and (more importantly) too fragile
       "set executeTests in `persistence-cassandra-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      "set executeTests in `testkit-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      // https://github.com/lagom/lagom/issues/1413
+      "set excludeFilter in (Test, unmanagedSources) in `persistence-cassandra-core` := HiddenFileFilter || \"ServiceLocatorSessionProviderSpec.scala\""
+      // more flaky tests I haven't reported upstream
+      "set excludeFilter in (Test, unmanagedSources) in `server-scaladsl` := HiddenFileFilter || \"LagomApplicationSpec.scala\""
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -851,8 +851,6 @@ build += {
       "set sources in (PlayProject, Compile, compile) := (sources in (PlayProject, Compile, compile)).value.distinct"
       // there was some Scaladoc error here I didn't bother to look into
       "set sources in doc in Compile in PlayProject := List()"
-      // https://github.com/scala/community-builds/pull/728
-      "set executeTests in PlayAhcWsProject in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
     ]
   }
 


### PR DESCRIPTION
there is a new recurring failure we need to address

but also, now that I know how to exclude failing tests per-source-file rather than the coarser per-subproject, let's re-enable tests in the subprojects we'd excluded and see what fails