### PR TITLE
build everything with sbt 1 by default

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -48,8 +48,8 @@ include file(".dbuild/resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "0.13.18"
-  sbt-1-version: "1.2.7"
+  sbt-0-13-version: "0.13.18"
+  sbt-version: "1.2.7"
 }
 
 //// compiler options manipulation
@@ -117,7 +117,6 @@ build += {
   {
     name: "cloc-plugin"
     uri:  "https://github.com/SethTisue/cloc-plugin.git"
-    extra.sbt-version: ${vars.sbt-1-version}
   }
   {
     name:  "scala"
@@ -152,7 +151,7 @@ build += {
         cross-version: standard
         // override sbt version here since otherwise we get
         // whatever random sbt version the module has
-        extra.sbt-version: ${vars.sbt-version}
+        extra.sbt-version: ${vars.sbt-0-13-version}
         extra.commands: ${vars.default-commands} [
           // override scalaVersion here since otherwise we get
           // whatever random Scala version the module has
@@ -190,12 +189,14 @@ build += {
   ${vars.base} {
     name: "scalatest"
     uri:  ${vars.uris.scalatest-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["scalatest", "scalactic"]
   }
 
   ${vars.base} {
     name: "scala-parser-combinators"
     uri:  ${vars.uris.scala-parser-combinators-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: ["scala-parser-combinatorsJS", "scala-parser-combinatorsNative"]
     extra.commands: ${vars.base.extra.commands} [
       // work around https://github.com/scala/community-builds/issues/575
@@ -207,7 +208,6 @@ build += {
   ${vars.base} {
     name: "scala-js-stubs"
     uri:  ${vars.uris.scala-js-stubs-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // forked (May 2017) to make a trivial source change for 2.12.3 compat;
@@ -220,20 +220,17 @@ build += {
   ${vars.base} {
     name: "shapeless"
     uri:  ${vars.uris.shapeless-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM"]
   }
 
   ${vars.base} {
     name: "kind-projector"
     uri:  ${vars.uris.kind-projector-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "specs2"
     uri:  ${vars.uris.specs2-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // I don't see a project that aggregates JVM-only stuff, so...
     extra.projects: [
       "analysisJVM", "commonJVM", "coreJVM", "fpJVM"
@@ -250,21 +247,18 @@ build += {
   ${vars.base} {
     name: "silencer"
     uri:  ${vars.uris.silencer-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // dependency of scribe
   ${vars.base} {
     name: "perfolation"
     uri:  ${vars.uris.perfolation-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM"]
   }
 
   ${vars.base} {
     name: "scribe"
     uri:  ${vars.uris.scribe-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "macrosJVM"]
     // intermittently failing test I haven't gotten around to reporting upstream
     extra.commands: ${vars.default-commands} [
@@ -293,6 +287,7 @@ build += {
   ${vars.base} {
     name: "scala-collection-compat"
     uri:  ${vars.uris.scala-collection-compat-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // change to "compat12" when we unfreeze
     extra.projects: ["scala-collection-compat"]  // no Scala.js or Scalafix rules plz
   }
@@ -301,20 +296,19 @@ build += {
   ${vars.base} {
     name: "export-hook"
     uri:  ${vars.uris.export-hook-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["coreJVM"]  // no Scala.js plz
   }
 
   ${vars.base} {
     name: "simulacrum"
     uri:  ${vars.uris.simulacrum-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "examplesJVM"] // no Scala.js please
   }
 
   ${vars.base} {
     name: "discipline"
     uri:  ${vars.uris.discipline-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["disciplineJVM"]  // no Scala.js please
   }
 
@@ -323,7 +317,6 @@ build += {
   ${vars.base} {
     name: "catalysts"
     uri:  ${vars.uris.catalysts-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // other projects aren't pertinent or errored out (not investigated)
     extra.projects: ["specbaseJVM", "lawkitJVM", "scalatestJVM", "macrosJVM", "platformJVM", "testkitJVM"]
   }
@@ -331,13 +324,13 @@ build += {
   ${vars.base} {
     name: "machinist"
     uri:  ${vars.uris.machinist-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["machinistJVM"]  // no Scala.js please
   }
 
   ${vars.base} {
     name: "macro-compat"
     uri:  ${vars.uris.macro-compat-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // no Scala.js plz
     extra.projects: ["testJVM"]
   }
@@ -345,13 +338,13 @@ build += {
   ${vars.base} {
     name: "wartremover"
     uri:  ${vars.uris.wartremover-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: ["sbt-plugin"]
   }
 
   ${vars.base} {
     name: "cats"
     uri:  ${vars.uris.cats-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
     // (and "docs") doesn't succeed in removing the depending on cats-bench.
     // using deps.ignore doesn't fix it either. not sure how else to fix it
@@ -368,13 +361,13 @@ build += {
   ${vars.base} {
     name: "kittens"
     uri:  ${vars.uris.kittens-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["coreJVM"]  // sorry, Scala.js
   }
 
   ${vars.base} {
     name: "tut"
     uri:  ${vars.uris.tut-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: [
       "plugin"  // we never build sbt plugins
       "docs"  // out of scope
@@ -392,11 +385,13 @@ build += {
   ${vars.base} {
     name: "genjavadoc"
     uri:  ${vars.uris.genjavadoc-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   ${vars.base} {
     name: "scalaz"
     uri:  ${vars.uris.scalaz-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["rootJVM"]  // no Scala.js please
     extra.exclude: ["scalacheck-binding_1_13JVM"]  // we're on 1.14
   }
@@ -407,6 +402,7 @@ build += {
   ${vars.base} {
     name: "scala-js"
     uri:  ${vars.uris.scala-js-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.options: [
       // hopefully avoid intermittent OutOfMemoryErrors with default 1.5G heap?
       "-Xmx2048m"
@@ -428,7 +424,6 @@ build += {
   ${vars.base} {
     name: "specs2-more"
     uri:  ${vars.uris.specs2-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: [
       "shapelessJVM", "catsJVM", "scalazJVM", "examplesJVM"
     ]
@@ -449,6 +444,7 @@ build += {
   ${vars.base} {
     name: "scala-java8-compat"
     uri:  ${vars.uris.scala-java8-compat-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       // For some reason dbuild includes test sources in the javadocs, which trips up javadoc because
       // we use "assert" as an identifier there. We disable doc building to avoid that.
@@ -464,7 +460,6 @@ build += {
   ${vars.base} {
     name: "akka"
     uri:  ${vars.uris.akka-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"]
     extra.projects: ["akka-actor", "akka-actor-typed", "akka-testkit", "akka-actor-tests"]
     extra.commands: ${vars.default-commands} [
@@ -489,6 +484,7 @@ build += {
   ${vars.base} {
     name: "scalatest-tests"
     uri:  ${vars.uris.scalatest-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // we already built these above
       "scalatest", "scalactic", "scalacticMacro"
@@ -506,11 +502,13 @@ build += {
   ${vars.base} {
     name: "scala-partest"
     uri:  ${vars.uris.scala-partest-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   ${vars.base} {
     name: "scala-swing"
     uri:  ${vars.uris.scala-swing-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       // work around https://github.com/scala/community-builds/issues/575
       // (in a community build context, we don't need MiMa to run)
@@ -542,14 +540,12 @@ build += {
   ${vars.base} {
     name: "scodec-bits"
     uri:  ${vars.uris.scodec-bits-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM"]
   }
 
   ${vars.base} {
     name: "scodec"
     uri:  ${vars.uris.scodec-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM"]
     extra.commands: ${vars.base.extra.commands} [
       // because scodec-build brings in sbt-gpg which errors on `publish`
@@ -569,7 +565,6 @@ build += {
   ${vars.base} {
     name: "akka-stream"
     uri:  ${vars.uris.akka-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"
       // repo readme recommended
       "-Xmx2g"
@@ -600,7 +595,6 @@ build += {
   ${vars.base} {
     name: "akka-more"
     uri:  ${vars.uris.akka-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false"
       // repo readme recommended
       "-Xmx2g"
@@ -632,7 +626,6 @@ build += {
   ${vars.base} {
     name: "akka-http"
     uri:  ${vars.uris.akka-http-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["docs", "akka-http-bench-jmh"]
     extra.options: [
       "-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false"
@@ -654,18 +647,19 @@ build += {
   ${vars.base} {
     name: "scalariform"
     uri: ${vars.uris.scalariform-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "scala-async"
     uri:  ${vars.uris.scala-async-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   // forked (September 2018) for JDK 11 friendliness
   ${vars.base} {
     name: "slick"
     uri:  ${vars.uris.slick-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     deps.inject: ${vars.base.deps.inject} [
       // without this dbuild doesn't pick up that one of the subprojects has this dependency.
       // it doesn't even make sense; it seems to me that testNGSettings should not be adding
@@ -692,6 +686,7 @@ build += {
   ${vars.base} {
     name: "sbt-testng"
     uri:  ${vars.uris.sbt-testng-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["sbt-testng-interface"]  // just the interface, we don't need to build the plugin
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
@@ -702,6 +697,7 @@ build += {
   ${vars.base} {
     name: "sbinary"
     uri:  ${vars.uris.sbinary-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     // we have to disable this early (extra.commands isn't soon enough)
     // or scalafmt will run `update` and `cloc-plugin` won't be found
@@ -715,13 +711,13 @@ build += {
   ${vars.base} {
     name: "acyclic"
     uri:  ${vars.uris.acyclic-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // forked (June 2018) to upgrade sbt-osgi to a Java 9 friendly version
   ${vars.base} {
     name: "sourcecode"
     uri:  ${vars.uris.sourcecode-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // no Scala.js plz
     extra.projects: ["sourcecodeJVM"]
   }
@@ -729,7 +725,6 @@ build += {
   ${vars.base} {
     name: "utest"
     uri:  ${vars.uris.utest-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // no Scala.js plz
     extra.projects: ["utestJVM"]
     // waiting for fix on https://github.com/lihaoyi/utest/issues/168
@@ -741,6 +736,7 @@ build += {
   ${vars.base} {
     name: "fastparse"
     uri:  ${vars.uris.fastparse-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: [
       "fastparseJVM"   // no Scala.js plz
       "scalaparseJVM"  // dependency of scalatex
@@ -754,18 +750,19 @@ build += {
   ${vars.base} {
     name: "geny"
     uri:  ${vars.uris.geny-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["genyJVM"]  // no Scala.js plz
   }
 
   ${vars.base} {
     name: "scala-logging"
     uri:  ${vars.uris.scala-logging-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "scalaprops"
     uri:  ${vars.uris.scalaprops-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["rootJVM"]  // no Scala.js please
     check-missing: false  // ignore missing scalafmt
   }
@@ -774,7 +771,6 @@ build += {
   ${vars.base} {
     name: "kxbmap-configs"
     uri:  ${vars.uris.kxbmap-configs-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["docs"]
   }
 
@@ -784,7 +780,6 @@ build += {
     name: "cats-effect"
     uri:  ${vars.uris.cats-effect-uri}
     extra.projects: ["coreJVM", "lawsJVM"]  // no Scala.js plz
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // frozen at v1.0.0 tag for now, perhaps excessively cautiously; we might
@@ -792,7 +787,6 @@ build += {
   ${vars.base} {
     name: "fs2"
     uri:  ${vars.uris.fs2-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "io"]  // no Scala.js, no benchmarks or docs
     extra.commands: ${vars.base.extra.commands} [
       // otherwise sbt-gpg errors on `publish`
@@ -803,20 +797,19 @@ build += {
   ${vars.base} {
     name: "parboiled"
     uri:  ${vars.uris.parboiled-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["parboiled-scala"]
   }
 
   ${vars.base} {
     name: "parboiled2"
     uri:  ${vars.uris.parboiled2-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["parboiledJVM", "examples"]
   }
 
   ${vars.base} {
     name: "eff"
     uri:  ${vars.uris.eff-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: [
       // this is an aggregation project that we exclude because it adds a
       // ScalaMeter dependency
@@ -842,6 +835,7 @@ build += {
   ${vars.base} {
     name: "jackson-module-scala"
     uri:  ${vars.uris.jackson-module-scala-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // surely they'll drop this crufty thing from their build eventually,
     // but for the time being we need to fill in something:
     extra.options: ["-Djava7.home="${JAVA_HOME}]
@@ -872,6 +866,7 @@ build += {
   ${vars.base} {
     name: "mima"
     uri:  ${vars.uris.mima-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // we don't compile sbt plugins
     extra.exclude: ["sbtplugin"]
   }
@@ -879,14 +874,12 @@ build += {
   ${vars.base} {
     name: "mouse"
     uri:  ${vars.uris.mouse-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["crossJVM"]  // no Scala.js please
   }
 
   ${vars.base} {
     name: "ssl-config"
     uri:  ${vars.uris.ssl-config-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["sslConfigCore"]
     // repeated hangs during testing; see
     // https://github.com/scala/community-builds/issues/560
@@ -897,13 +890,13 @@ build += {
   ${vars.base} {
     name: "spray-json"
     uri:  ${vars.uris.spray-json-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // forked (September 2018) for JDK 11 friendliness
   ${vars.base} {
     name: "pcplod"
     uri:  ${vars.uris.pcplod-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // in our fork we removed the sbt-sensible plugin, setting this
     // was one of the things the plugin did. tests fail otherwise
     extra.commands: ${vars.default-commands} [
@@ -918,7 +911,6 @@ build += {
   ${vars.base} {
     name: "scalikejdbc"
     uri:  ${vars.uris.scalikejdbc-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // don't build sbt plugin
     extra.exclude: ["mapper-generator"]
     // ignore missing scripted-sbt (https://github.com/sbt/sbt/issues/3917 ?)
@@ -929,7 +921,6 @@ build += {
   ${vars.base} {
     name: "scopt"
     uri:  ${vars.uris.scopt-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["scoptJVM"]  // no Scala.js plz
   }
 
@@ -937,13 +928,13 @@ build += {
   ${vars.base} {
     name: "expecty"
     uri:  ${vars.uris.expecty-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["expectyJVM"]
   }
 
   ${vars.base} {
     name: "twirl"
     uri:  ${vars.uris.twirl-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [ "plugin", "apiJS" ]
   }
 
@@ -955,6 +946,7 @@ build += {
   ${vars.base} {
     name: "play-json"
     uri:  ${vars.uris.play-json-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["play-jsonJVM"]  // no Scala.js plz
   }
 
@@ -967,7 +959,6 @@ build += {
   ${vars.base} {
     name: "play-ws"
     uri:  ${vars.uris.play-ws-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // NullPointerException in CachingSpec
     // (https://github.com/scala/community-builds/issues/564)
     extra.exclude: ["integration-tests"]
@@ -986,6 +977,7 @@ build += {
   ${vars.base} {
     name: "playframework"
     uri:  ${vars.uris.playframework-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // TODO: enable more projects? these are just a few that seemed especially high-value.
     // we tried including "Play-Integration-Test" but hit a mysterious StackOverflowError
     // in scala.tools.nsc.javac.JavaScanners; see https://github.com/scala/community-builds/issues/304
@@ -1011,6 +1003,7 @@ build += {
   ${vars.base} {
     name: "json4s"
     uri:  ${vars.uris.json4s-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // TODO: exclude subprojects we don't want, rather than naming a few we want. probably adding more would work?
     extra.projects: ["json4s-native", "json4s-jackson", "json4s-ast"]
     // disable Java version check which would otherwise reject Java 9
@@ -1020,6 +1013,7 @@ build += {
   ${vars.base} {
     name: "lift-json"
     uri:  ${vars.uris.lift-json-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["lift-json"]
   }
 
@@ -1030,6 +1024,7 @@ build += {
   ${vars.base} {
     name: "scalamock"
     uri:  ${vars.uris.scalamock-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       // work around https://github.com/scala/scala-dev/issues/252 ;
       // see https://github.com/scala/community-builds/issues/434
@@ -1046,6 +1041,7 @@ build += {
   ${vars.base} {
     name: "argonaut"
     uri:  ${vars.uris.argonaut-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["argonautJVM"]  // no Scala.js
     extra.exclude: [
       // fails to declare its scala-parser-combinators dependency,
@@ -1061,7 +1057,6 @@ build += {
   ${vars.base} {
     name: "monocle"
     uri:  ${vars.uris.monocle-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // try to enable more subprojects?
     extra.projects: ["coreJVM", "macrosJVM", "lawJVM", "genericJVM"]
   }
@@ -1069,12 +1064,12 @@ build += {
   ${vars.base} {
     name: "scala-continuations"
     uri:  ${vars.uris.scala-continuations-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   ${vars.base} {
     name: "scala-ssh"
     uri:  ${vars.uris.scala-ssh-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // we have to disable this early (extra.commands isn't soon enough)
     // or scalafmt will run `update` and `cloc-plugin` won't be found
     extra.settings: ${vars.base.extra.settings} [
@@ -1092,6 +1087,7 @@ build += {
   ${vars.base} {
     name: "scalameter"
     uri:  ${vars.uris.scalameter-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     check-missing: false
     deps.ignore: [
       // doesn't support 2.12 (yet?)
@@ -1108,7 +1104,6 @@ build += {
   ${vars.base} {
     name: "scalajson"
     uri:  ${vars.uris.scalajson-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // no Scala.js please, and no benchmarks either
     extra.projects: ["scalaJsonJVM"]
     check-missing: false  // ignore missing scalafmt
@@ -1117,32 +1112,31 @@ build += {
   ${vars.base} {
     name: "scalatags"
     uri:  ${vars.uris.scalatags-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["scalatagsJVM"]  // no Scala.js
   }
 
   ${vars.base} {
     name: "scala-refactoring"
     uri:  ${vars.uris.scala-refactoring-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   ${vars.base} {
     name: "nyaya"
     uri:  ${vars.uris.nyaya-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["testModuleJVM"]  // no Scala.js, no benchmarks
   }
 
   ${vars.base} {
     name: "minitest"
     uri:  ${vars.uris.minitest-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["minitestJVM", "lawsJVM"]  // no Scala.js
   }
 
   ${vars.base} {
     name: "monix"
     uri:  ${vars.uris.monix-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dmonix.requireJava8=false"]
     // no Scala.js, no benchmarks.
     // (but also, perhaps this excludes more stuff than necessary?)
@@ -1153,6 +1147,7 @@ build += {
   ${vars.base} {
     name: "conductr-lib"
     uri:  ${vars.uris.conductr-lib-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // we're on Akka 2.5
       "akka24ConductRClientLib", "akka24Common", "akka24ConductRBundleLib"
@@ -1178,6 +1173,7 @@ build += {
   ${vars.base} {
     name: "akka-contrib-extra"
     uri:  ${vars.uris.akka-contrib-extra-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1190,18 +1186,17 @@ build += {
   ${vars.base} {
     name: "unfiltered"
     uri:  ${vars.uris.unfiltered-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "dispatch"
     uri:  ${vars.uris.dispatch-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "atto"
     uri:  ${vars.uris.atto-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // just scalaz72 plz!
       "scalaz71"
@@ -1215,13 +1210,13 @@ build += {
   ${vars.base} {
     name: "log4s"
     uri:  ${vars.uris.log4s-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["coreJS", "testingJS"]
   }
 
   ${vars.base} {
     name: "http4s-websocket"
     uri:  ${vars.uris.http4s-websocket-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["http4sWebsocketJVM"]  // no Scala.js plz
   }
 
@@ -1229,7 +1224,6 @@ build += {
   ${vars.base} {
     name: "blaze"
     uri: ${vars.uris.blaze-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // forked (October 2017, November 2018) because utest 0.6.0 (we track utest master) made
@@ -1238,6 +1232,7 @@ build += {
   ${vars.base} {
     name: "fansi"
     uri:  ${vars.uris.fansi-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["fansiJVM"]  // no Scala.js
   }
 
@@ -1245,6 +1240,7 @@ build += {
   ${vars.base} {
     name: "pprint"
     uri:  ${vars.uris.pprint-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["pprintJVM"]  // no Scala.js
     // there is a post-2.12.6 failure because a test is sensitive
     // Iterator#toString format.  we could re-enable once 2.12.7
@@ -1257,6 +1253,7 @@ build += {
   ${vars.base} {
     name: "algebra"
     uri:  ${vars.uris.algebra-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["coreJVM", "lawsJVM"]  // no Scala.js, no benchmarks, no docs
   }
 
@@ -1279,7 +1276,6 @@ build += {
   ${vars.base} {
     name: "lightbend-emoji"
     uri:  ${vars.uris.lightbend-emoji-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
   }
 
@@ -1291,7 +1287,6 @@ build += {
   ${vars.base} {
     name: "twotails"
     uri:  ${vars.uris.twotails-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
@@ -1306,7 +1301,6 @@ build += {
   ${vars.base} {
     name: "scalapb"
     uri:  ${vars.uris.scalapb-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // just what scalameta needs, for now
     extra.projects: ["runtimeJVM"]
     // there's a 2.12 -> 2.11 symlink that should make this unnecessary, don't know why we need this:
@@ -1315,7 +1309,6 @@ build += {
   ${vars.base} {
     name: "paiges"
     uri:  ${vars.uris.paiges-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "catsJVM"]  // but not "benchmark"
   }
 
@@ -1329,6 +1322,7 @@ build += {
   ${vars.base} {
     name: "case-app"
     uri:  ${vars.uris.case-app-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // this is enough for scalafix, I didn't even try adding the rest
     extra.projects: ["coreJVM"]
   }
@@ -1336,7 +1330,6 @@ build += {
   ${vars.base} {
     name: "doodle"
     uri: ${vars.uris.doodle-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["doodleJVM"]  // no Scala.js plz
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
@@ -1348,6 +1341,7 @@ build += {
   ${vars.base} {
     name: "scala-collections-laws"
     uri: ${vars.uris.scala-collections-laws-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // as per the repo readme
     extra.options: ["-XX:MaxMetaspaceSize=1G", "-Xmx6G"]
     // note that we're not actually doing
@@ -1361,7 +1355,6 @@ build += {
   ${vars.base} {
     name: "better-files"
     uri: ${vars.uris.better-files-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.commands: ${vars.default-commands} [
       // keep scalafmtSbtCheck from complaining about code dbuild injects
       "set checkFormat := {}"
@@ -1371,6 +1364,7 @@ build += {
   ${vars.base} {
     name: "scalastyle"
     uri: ${vars.uris.scalastyle-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.options: ["-Dscalastyle.publish-ivy-only=true"]
   }
 
@@ -1386,7 +1380,6 @@ build += {
   ${vars.base} {
     name: "gigahorse"
     uri:  ${vars.uris.gigahorse-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // as of August 2017, doesn't compile against latest akka-http
     extra.exclude: ["akkaHttp"]
     // pending: https://github.com/eed3si9n/gigahorse/issues/54
@@ -1397,19 +1390,16 @@ build += {
   ${vars.base} {
     name: "scalalib"
     uri:  ${vars.uris.scalalib-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "scalachess"
     uri:  ${vars.uris.scalachess-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "sbt-io"
     uri:  ${vars.uris.sbt-io-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     // we have to disable this early (extra.commands isn't soon enough)
     // or scalafmt will run `update` and `cloc-plugin` won't be found
@@ -1426,7 +1416,6 @@ build += {
   ${vars.base} {
     name: "argonaut-shapeless"
     uri:  ${vars.uris.argonaut-shapeless-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM"]
   }
 
@@ -1437,7 +1426,6 @@ build += {
   ${vars.base} {
     name: "coursier"
     uri:  ${vars.uris.coursier-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // no Scala.js or Scala Native plz
     extra.projects: ["jvm"]
     // these depend on Scala Native
@@ -1449,7 +1437,6 @@ build += {
   ${vars.base} {
     name: "scallop"
     uri:  ${vars.uris.scallop-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["scallopJVM"]  // no Scala.js or Scala Native plz
   }
 
@@ -1457,6 +1444,7 @@ build += {
   ${vars.base} {
     name: "nscala-time"
     uri:  ${vars.uris.nscala-time-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   // dependency of scaladex.
@@ -1465,6 +1453,7 @@ build += {
   ${vars.base} {
     name: "elastic4s"
     uri:  ${vars.uris.elastic4s-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["elastic4s-core", "elastic4s-embedded"]
     // some test code uses scala.util.parsing.json, which no longer
     // exists in the latest scala-parser-combinators
@@ -1475,6 +1464,7 @@ build += {
   ${vars.base} {
     name: "sksamuel-exts"
     uri:  ${vars.uris.sksamuel-exts-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       // reported upstream at https://github.com/sksamuel/exts/commit/5f69f7254d9ad58a94dd304a0e1cdb560486d6c2#r29458859
       "set excludeFilter in (Test, unmanagedSources) := HiddenFileFilter || \"FileWatcherTest.scala\""
@@ -1485,7 +1475,6 @@ build += {
   ${vars.base} {
     name: "akka-http-cors"
     uri:  ${vars.uris.akka-http-cors-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["akka-http-cors-bench-jmh"]
   }
 
@@ -1494,14 +1483,12 @@ build += {
   ${vars.base} {
     name: "akka-http-session"
     uri:  ${vars.uris.akka-http-session-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["core"]
   }
 
   ${vars.base} {
     name: "paradox"
     uri:  ${vars.uris.paradox-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["plugin", "themePlugin", "genericTheme"]
     check-missing: false  // ignore missing scripted-sbt
     extra.commands: ${vars.default-commands} [
@@ -1517,13 +1504,13 @@ build += {
   ${vars.base} {
     name: "akka-persistence-cassandra"
     uri:  ${vars.uris.akka-persistence-cassandra-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   // dependency of lagom
   ${vars.base} {
     name: "akka-persistence-jdbc"
     uri:  ${vars.uris.akka-persistence-jdbc-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1537,6 +1524,7 @@ build += {
   ${vars.base} {
     name: "lagom"
     uri:  ${vars.uris.lagom-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // these pull in a number of dependent projects
     extra.projects: ["server", "testkit-scaladsl"]
     extra.options: [
@@ -1556,14 +1544,13 @@ build += {
   // droppable if it acts up
   ${vars.base} {
     name: "scala-sculpt"
-    extra.sbt-version: ${vars.sbt-1-version}
     uri:  ${vars.uris.scala-sculpt-uri}
   }
 
   ${vars.base} {
     name: "singleton-ops"
     uri:  ${vars.uris.singleton-ops-uri}
-    extra.sbt-version: ${vars.sbt-version}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["singleton_opsJVM"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1576,7 +1563,6 @@ build += {
   ${vars.base} {
     name: "metrics-scala"
     uri:  ${vars.uris.metrics-scala-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["metricsAkka24"]  // our Akka version is 25
   }
 
@@ -1585,12 +1571,12 @@ build += {
   ${vars.base} {
     name: "scapegoat"
     uri:  ${vars.uris.scapegoat-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "linter"
     uri:  ${vars.uris.linter-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // test failures; see https://github.com/scala/community-builds/pull/696
     extra.test-tasks: "compile"
   }
@@ -1599,12 +1585,12 @@ build += {
     name: "scala-newtype"
     uri:  ${vars.uris.scala-newtype-uri}
     extra.exclude: ["newtypeJS", "catsTestsJS"]  // no Scala.js plz
+    extra.sbt-version: ${vars.sbt-0-13-version}
   }
 
   ${vars.base} {
     name: "fast-string-interpolator"
     uri:  ${vars.uris.fast-string-interpolator-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1616,7 +1602,6 @@ build += {
   ${vars.base} {
     name: "scalacheck-shapeless"
     uri:  ${vars.uris.scalacheck-shapeless-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "testJVM"]  // no Scala.js plz
     // weird missing self-dependency in testJVM project: "the library
     // com.github.alexarchambault#scalacheck-shapeless is not provided
@@ -1631,6 +1616,7 @@ build += {
   ${vars.base} {
     name: "curryhoward"
     uri:  ${vars.uris.curryhoward-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // I guess dbuild is getting confused by the extra _1.13?
     deps.ignore: ["com.github.alexarchambault#scalacheck-shapeless"]
     deps.inject: ${vars.base.deps.inject} [
@@ -1646,14 +1632,12 @@ build += {
   ${vars.base} {
     name: "mercator"
     uri:  ${vars.uris.mercator-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "tests"]
   }
 
   ${vars.base} {
     name: "magnolia"
     uri:  ${vars.uris.magnolia-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "examplesJVM", "tests"]
   }
 
@@ -1665,6 +1649,7 @@ build += {
   ${vars.base} {
     name: "scalasti"
     uri:  ${vars.uris.scalasti-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1680,7 +1665,6 @@ build += {
   ${vars.base} {
     name: "grizzled"
     uri:  ${vars.uris.grizzled-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1695,7 +1679,6 @@ build += {
   ${vars.base} {
     name: "classutil"
     uri:  ${vars.uris.classutil-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -1717,7 +1700,6 @@ build += {
   ${vars.base} {
     name: "spire"
     uri:  ${vars.uris.spire-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // hopefully avoid intermittent OutOfMemoryErrors during compilation
     extra.options: ["-Xmx2560m"]
     extra.projects: ["spireJVM"]  // no Scala.js please
@@ -1728,7 +1710,6 @@ build += {
   ${vars.base} {
     name: "breeze"
     uri:  ${vars.uris.breeze-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // spire moved from org.spire to org.typelevel but breeze hasn't
     // changed their dependency yet
     deps.ignore: ["org.spire-math#spire"]
@@ -1743,7 +1724,6 @@ build += {
   ${vars.base} {
     name: "multibot"
     uri:  ${vars.uris.multibot-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // linter isn't essential to the build
     deps.ignore: ["org.psywerx.hairyfotr#linter"]
     check-missing: false
@@ -1758,6 +1738,7 @@ build += {
   ${vars.base} {
     name: "scalameta"
     uri:  ${vars.uris.scalameta-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // allow building on JDK 11
     extra.options: ["-Dscalameta.allow-any-jdk"]
     extra.projects: [
@@ -1779,14 +1760,12 @@ build += {
   ${vars.base} {
     name: "jsoniter-scala"
     uri:  ${vars.uris.jsoniter-scala-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["jsoniter-scala-benchmark"]
   }
 
   ${vars.base} {
     name: "scalatex"
     uri:  ${vars.uris.scalatex-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: [
       "scalatexSbtPlugin"  // we never build sbt plugins
       "site", "readme", "scrollspy"  // these use Scala.js
@@ -1799,12 +1778,12 @@ build += {
   ${vars.base} {
     name: "better-monadic-for"
     uri:  ${vars.uris.better-monadic-for-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   ${vars.base} {
     name: "metaconfig"
     uri:  ${vars.uris.metaconfig-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["metaconfig-hoconJVM", "metaconfig-typesafe-config"]  // no Scala.js plz
     // I guess dbuild is getting confused by the extra _1.13?
     deps.ignore: ["com.github.alexarchambault#scalacheck-shapeless"]
@@ -1826,7 +1805,6 @@ build += {
   ${vars.base} {
     name: "scalafmt"
     uri:  ${vars.uris.scalafmt-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["coreJVM", "cli", "tests"]
     extra.options: [
       "-Dbintray.user=dummy", "-Dbintray.pass=dummy"
@@ -1846,7 +1824,6 @@ build += {
   ${vars.base} {
     name: "coursier-small"
     uri:  ${vars.uris.coursier-small-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // reported upstream: https://github.com/olafurpg/coursier-small/issues/8
     extra.commands: ${vars.default-commands} [
       "set excludeFilter in (Test, unmanagedSources) in small := HiddenFileFilter || \"CoursierSmallSuite.scala\""
@@ -1859,7 +1836,6 @@ build += {
   ${vars.base} {
     name: "scalafix"
     uri:  ${vars.uris.scalafix-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: ["docs"]
     extra.commands: ${vars.default-commands} [
       // java.lang.IllegalStateException: unable to auto-detect semanticdb-scalac compiler plugin
@@ -1878,7 +1854,6 @@ build += {
   ${vars.base} {
     name: "portable-scala-reflect"
     uri:  ${vars.uris.portable-scala-reflect-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["portable-scala-reflectJVM"]  // no Scala.js plz
   }
 
@@ -1886,6 +1861,7 @@ build += {
   ${vars.base} {
     name: "classpath-shrinker"
     uri:  ${vars.uris.classpath-shrinker-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
     ]
@@ -1903,7 +1879,6 @@ build += {
   ${vars.base} {
     name: "euler"
     uri:  ${vars.uris.euler-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // some solutions are heap-hungry. avoiding parallel execution prevents
     // intermittent OOM issue
     extra.commands: ${vars.default-commands} [
@@ -1920,7 +1895,6 @@ build += {
   ${vars.base} {
     name: "airframe"
     uri:  ${vars.uris.airframe-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["projectJVM"]  // no Scala.js plz
     extra.exclude: [
       "jsonBenchmark"  // out of scope
@@ -1950,6 +1924,7 @@ build += {
   ${vars.base} {
     name: "jawn-0-10"
     uri:  ${vars.uris.jawn-0-10-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // omitted TODO: play
     // omitted: rojoma-v3, rojoma, benchmark, argonaut
     // (we have Argonaut in the community build, but it depends on jawn! dbuild
@@ -1968,6 +1943,7 @@ build += {
   ${vars.base} {
     name: "sjson-new"
     uri:  ${vars.uris.sjson-new-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: ["benchmark"]
   }
 
@@ -1976,7 +1952,6 @@ build += {
   ${vars.base} {
     name: "sbt-util"
     uri:  ${vars.uris.sbt-util-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     check-missing: false  // ignore missing scalafmt
     extra.commands: ${vars.default-commands} [
@@ -1987,7 +1962,6 @@ build += {
   ${vars.base} {
     name: "sbt-librarymanagement"
     uri:  ${vars.uris.sbt-librarymanagement-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
     // we have to disable this early (extra.commands isn't soon enough)
     // or scalafmt will run `update` and `cloc-plugin` won't be found
@@ -2066,6 +2040,7 @@ build += {
   ${vars.base} {
     name: "upickle"
     uri:  ${vars.uris.upickle-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     // no Scala.js; also only upickle no pprint
     extra.projects: ["upickleJVM"]
   }
@@ -2074,6 +2049,7 @@ build += {
   ${vars.base} {
     name: "autowire"
     uri:  ${vars.uris.autowire-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["autowireJVM"]  // no Scala.js plz
   }
 
@@ -2081,7 +2057,6 @@ build += {
   ${vars.base} {
     name: "akka-http-json"
     uri:  ${vars.uris.akka-http-json-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.exclude: [
       // we're in jawn 0.10 space because scaladex is, but circe is over in jawn 0.11 space.
       // (if it becomes important, we could have entries in both spaces.)
@@ -2111,6 +2086,7 @@ build += {
   ${vars.base} {
     name: "scaladex"
     uri:  ${vars.uris.scaladex-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // no Scala.js plz
       "sharedJS", "client"
@@ -2125,6 +2101,7 @@ build += {
   ${vars.base} {
     name: "scala-debugger"
     uri:  ${vars.uris.scala-debugger-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // no sbt plugins plz!
       "sbtScalaDebuggerPlugin"
@@ -2158,7 +2135,6 @@ build += {
   ${vars.base} {
     name: "circe"
     uri:  ${vars.uris.circe-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: [
       // easy
       "coreJVM", "numbersJVM"
@@ -2174,14 +2150,12 @@ build += {
   ${vars.base} {
     name: "boopickle"
     uri:  ${vars.uris.boopickle-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["boopickleJVM", "shapelessJVM"]  // no Scala.js, no "perftests"
   }
 
   ${vars.base} {
     name: "enumeratum"
     uri:  ${vars.uris.enumeratum-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: [
       // for some reason dbuild doesn't seem to pick up on which subprojects
       // depend on each other, so we have to list them individually (even
@@ -2212,13 +2186,13 @@ build += {
   ${vars.base} {
     name: "jawn-fs2"
     uri:  ${vars.uris.jawn-fs2-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // dependency of http4s (it's their fork of parboiled2)
   ${vars.base} {
     name: "http4s-parboiled2"
     uri:  ${vars.uris.http4s-parboiled2-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["parboiledJVM"]
   }
 
@@ -2227,7 +2201,6 @@ build += {
   ${vars.base} {
     name: "http4s"
     uri:  ${vars.uris.http4s-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.commands: ${vars.default-commands} [
       // didn't compile (October 2018), it didn't seem worth investigating, probably a specs2 change
       "set excludeFilter in (Test, unmanagedSources) in tests := HiddenFileFilter || \"UriSpec.scala\""
@@ -2264,7 +2237,6 @@ build += {
   ${vars.base} {
     name: "circe-config"
     uri:  ${vars.uris.circe-config-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   # forked (November 2017, refreshed January 2018) to remove a build.sbt thing that
@@ -2274,6 +2246,7 @@ build += {
   ${vars.base} {
     name: "pureconfig"
     uri:  ${vars.uris.pureconfig-uri}
+    extra.sbt-version: ${vars.sbt-0-13-version}
     deps.inject: ${vars.base.deps.inject} [
       // I guess dbuild is getting confused by the extra _1.13
       "com.github.alexarchambault#scalacheck-shapeless_1.13"
@@ -2289,7 +2262,6 @@ build += {
   ${vars.base} {
     name: "refined"
     uri:  ${vars.uris.refined-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // I don't see a project that aggregates just the JVM subprojects, so we name them one by one.
     // scodecJVM isn't included because the dependency wasn't found, maybe a version mismatch?
     // it's okay, we don't need to have absolutely every subproject
@@ -2306,7 +2278,6 @@ build += {
   ${vars.base} {
     name: "sttp"
     uri:  ${vars.uris.sttp-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // aggregates all JVM projects
     extra.projects: ["rootJVM"]
     extra.exclude: [
@@ -2325,7 +2296,6 @@ build += {
   ${vars.base} {
     name: "scrooge"
     uri:  ${vars.uris.scrooge-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["scrooge-core"]
     extra.commands: ${vars.default-commands} [
       "set every bintrayReleaseOnPublish := false"
@@ -2341,14 +2311,12 @@ build += {
   ${vars.base} {
     name: "scrooge-shapes"
     uri:  ${vars.uris.scrooge-shapes-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // dependency of lsp4s
   ${vars.base} {
     name: "circe-derivation"
     uri:  ${vars.uris.circe-derivation-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     // there are some others, but really just trying to get lsp4s going at the moment
     extra.projects: ["derivation", "annotations"]
   }
@@ -2372,7 +2340,6 @@ build += {
   ${vars.base} {
     name: "pascal"
     uri:  ${vars.uris.pascal-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
   }
 
   // needs its own space because:
@@ -2383,7 +2350,6 @@ build += {
   ${vars.base} {
     name: "scalaz8"
     uri:  ${vars.uris.scalaz8-uri}
-    extra.sbt-version: ${vars.sbt-1-version}
     extra.projects: ["baseJVM", "effectJVM", "metaJVM"]
   }
 


### PR DESCRIPTION
probably there are some projects that we could be building using sbt 1, but aren't.

let's find out what they are.

let's also flip the default so that sbt 1 is assumed, and a project has to explicitly request 0.13 instead.

fyi @eed3si9n 