### PR TITLE
unfreeze discipline. use master instead of v0.7

### DIFF
--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -34,7 +34,7 @@ vars.uris: {
   conductr-lib-uri:             "https://github.com/typesafehub/conductr-lib.git"
   coursier-uri:                 "https://github.com/coursier/coursier.git#4177b0adc70a"  # was master
   curryhoward-uri:              "https://github.com/Chymyst/curryhoward.git"
-  discipline-uri:               "https://github.com/typelevel/discipline.git#v0.7"
+  discipline-uri:               "https://github.com/typelevel/discipline.git"
   dispatch-uri:                 "https://github.com/dispatch/reboot.git#0.14.x"
   doodle-uri:                   "https://github.com/underscoreio/doodle.git#develop"
   eff-uri:                      "https://github.com/atnos-org/eff.git"


### PR DESCRIPTION
master branch support Scala 2.13.0-M4
https://github.com/typelevel/discipline/commit/c4b31ece727bb962187257a0e00b14a8a6bb757c