### PR TITLE
unfreeze Play

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -961,8 +961,6 @@ build += {
     uri:  ${vars.uris.cachecontrol-uri}
   }
 
-  // frozen (July 2018) until lagom catches up with CoordinateShutdownProvider
-  // changes on master
   ${vars.base} {
     name: "play-core"
     uri:  ${vars.uris.play-core-uri}
@@ -1515,26 +1513,6 @@ build += {
     ]
   }
 
-  // there are a *ton* of subprojects.  it might be interesting to try to add
-  // as many as possible. for now, we've somewhat arbitrarily selected a few
-  ${vars.base} {
-    name: "lagom"
-    uri:  ${vars.uris.lagom-uri}
-    // these pull in a number of dependent projects
-    extra.projects: ["server", "testkit-scaladsl"]
-    extra.options: [
-      // hopefully avoid intermittent OutOfMemoryErrors with default heap
-      "-Xmx2g"
-    ]
-    extra.commands: ${vars.default-commands} [
-      // tests in these subprojects are too slow and (more importantly) too fragile
-      "set executeTests in `persistence-cassandra-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-      "set executeTests in `testkit-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-      // more flaky tests I haven't reported upstream
-      "set excludeFilter in (Test, unmanagedSources) in `server-scaladsl` := HiddenFileFilter || \"LagomApplicationSpec.scala\""
-    ]
-  }
-
   // dependency of lagom. forked (August 2018) at last green version,
   // since newer commits break lagom; see https://github.com/lagom/lagom/issues/1413
   // the fork is so we could cherry-pick https://github.com/akka/akka-persistence-cassandra/pull/377
@@ -1555,6 +1533,26 @@ build += {
     ]
     // at least one test was hanging
     extra.test-tasks: "compile"
+  }
+
+  // there are a *ton* of subprojects.  it might be interesting to try to add
+  // as many as possible. for now, we've somewhat arbitrarily selected a few
+  ${vars.base} {
+    name: "lagom"
+    uri:  ${vars.uris.lagom-uri}
+    // these pull in a number of dependent projects
+    extra.projects: ["server", "testkit-scaladsl"]
+    extra.options: [
+      // hopefully avoid intermittent OutOfMemoryErrors with default heap
+      "-Xmx2g"
+    ]
+    extra.commands: ${vars.default-commands} [
+      // tests in these subprojects are too slow and (more importantly) too fragile
+      "set executeTests in `persistence-cassandra-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      "set executeTests in `testkit-scaladsl` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+      // more flaky tests I haven't reported upstream
+      "set excludeFilter in (Test, unmanagedSources) in `server-scaladsl` := HiddenFileFilter || \"LagomApplicationSpec.scala\""
+    ]
   }
 
   // not (as of January 2018 anyway) an actively maintained project, so it's

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -91,7 +91,7 @@ vars.uris: {
   parboiled2-uri:               "https://github.com/sirthias/parboiled2.git#release-2.1"
   pascal-uri:                   "https://github.com/TomasMikula/pascal.git"
   pcplod-uri:                   "https://github.com/ensime/pcplod.git"
-  play-core-uri:                "https://github.com/playframework/playframework.git#835b2ab72"
+  play-core-uri:                "https://github.com/playframework/playframework.git"
   play-doc-uri:                 "https://github.com/playframework/play-doc.git"
   play-json-uri:                "https://github.com/playframework/play-json.git"
   play-webgoat-uri:             "https://github.com/playframework/play-webgoat.git"


### PR DESCRIPTION
the latest Lagom needs newer Play changes, so instead of freezing
Lagom, let's try unfreezing Play

also reorder projects a little so lagom's dependencies all appear
before lagom