### PR TITLE
Add airframe (only for JVM projects) to the community build

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1913,6 +1913,13 @@ build += {
     ]
   }
 
+  ${vars.base} {
+    name: "airframe"
+    uri:  ${vars.uris.airframe-uri}
+    extra.sbt-version: ${vars.sbt-1-version}
+    extra.projects: ["projectJVM"]  // no Scala.js plz
+  }
+
 ]}
 
 //// space: jawn_0_10

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1921,6 +1921,7 @@ build += {
     extra.exclude: [
       "jsonBenchmark"  // out of scope
       "jdbc"  // requires PostgreSQL for testing
+      "fluentd"  // requires org.xerial#fluentd-standalone which we don't have
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1918,6 +1918,10 @@ build += {
     uri:  ${vars.uris.airframe-uri}
     extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["projectJVM"]  // no Scala.js plz
+    extra.exclude: [
+      "jsonBenchmark"  // out of scope
+      "jdbc"  // requires PostgreSQL for testing
+    ]
   }
 
 ]}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -1,5 +1,6 @@
 vars.uris: {
   acyclic-uri:                    "https://github.com/lihaoyi/acyclic.git#cfaa2465105871e41681985c325ce262d1a6460a"
+  airframe-url:                   "https://github.com/wvlet/airframe.git#46b58ef6d0322e4e02d3921b6ad43638f23cf0f9"
   akka-contrib-extra-uri:         "https://github.com/typesafehub/akka-contrib-extra.git#7ca1ec0c6ce496fa902a57199b50b95e580f8636"
   akka-http-cors-uri:             "https://github.com/lomigmegard/akka-http-cors.git#93f8690c72f77ea796dead59b14db61c44b955f2"
   akka-http-json-uri:             "https://github.com/hseeberger/akka-http-json.git#9d6e2ff951768ae072ea61ac0ab0f86b5f05284d"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -1,6 +1,6 @@
 vars.uris: {
   acyclic-uri:                    "https://github.com/lihaoyi/acyclic.git#cfaa2465105871e41681985c325ce262d1a6460a"
-  airframe-url:                   "https://github.com/wvlet/airframe.git#46b58ef6d0322e4e02d3921b6ad43638f23cf0f9"
+  airframe-uri:                   "https://github.com/wvlet/airframe.git#46b58ef6d0322e4e02d3921b6ad43638f23cf0f9"
   akka-contrib-extra-uri:         "https://github.com/typesafehub/akka-contrib-extra.git#7ca1ec0c6ce496fa902a57199b50b95e580f8636"
   akka-http-cors-uri:             "https://github.com/lomigmegard/akka-http-cors.git#93f8690c72f77ea796dead59b14db61c44b955f2"
   akka-http-json-uri:             "https://github.com/hseeberger/akka-http-json.git#9d6e2ff951768ae072ea61ac0ab0f86b5f05284d"


### PR DESCRIPTION
@SethTisue This is an initial attempt to add Airframe (https://github.com/wvlet/airframe) to the community build, as we talked at Scale By The Bay.

Let me know if we need some fixes. 

Thanks.