### PR TITLE
Revert to tracking scala-js master, and add scala-js-stubs

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -96,9 +96,7 @@ vars: {
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
-  // we were on master, but https://github.com/scala-js/scala-js/pull/3356 broke utest;
-  // 0.6.x is fine I guess
-  scala-js-ref                 : "scala-js/scala-js.git#0.6.x"
+  scala-js-ref                 : "scala-js/scala-js.git"
   // freeze at March 2017 commit, before Ornate was added, which caused a failure
   // (https://github.com/scala/community-builds/issues/513). we could backport a fix
   // but 2.11 is nearly moribund these days so let's just freeze.
@@ -522,7 +520,7 @@ build += {
       // e.g. https://scala-ci.typesafe.com/job/scala-2.11.x-jdk8-integrate-community-build/111/consoleFull
       options: ["-Xmx2048m"]
       // not really sure how this list was arrived at
-      projects: [tools, testSuite, stubs]
+      projects: [ io, logging, linker, testSuite, stubs ]
       commands: ${vars.default-commands} [
         // - Disable fatal Scaladoc warnings, too fragile
         "removeScalacOptions -Xfatal-warnings"
@@ -530,6 +528,7 @@ build += {
         //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects
         //   that `testSuite` depends on (transitively), so we need to set it in a bunch of places.
         "set Seq(library, testInterface, jUnitRuntime, testSuite).map(p => jsEnv in p := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withExecutable(\""${vars.node}"\").withSourceMap(false)))"
+        "set MyScalaJSPlugin.wantSourceMaps in testSuite := false"
       ]
     }
   }

--- a/common.conf
+++ b/common.conf
@@ -96,6 +96,7 @@ vars: {
   scalaz-ref                   : "scalaz/scalaz.git#series/7.1.x"
   scodec-bits-ref              : "scodec/scodec-bits.git#series/1.0.x"
   discipline-ref               : "typelevel/discipline.git#v0.2"
+  scala-js-stubs-ref           : "scala-js/scala-js-stubs.git"
   scala-js-ref                 : "scala-js/scala-js.git"
   // freeze at March 2017 commit, before Ornate was added, which caused a failure
   // (https://github.com/scala/community-builds/issues/513). we could backport a fix
@@ -513,6 +514,11 @@ build += {
   }
 
   ${vars.base} {
+    name:   "scala-js-stubs"
+    uri:    "http://github.com/"${vars.scala-js-stubs-ref}
+  }
+
+  ${vars.base} {
     name:   "scala-js"
     uri:    "http://github.com/"${vars.scala-js-ref}
     extra: ${vars.base.extra} {
@@ -520,7 +526,7 @@ build += {
       // e.g. https://scala-ci.typesafe.com/job/scala-2.11.x-jdk8-integrate-community-build/111/consoleFull
       options: ["-Xmx2048m"]
       // not really sure how this list was arrived at
-      projects: [ io, logging, linker, testSuite, stubs ]
+      projects: [ io, logging, linker, testSuite ]
       commands: ${vars.default-commands} [
         // - Disable fatal Scaladoc warnings, too fragile
         "removeScalacOptions -Xfatal-warnings"


### PR DESCRIPTION
We can revert because uTest has been updated to support Scala.js' master, in particular the disappearance of `TestUtils` in favor of https://github.com/portable-scala/portable-scala-reflect.

The separation of scala-js-stubs into a different repo will also make [the hack for better caching in the 2.12.x branch](https://github.com/scala/community-builds/blob/d6b8d6ae6c8fa2779994eb336937012bd320605d/configs/community.dbuild#L208-L213) irrelevant.