### PR TITLE
freeze jackson-module-scala (to fix scalameter tests)

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -945,6 +945,11 @@ build += {
     extra.test-tasks: "compile"
   }
 
+  // frozen (July 2018) at a February 2017 commit, because there were
+  // scalameter test failures when we used master.  (whether going all the
+  // way back to February 2017 is actually necessary, I don't know; I
+  // just used the last green commit, which happens to be old because
+  // we had the project frozen already for a long time)
   ${vars.base} {
     name: "jackson-module-scala"
     uri:  ${vars.uris.jackson-module-scala-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -54,7 +54,7 @@ vars.uris: {
   http4s-parboiled2-uri:        "https://github.com/http4s/parboiled2.git"
   http4s-uri:                   "https://github.com/http4s/http4s.git#d803035b56d"
   http4s-websocket-uri:         "https://github.com/http4s/http4s-websocket.git"
-  jackson-module-scala-uri:     "https://github.com/FasterXML/jackson-module-scala.git"
+  jackson-module-scala-uri:     "https://github.com/FasterXML/jackson-module-scala.git#abacab34f06"  # was master
   jawn-0-10-uri:                "https://github.com/scalacommunitybuild/jawn.git#community-build-2.12-0.10"  # was non, v0.10.4
   jawn-0-11-uri:                "https://github.com/scalacommunitybuild/jawn.git#community-build-2.12-0.11"  # was non, v0.11.1
   jawn-fs2-uri:                 "https://github.com/rossabaker/jawn-fs2.git#v0.12.2"  # was master


### PR DESCRIPTION
I've already verified in a local test that this makes scalameter green again (here's an [example of the failure](https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/3096/) we were getting), but I have a feeling some other downstream project is going to break, we'll need a test run to find out. (if that's what happens, we'll disable the scalameter tests and ask @axel22 if he can move scalameter to a newer jackson-module-scala version.)

previously: #730