### PR TITLE
hoping to fix slick failure hanging whole JDK 10 build

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -574,7 +574,7 @@ build += {
       "de.johoop#sbt-testng-interface"
     ]
     // as per https://github.com/slick/slick/issues/1908, we need this on Java 9+
-    extra.options: ["-J--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"]
+    extra.options: ["--add-modules=java.xml.bind", "-J--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"]
     extra.exclude: [
       // unless we exclude, it looks for an Ornate dependency here
       "root"


### PR DESCRIPTION
see e.g. https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk10-integrate-community-build/84/