### PR TITLE
fix akka-more on jdk9

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -587,7 +587,7 @@ build += {
       // repo readme recommended
       "-Xmx2g"
       // the usual thing some projects need on JDK 9
-      "--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"
+      "--add-modules=java.xml.bind", "-J--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"
     ]
     extra.projects: ["akka-scala-nightly"]
     extra.commands: ${vars.default-commands} [

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -595,7 +595,7 @@ build += {
       // repo readme recommended
       "-Xmx2g"
       // the usual thing some projects need on JDK 9
-      "--add-modules=java.xml.bind", "-J--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"
+      "--add-modules=java.xml.bind", "-XX:+IgnoreUnrecognizedVMOptions"
     ]
     extra.projects: ["akka-scala-nightly"]
     extra.commands: ${vars.default-commands} [

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -11,7 +11,7 @@ vars.uris: {
   akka-http-uri:                "https://github.com/akka/akka-http.git"
   akka-persistence-cassandra-uri: "https://github.com/akka/akka-persistence-cassandra.git#2a53c6a0a1f64"  # was master
   akka-persistence-jdbc-uri:    "https://github.com/dnvriend/akka-persistence-jdbc.git"
-  akka-uri:                     "https://github.com/akka/akka.git#131e6d10d63fb4"  # was master
+  akka-uri:                     "https://github.com/akka/akka.git#729313c66fd"  # was master (or a v2.5.x tag)
   algebra-uri:                  "https://github.com/denisrosset/algebra.git#topic/cats-compatibility"   # was typelevel, master
   ammonite-uri:                 "https://github.com/lihaoyi/ammonite.git#af54e9d1"  # was master
   argonaut-shapeless-uri:       "https://github.com/alexarchambault/argonaut-shapeless.git"


### PR DESCRIPTION
seen at https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk9-integrate-community-build/325/consoleFull: `[akka-more] Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlRootElement`