### PR TITLE
unfreeze blaze (use master instead of an old release branch)

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1196,9 +1196,6 @@ build += {
     extra.projects: ["http4sWebsocketJVM"]  // no Scala.js plz
   }
 
-  // tracking 0.12.x, not master, because that's the version http4s depends
-  // on (as of December 2017, anyway; see discussion at
-  // https://github.com/http4s/blaze/issues/97)
   ${vars.base} {
     name: "blaze"
     uri: ${vars.uris.blaze-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -21,7 +21,7 @@ vars.uris: {
   base64-uri:                   "https://github.com/marklister/base64.git"
   better-files-uri:             "https://github.com/pathikrit/better-files.git"
   better-monadic-for-uri:       "https://github.com/oleg-py/better-monadic-for.git"
-  blaze-uri:                    "https://github.com/http4s/blaze.git#release-0.12.x"
+  blaze-uri:                    "https://github.com/http4s/blaze.git"
   breeze-uri:                   "https://github.com/SethTisue/breeze.git#sbt-api-mappings-version-bump"  # was scalanlp, master
   cachecontrol-uri:             "https://github.com/playframework/cachecontrol.git#a38127e"  # was master
   case-app-uri:                 "https://github.com/scalacommunitybuild/case-app.git#community-build-2.12"


### PR DESCRIPTION
motivation is to get https://github.com/http4s/blaze/pull/213
which makes blaze compile on JDK 9