### PR TITLE
separate akka-stream from akka-more

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -476,6 +476,26 @@ build += {
     ]
   }
 
+  ${vars.base} {
+    name: "akka-stream"
+    uri:  ${vars.uris.akka-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
+    extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"
+      // repo readme recommended
+      "-Xmx2g"
+    ]
+    extra.projects: ["akka-stream", "streamTests"]
+    extra.commands: ${vars.default-commands} [
+      // https://github.com/scala/community-builds/issues/373
+      "set every apiURL := None"
+      // UnfoldResourceSourceSpec kept failing. I should report upstream if it persists after next unfreeze
+      "set executeTests in streamTests in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    ]
+    extra.exclude: [
+      "akka-actor"  // because we already built it in "akka"
+    ]
+  }
+
   // this is separate from "akka-actor" because there is a circular dependency between
   // the akka and ssl-config repos
   ${vars.base} {
@@ -490,12 +510,11 @@ build += {
     extra.commands: ${vars.default-commands} [
       // https://github.com/scala/community-builds/issues/373
       "set every apiURL := None"
-      // UnfoldResourceSourceSpec kept failing. I should report upstream if it persists after next unfreeze
-      "set executeTests in streamTests in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
     ]
     extra.exclude: [
       "akka-docs"   // this is Sphinx stuff, not really apropos here, no Sphinx on Jenkins anyway
       "akka-actor"  // because we already built it in "akka"
+      "akka-stream", "akka-stream-testkit", "akka-remote"  // because we already built them in "akka-stream"
       "akka-bench-jmh"  // we'd have to add a resolver to get the JMH dependency, and we prefer not to run benchmarks here anyway
     ]
   }

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -392,10 +392,12 @@ build += {
     uri:  ${vars.uris.akka-uri}
     extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"]
-    extra.projects: ["akka-actor", "akka-actor-typed"]
+    extra.projects: ["akka-actor", "akka-actor-typed", "akka-testkit", "akka-actor-tests"]
     extra.commands: ${vars.default-commands} [
       // https://github.com/scala/community-builds/issues/373
       "set every apiURL := None"
+      // needed downstream in akka-stream and/or akka-more
+      "set skip in publish in actorTests := false"
     ]
   }
 
@@ -498,7 +500,8 @@ build += {
       "set every publishMavenStyle := false"
     ]
     extra.exclude: [
-      "akka-actor", "akka-actor-typed"  // because we already built them in "akka-actor"
+      // because we already built them in "akka-actor"
+      "akka-actor", "akka-actor-typed", "akka-testkit", "akka-actor-tests"
     ]
   }
 
@@ -519,10 +522,10 @@ build += {
     ]
     extra.exclude: [
       "akka-docs"   // this is Sphinx stuff, not really apropos here, no Sphinx on Jenkins anyway
-      "akka-actor", "akka-actor-typed"  // because we already built them in "akka-actor"
+      "akka-actor", "akka-actor-typed", "akka-actor-tests", "akka-testkit"  // because we already built them in "akka-actor"
       "akka-stream", "akka-stream-testkit", "akka-remote"  // because we already built them in "akka-stream"
       "akka-bench-jmh"  // we'd have to add a resolver to get the JMH dependency, and we prefer not to run benchmarks here anyway
-      "akka-testkit", "akka-protobuf", "akka-multi-node-testkit"  // already built these in akka-stream
+      "akka-protobuf", "akka-multi-node-testkit"  // already built these in akka-stream
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -398,6 +398,8 @@ build += {
       "set every apiURL := None"
       // needed downstream in akka-stream and/or akka-more
       "set skip in publish in actorTests := false"
+      // makes "configuration not public" errors downstream go away
+      "set every publishMavenStyle := false"
     ]
   }
 
@@ -496,7 +498,7 @@ build += {
       "set every apiURL := None"
       // UnfoldResourceSourceSpec kept failing. I should report upstream if it persists after next unfreeze
       "set executeTests in streamTests in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-      // makes a "configuration not public" error downstream (in akka-more) go away
+      // makes "configuration not public" errors downstream go away
       "set every publishMavenStyle := false"
     ]
     extra.exclude: [

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -516,6 +516,7 @@ build += {
       "akka-actor"  // because we already built it in "akka"
       "akka-stream", "akka-stream-testkit", "akka-remote"  // because we already built them in "akka-stream"
       "akka-bench-jmh"  // we'd have to add a resolver to get the JMH dependency, and we prefer not to run benchmarks here anyway
+      "akka-testkit", "akka-protobuf"  // already built these in akka-stream
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -484,7 +484,7 @@ build += {
       // repo readme recommended
       "-Xmx2g"
     ]
-    extra.projects: ["akka-stream", "streamTests"]
+    extra.projects: ["akka-stream", "akka-stream-tests"]
     extra.commands: ${vars.default-commands} [
       // https://github.com/scala/community-builds/issues/373
       "set every apiURL := None"

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -392,7 +392,7 @@ build += {
     uri:  ${vars.uris.akka-uri}
     extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"]
-    extra.projects: ["akka-actor"]
+    extra.projects: ["akka-actor", "akka-actor-typed"]
     extra.commands: ${vars.default-commands} [
       // https://github.com/scala/community-builds/issues/373
       "set every apiURL := None"
@@ -484,7 +484,11 @@ build += {
       // repo readme recommended
       "-Xmx2g"
     ]
-    extra.projects: ["akka-stream", "akka-stream-tests"]
+    extra.projects: [
+      "akka-stream", "akka-stream-tests"
+      // not part of akka-stream, but throwing it in so that akka-http doesn't need anything from akka-more
+      "akka-multi-node-testkit"
+    ]
     extra.commands: ${vars.default-commands} [
       // https://github.com/scala/community-builds/issues/373
       "set every apiURL := None"
@@ -492,7 +496,7 @@ build += {
       "set executeTests in streamTests in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
     ]
     extra.exclude: [
-      "akka-actor"  // because we already built it in "akka"
+      "akka-actor", "akka-actor-typed"  // because we already built them in "akka-actor"
     ]
   }
 
@@ -513,10 +517,10 @@ build += {
     ]
     extra.exclude: [
       "akka-docs"   // this is Sphinx stuff, not really apropos here, no Sphinx on Jenkins anyway
-      "akka-actor"  // because we already built it in "akka"
+      "akka-actor", "akka-actor-typed"  // because we already built them in "akka-actor"
       "akka-stream", "akka-stream-testkit", "akka-remote"  // because we already built them in "akka-stream"
       "akka-bench-jmh"  // we'd have to add a resolver to get the JMH dependency, and we prefer not to run benchmarks here anyway
-      "akka-testkit", "akka-protobuf"  // already built these in akka-stream
+      "akka-testkit", "akka-protobuf", "akka-multi-node-testkit"  // already built these in akka-stream
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -494,6 +494,8 @@ build += {
       "set every apiURL := None"
       // UnfoldResourceSourceSpec kept failing. I should report upstream if it persists after next unfreeze
       "set executeTests in streamTests in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      // makes a "configuration not public" error downstream (in akka-more) go away
+      "set every publishMavenStyle := false"
     ]
     extra.exclude: [
       "akka-actor", "akka-actor-typed"  // because we already built them in "akka-actor"


### PR DESCRIPTION
akka-more is a big grab bag and it's annoying when we have to
rebuild all of it because something downstream needs akka-stream