### PR TITLE
Disable tools APIs of Scala.js until parallel collections work.

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -452,8 +452,9 @@ build += {
       // hopefully avoid intermittent OutOfMemoryErrors with default 1.5G heap?
       "-Xmx2048m"
     ]
-    // not really sure how this list was arrived at
-    extra.projects: ["io", "logging", "linker", "testSuite"]
+    // until parallel collections are back on track, we can only run the testSuite and the testSuiteJVM
+    // eventually we should re-enable "ir", "logging", "io", "linker"
+    extra.projects: ["testSuite", "testSuiteJVM"]
     // exclude it here because we build it separately in scala-js-stubs
     extra.exclude: ["stubs"]
     extra.commands: ${vars.default-commands} [
@@ -461,6 +462,7 @@ build += {
       //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
       //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
       "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withExecutable(\""${vars.node}"\").withSourceMap(false)))"
+      "set MyScalaJSPlugin.wantSourceMaps in testSuite := false"
     ]
   }
 


### PR DESCRIPTION
We enable `testSuiteJVM` in the process, which runs cross-compiling tests on the JVM.

This should make Scala.js green again.