### PR TITLE
newer fs2, cats, cats-effect

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2249,7 +2249,7 @@ build += {
     extra.projects: ["rootJVM"]
     // I got some compile error here (September 2018) that seemed unlikely to be
     // significant. it's fine, we don't need to have every last subproject
-    extra.exclude: ["monix", "okhttpBackendMonix"]
+    extra.exclude: ["monix", "okhttpBackendMonix", "asyncHttpClientBackendMonix"]
   }
 
   // dependency of scrooge-shapes.

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1484,7 +1484,7 @@ build += {
   ${vars.base} {
     name: "paradox"
     uri:  ${vars.uris.paradox-uri}
-    extra.sbt-version: ${vars.sbt-1-1-version}
+    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["plugin", "themePlugin", "genericTheme"]
     check-missing: false  // ignore missing scripted-sbt
     extra.commands: ${vars.default-commands} [

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -25,8 +25,8 @@ vars.uris: {
   cachecontrol-uri:             "https://github.com/playframework/cachecontrol.git#a38127e"  # was master
   case-app-uri:                 "https://github.com/scalacommunitybuild/case-app.git#community-build-2.12"  # was alexarchambault, master
   catalysts-uri:                "https://github.com/typelevel/catalysts.git#f8676a18"  # was master
-  cats-effect-uri:              "https://github.com/typelevel/cats-effect.git#v1.0.0-RC3"  # was master
-  cats-uri:                     "https://github.com/typelevel/cats.git#v1.2.0"  # was master
+  cats-effect-uri:              "https://github.com/typelevel/cats-effect.git#v1.0.0"  # was master
+  cats-uri:                     "https://github.com/typelevel/cats.git#v1.4.0"  # was master
   circe-config-uri:             "https://github.com/circe/circe-config.git"
   circe-uri:                    "https://github.com/circe/circe.git"
   circe-derivation-uri:         "https://github.com/circe/circe-derivation.git"
@@ -49,7 +49,7 @@ vars.uris: {
   fast-string-interpolator-uri: "https://github.com/Sizmek/fast-string-interpolator.git"
   fastparse-uri:                "https://github.com/lihaoyi/fastparse.git"
   fs2-reactive-streams-uri:     "https://github.com/zainab-ali/fs2-reactive-streams.git"
-  fs2-uri:                      "https://github.com/functional-streams-for-scala/fs2.git#v1.0.0-M4"
+  fs2-uri:                      "https://github.com/functional-streams-for-scala/fs2.git#v1.0.0-M5"
   genjavadoc-uri:               "https://github.com/lightbend/genjavadoc.git"
   geny-uri:                     "https://github.com/lihaoyi/geny.git"
   gigahorse-uri:                "https://github.com/eed3si9n/gigahorse.git#0.3.x"

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -35,8 +35,7 @@ object SuccessReport {
     System.getProperty("java.specification.version") match {
       case "1.8" =>
         Set(
-          "fs2-reactive-streams",
-          "sttp",
+          "http4s",
         )
       case "9" =>
         Set(


### PR DESCRIPTION
this should fix fs2-reactive-streams which has been failing

downstream from fs2 are: jawn-fs2, sttp, http4s. we'll see what happens with those