### PR TITLE
newer coursier SHA with JDK 11 support

### DIFF
--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -35,7 +35,7 @@ vars.uris: {
   cloc-plugin-uri:                "https://github.com/SethTisue/cloc-plugin.git#dc8eaea30ad4b7ad33deed70b6fba17d4d429b0b"
   conductr-lib-uri:               "https://github.com/typesafehub/conductr-lib.git#c2e6d8634ab940155c93f6910086d95481e1d931"
   coursier-small-uri:             "https://github.com/olafurpg/coursier-small.git#0db603c5431cc61cf80f3477355d3b659b9b2801"
-  coursier-uri:                   "https://github.com/coursier/coursier.git#dbaf748fadab1937b3d4dfbfed3cc38727d45c1a"
+  coursier-uri:                   "https://github.com/coursier/coursier.git#79c26cf49ddb9eb5172ac8f82ebba06d60842f37"
   curryhoward-uri:                "https://github.com/Chymyst/curryhoward.git#6c1ea1672146a763c6657365872880152527f67d"
   decline-uri:                    "https://github.com/SethTisue/decline.git#137e7b4591f84f94b19656556a39caa38e3b262f"
   discipline-uri:                 "https://github.com/typelevel/discipline.git#824fec939f4bde3e7ae97dc90f9c891ca32e7ab7"


### PR DESCRIPTION
references https://github.com/coursier/coursier/pull/954

fyi @alexarchambault