### PR TITLE
2.13: cats: enable cats-kernel-laws

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -373,13 +373,14 @@ build += {
     // other than just enumerating what we want:
     extra.projects: [
       "coreJVM", "freeJVM", "kernelJVM",
-      "lawsJVM", "macrosJVM", "testkitJVM", "testsJVM", "alleycatsCoreJVM"
+      "lawsJVM", "macrosJVM", "testkitJVM", "testsJVM",
+      "kernelLawsJVM", "alleycatsCoreJVM"
     ]
     extra.exclude: [
       // failing as of Nov 14 2018, not investigated.
       // for now we're mainly interested in letting downstream projects build,
       // less interested in making every test pass, but perhaps we can come back to this before RC1
-      "kernelLawsJVM", "alleycatsTestsJVM"
+      "alleycatsTestsJVM"
       // out of scope
       "bench", "docs"
     ]

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -395,6 +395,8 @@ build += {
       "set sources in doc in Compile in alleycatsCoreJVM := List()"
       // 2.13: sigh, https://github.com/typelevel/cats/issues/2360
       "set excludeFilter in (Test, unmanagedSources) in testsJVM := HiddenFileFilter || \"OpSuite.scala\""
+      // 2.13: some hashing thing, the cats team will presumably hit & fix it
+      "set excludeFilter in (Test, unmanagedSources) in kernelLaws.jvm := HiddenFileFilter || \"LawTests.scala\""
     ]
   }
 

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -34,13 +34,11 @@ object SuccessReport {
 
   val expectedToFail = Set[String](
     "akka",
-    "algebra",  // needs cats-kernel-laws (we could re-enable that but disable the failing tests)
     "base64",
     "boopickle",
     "cachecontrol",
     "case-app",
     "cats-effect",
-    "circe",  // needs cats-kernel-laws (see algebra)
     "circe-config",
     "fastparse",
     "geny",
@@ -49,14 +47,12 @@ object SuccessReport {
     "jackson-module-scala",
     "jawn-0-10",
     "jsoniter-scala",
-    "kittens",  // needs cats-kernel-laws (see algebra)
     "lift-json",
     "linter",
     "log4s",
     "magnolia",
     "mima",  // ran afoul of some scala.tools.nsc change, it looks like
     "nyaya",
-    "paiges",  // needs cats-kernel-laws (see algebra)
     "paradox",
     "parboiled2",
     "pcplod",


### PR DESCRIPTION
(we got cats green by removing cats-kernel-laws, but it turns out it's needed downstream by a number of projects)