### PR TITLE
2.12 Use alternate symbol syntax

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -731,7 +731,6 @@ build += {
   ${vars.base} {
     name: "sourcecode"
     uri:  ${vars.uris.sourcecode-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
     // no Scala.js plz
     extra.projects: ["sourcecodeJVM"]
   }
@@ -751,14 +750,6 @@ build += {
     name: "fastparse"
     uri:  ${vars.uris.fastparse-uri}
     extra.sbt-version: ${vars.sbt-0-13-version}
-    extra.projects: [
-      "fastparseJVM"   // no Scala.js plz
-      "scalaparseJVM"  // dependency of scalatex
-    ]
-    extra.commands: ${vars.default-commands} [
-      // too prone to unexplained failure
-      "set executeTests in scalaparseJVM in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-    ]
   }
 
   ${vars.base} {
@@ -1040,7 +1031,6 @@ build += {
   ${vars.base} {
     name: "scalamock"
     uri:  ${vars.uris.scalamock-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.commands: ${vars.default-commands} [
       // work around https://github.com/scala/scala-dev/issues/252 ;
       // see https://github.com/scala/community-builds/issues/434
@@ -1048,9 +1038,8 @@ build += {
     ]
     extra.projects: [
       // no Scala.js
-      "scalamock-coreJVM"
-      // dependency of github4s
-      "scalamock-scalatest-supportJVM"
+      "scalamockJVM"
+      "examplesJVM"
     ]
   }
 

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -11,8 +11,10 @@ vars.uris: {
   akka-http-session-uri:        "https://github.com/softwaremill/akka-http-session.git"
   akka-http-uri:                "https://github.com/akka/akka-http.git"
   akka-persistence-cassandra-uri: "https://github.com/scalacommunitybuild/akka-persistence-cassandra.git#community-build-2.12"  # was akka, 2a53c6a0a1f64
+  akka-more-uri:                "https://github.com/ashawley/akka.git#drop-symlit" # was akka, master
   akka-persistence-jdbc-uri:    "https://github.com/dnvriend/akka-persistence-jdbc.git"
-  akka-uri:                     "https://github.com/SethTisue/akka.git#wip-201812"
+  akka-stream-uri:              "https://github.com/ashawley/akka.git#drop-symlit" # was akka, master
+  akka-uri:                     "https://github.com/ashawley/akka.git#drop-symlit"  # was akka, v2.5.18
   algebra-uri:                  "https://github.com/typelevel/algebra.git"
   argonaut-shapeless-uri:       "https://github.com/alexarchambault/argonaut-shapeless.git"
   argonaut-uri:                 "https://github.com/argonaut-io/argonaut.git"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -3,22 +3,24 @@
 # (keeping those comments here caused too many annoying merge conflicts)
 
 vars.uris: {
-  acyclic-uri:                  "https://github.com/lihaoyi/acyclic.git"
+  acyclic-uri:                  "https://github.com/ashawley/acyclic.git#drop-symlit" # was lihaoyi, master
   airframe-uri:                 "https://github.com/wvlet/airframe.git"
   akka-contrib-extra-uri:       "https://github.com/typesafehub/akka-contrib-extra.git"
   akka-http-cors-uri:           "https://github.com/lomigmegard/akka-http-cors.git"
   akka-http-json-uri:           "https://github.com/hseeberger/akka-http-json.git"
   akka-http-session-uri:        "https://github.com/softwaremill/akka-http-session.git"
   akka-http-uri:                "https://github.com/akka/akka-http.git#6fa7fab8ee7b1"  # was master
+  akka-more-uri:                "https://github.com/akka/akka.git"
   akka-persistence-cassandra-uri: "https://github.com/scalacommunitybuild/akka-persistence-cassandra.git#community-build-2.12"  # was akka, 2a53c6a0a1f64
   akka-persistence-jdbc-uri:    "https://github.com/dnvriend/akka-persistence-jdbc.git"
+  akka-stream-uri:              "https://github.com/akka/akka.git"
   akka-uri:                     "https://github.com/akka/akka.git#v2.5.18"  # was master
   algebra-uri:                  "https://github.com/typelevel/algebra.git"
   argonaut-shapeless-uri:       "https://github.com/alexarchambault/argonaut-shapeless.git"
   argonaut-uri:                 "https://github.com/argonaut-io/argonaut.git"
   atto-uri:                     "https://github.com/tpolecat/atto.git#series/0.5.x"
   autowire-uri:                 "https://github.com/lihaoyi/autowire.git"
-  base64-uri:                   "https://github.com/marklister/base64.git"
+  base64-uri:                   "https://github.com/ashawley/base64.git#drop-symlit" # was marklister, master
   better-files-uri:             "https://github.com/pathikrit/better-files.git"
   better-monadic-for-uri:       "https://github.com/oleg-py/better-monadic-for.git"
   blaze-uri:                    "https://github.com/http4s/blaze.git#v0.14.0-M8"  # was master
@@ -37,7 +39,7 @@ vars.uris: {
   conductr-lib-uri:             "https://github.com/typesafehub/conductr-lib.git"
   coursier-uri:                 "https://github.com/coursier/coursier.git#dbaf748fadab19"  # was master
   coursier-small-uri:           "https://github.com/olafurpg/coursier-small.git"
-  curryhoward-uri:              "https://github.com/Chymyst/curryhoward.git"
+  curryhoward-uri:              "https://github.com/ashawley/curryhoward.git#drop-symlit" # was Chymyst, master
   decline-uri:                  "https://github.com/bkirwi/decline.git"
   discipline-uri:               "https://github.com/typelevel/discipline.git"
   dispatch-uri:                 "https://github.com/dispatch/reboot.git#0.14.x"
@@ -48,20 +50,20 @@ vars.uris: {
   euler-uri:                    "https://github.com/SethTisue/Project-Euler.git"
   expecty-uri:                  "https://github.com/eed3si9n/expecty.git"
   export-hook-uri:              "https://github.com/milessabin/export-hook.git"
-  fansi-uri:                    "https://github.com/lihaoyi/fansi.git"
+  fansi-uri:                    "https://github.com/ashawley/fansi.git#drop-symlit" # was lihaoyi, master
   fast-string-interpolator-uri: "https://github.com/Sizmek/fast-string-interpolator.git"
-  fastparse-uri:                "https://github.com/xuwei-k/fastparse.git#jdk11"  # was lihaoyi, master
+  fastparse-uri:                "https://github.com/ashawley/fastparse.git#drop-symlit"  # was lihaoyi, master
   fs2-uri:                      "https://github.com/functional-streams-for-scala/fs2.git#series/1.0"
   genjavadoc-uri:               "https://github.com/lightbend/genjavadoc.git"
-  geny-uri:                     "https://github.com/lihaoyi/geny.git"
+  geny-uri:                     "https://github.com/ashawley/geny.git#drop-symlit" # was lihaoyi, master
   gigahorse-uri:                "https://github.com/eed3si9n/gigahorse.git#0.3.x"
   giter8-uri:                   "https://github.com/foundweekends/giter8.git"
   github4s-uri:                 "https://github.com/47deg/github4s.git"
-  grizzled-uri:                 "https://github.com/bmc/grizzled-scala.git#316d56d87baa476"  # was master
+  grizzled-uri:                 "https://github.com/ashawley/grizzled-scala.git#drop-symlit"  # was bmc, 316d56d87baa476
   http4s-parboiled2-uri:        "https://github.com/http4s/parboiled2.git"
   http4s-uri:                   "https://github.com/http4s/http4s.git"
   http4s-websocket-uri:         "https://github.com/http4s/http4s-websocket.git"
-  jackson-module-scala-uri:     "https://github.com/FasterXML/jackson-module-scala.git"
+  jackson-module-scala-uri:     "https://github.com/ashawley/jackson-module-scala.git#drop-symlit" # was FasterXML, master
   jawn-0-10-uri:                "https://github.com/scalacommunitybuild/jawn.git#community-build-2.12-0.10"  # was non, v0.10.4
   jawn-0-11-uri:                "https://github.com/non/jawn.git"
   jawn-fs2-uri:                 "https://github.com/rossabaker/jawn-fs2.git"
@@ -78,7 +80,7 @@ vars.uris: {
   machinist-uri:                "https://github.com/typelevel/machinist.git"
   macro-compat-uri:             "https://github.com/milessabin/macro-compat.git"
   macro-paradise-uri:           "https://github.com/scalacommunitybuild/paradise.git#community-build-2.12"
-  magnolia-uri:                 "https://github.com/propensive/magnolia.git#0029616d4a5c6d117b4c7d"  # was master
+  magnolia-uri:                 "https://github.com/ashawley/magnolia.git#drop-symlit"  # was propensive, 0029616d4a5c6d117b4c7d
   mercator-uri:                 "https://github.com/propensive/mercator.git"
   metaconfig-uri:               "https://github.com/olafurpg/metaconfig.git"
   metrics-scala-uri:            "https://github.com/erikvanoosten/metrics-scala.git"
@@ -95,7 +97,7 @@ vars.uris: {
   parboiled-uri:                "https://github.com/sirthias/parboiled.git"
   parboiled2-uri:               "https://github.com/sirthias/parboiled2.git#release-2.1"
   pascal-uri:                   "https://github.com/TomasMikula/pascal.git"
-  pcplod-uri:                   "https://github.com/scalacommunitybuild/pcplod.git#community-build-2.12"  # was ensime, master
+  pcplod-uri:                   "https://github.com/ashawley/pcplod.git#drop-symlit"  # was ensime, master
   perfolation-uri:              "https://github.com/outr/perfolation.git"
   playframework-uri:            "https://github.com/SethTisue/playframework.git#community-build-2.12"  # was playframework, master
   play-doc-uri:                 "https://github.com/playframework/play-doc.git"
@@ -103,7 +105,7 @@ vars.uris: {
   play-webgoat-uri:             "https://github.com/playframework/play-webgoat.git"
   play-ws-uri:                  "https://github.com/SethTisue/play-ws.git#community-build-2.12"  # was playframework, v2.0.0-M6 or master
   portable-scala-reflect-uri:   "https://github.com/portable-scala/portable-scala-reflect.git"
-  pprint-uri:                   "https://github.com/xuwei-k/pprint.git#jdk11"  # was lihaoyi, master
+  pprint-uri:                   "https://github.com/ashawley/pprint.git#drop-symlit" # was lihaoyi, master
   pureconfig-uri:               "https://github.com/scalacommunitybuild/pureconfig.git#community-build-2.12"  # was pureconfig, master
   refined-uri:                  "https://github.com/fthomas/refined.git"
   sbinary-uri:                  "https://github.com/sbt/sbinary.git"
@@ -124,13 +126,13 @@ vars.uris: {
   scala-js-uri:                 "https://github.com/scala-js/scala-js.git"
   scala-logging-uri:            "https://github.com/lightbend/scala-logging.git"
   scala-newtype-uri:            "https://github.com/estatico/scala-newtype.git"
-  scala-parser-combinators-uri: "https://github.com/scala/scala-parser-combinators.git#1.1.x"
+  scala-parser-combinators-uri: "https://github.com/ashawley/scala-parser-combinators.git#1.1-scala-2.12-dropsymlit"
   scala-partest-uri:            "https://github.com/scala/scala-partest.git#1.1.x"
   scala-records-uri:            "https://github.com/scala-records/scala-records.git"
   scala-refactoring-uri:        "https://github.com/scala-ide/scala-refactoring.git"
   scala-sculpt-uri:             "https://github.com/lightbend/scala-sculpt.git"
   scala-ssh-uri:                "https://github.com/sirthias/scala-ssh.git"
-  scala-stm-uri:                "https://github.com/nbronson/scala-stm.git"
+  scala-stm-uri:                "https://github.com/ashawley/scala-stm.git#drop-symlit" # was nbronson, master
   scala-swing-uri:              "https://github.com/scala/scala-swing.git#2.0.x"
   scala-xml-quote-uri:          "https://github.com/allanrenucci/scala-xml-quote.git#bintray"
   scalacheck-shapeless-uri:     "https://github.com/alexarchambault/scalacheck-shapeless.git"
@@ -144,14 +146,14 @@ vars.uris: {
   scalalib-uri:                 "https://github.com/ornicar/scalalib.git"
   scalameta-uri:                "https://github.com/scalacommunitybuild/scalameta.git#community-build-2.12"  # was retronym/topic/v4.0.0-M11-2.12.7-adapt, before that was scalameta/v4.0.0-M11, before that was scalameta/master
   scalameter-uri:               "https://github.com/scalameter/scalameter.git"
-  scalamock-uri:                "https://github.com/scalacommunitybuild/ScalaMock.git#community-build-2.12"  # was paulbutcher, 1e84ffe (before that, was master)
+  scalamock-uri:                "https://github.com/ashawley/ScalaMock.git#drop-symlit"  # was paulbutcher, master
   scalapb-uri:                  "https://github.com/scalapb/ScalaPB.git"
   scalaprops-uri:               "https://github.com/scalaprops/scalaprops.git"
   scalariform-uri:              "https://github.com/scala-ide/scalariform.git"
   scalasti-uri:                 "https://github.com/scalacommunitybuild/scalasti.git#community-build-2.12"  # was bmc, release-2.1.4
   scalastyle-uri:               "https://github.com/scalastyle/scalastyle.git"
-  scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"
-  scalatest-uri:                "https://github.com/scalacommunitybuild/scalatest.git#community-build-2.12"  # was scalatest, 3.0.x
+  scalatags-uri:                "https://github.com/ashawley/scalatags.git#drop-symlit" # was lihaoyi, master
+  scalatest-uri:                "https://github.com/ashawley/scalatest.git#3.0-scala-2.12-drop-symlit"  # was scalatest, 3.0.x
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"
   scalaz-uri:                   "https://github.com/scalaz/scalaz.git#series/7.2.x"
   scalaz8-uri:                  "https://github.com/scalaz/scalaz.git#4d75c2b"  # was series/8.0.x
@@ -165,26 +167,27 @@ vars.uris: {
   scribe-uri:                   "https://github.com/outr/scribe.git"
   scrooge-uri:                  "https://github.com/twitter/scrooge.git"
   scrooge-shapes-uri:           "https://github.com/stripe/scrooge-shapes.git"
-  shapeless-uri:                "https://github.com/milessabin/shapeless.git"
+  shapeless-uri:                "https://github.com/ashawley/shapeless.git#drop-symlit" # was milessabin, master
   silencer-uri:                 "https://github.com/ghik/silencer.git"
   simulacrum-uri:               "https://github.com/mpilquist/simulacrum.git"
   singleton-ops-uri:            "https://github.com/fthomas/singleton-ops.git"
   sjson-new-uri:                "https://github.com/eed3si9n/sjson-new.git"
   sksamuel-exts-uri:            "https://github.com/sksamuel/exts.git"
   slick-uri:                    "https://github.com/slick/slick.git"
-  sourcecode-uri:               "https://github.com/scalacommunitybuild/sourcecode.git#community-build-2.12"  # was lihaoyi, master
-  specs2-uri:                   "https://github.com/etorreborre/specs2.git"
+  sourcecode-uri:               "https://github.com/ashawley/sourcecode.git#drop-symlit" # was lihaoyi, master
+  specs2-more-uri:              "https://github.com/ashawley/specs2.git#drop-symlit" # was etorreborre, master
+  specs2-uri:                   "https://github.com/ashawley/specs2.git#drop-symlit" # was etorreborre, master
   spire-uri:                    "https://github.com/non/spire.git"
   spray-json-uri:               "https://github.com/spray/spray-json.git"
   ssl-config-uri:               "https://github.com/lightbend/ssl-config.git"
   sttp-uri:                     "https://github.com/softwaremill/sttp.git"
   tut-uri:                      "https://github.com/tpolecat/tut.git#series/0.6.x"
-  twirl-uri:                    "https://github.com/playframework/twirl.git"
+  twirl-uri:                    "https://github.com/ashawley/twirl.git#drop-symlit" # was playframework, master
   twitter-util-uri:             "https://github.com/twitter/util.git#ce41d10ef2cd72d25"  # was develop
   twotails-uri:                 "https://github.com/wheaties/TwoTails.git"
   unfiltered-uri:               "https://github.com/unfiltered/unfiltered.git#0.10.x"
   upickle-uri:                  "https://github.com/scalacommunitybuild/upickle-pprint.git#community-build-2.12"
-  utest-uri:                    "https://github.com/lihaoyi/utest.git"
+  utest-uri:                    "https://github.com/ashawley/utest.git#drop-symlit" # was lihaoyi, master
   wartremover-uri:              "https://github.com/wartremover/wartremover.git"
   zinc-uri:                     "https://github.com/sbt/zinc.git#v1.2.1"
 }

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -72,7 +72,7 @@ vars.uris: {
   kittens-uri:                  "https://github.com/typelevel/kittens.git"
   kxbmap-configs-uri:           "https://github.com/scalacommunitybuild/configs.git#community-build-2.12"  # was kxbmap, master
   lagom-uri:                      "https://github.com/lagom/lagom.git#3fbbc22ed8a41fdb3d75e3e3570bcdf9e38545fa"
-  lift-json-uri:                "https://github.com/lift/framework.git"
+  lift-json-uri:                "https://github.com/ashawley/framework.git#drop-symlit" # was lift, master
   lightbend-emoji-uri:          "https://github.com/lightbend/lightbend-emoji.git"
   linter-uri:                   "https://github.com/hairyfotr/linter.git"
   log4s-uri:                    "https://github.com/Log4s/log4s.git"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -175,7 +175,7 @@ vars.uris: {
   specs2-more-uri:              "https://github.com/ashawley/specs2.git#drop-symlit" # was etorreborre, master
   specs2-uri:                   "https://github.com/ashawley/specs2.git#drop-symlit" # was etorreborre, master
   spire-uri:                    "https://github.com/non/spire.git"
-  spray-json-uri:               "https://github.com/spray/spray-json.git"
+  spray-json-uri:               "https://github.com/ashawley/spray-json.git#drop-symlit" # was spray, master
   ssl-config-uri:               "https://github.com/lightbend/ssl-config.git"
   sttp-uri:                     "https://github.com/softwaremill/sttp.git"
   tut-uri:                      "https://github.com/tpolecat/tut.git#series/0.6.x"


### PR DESCRIPTION
Previously, in #824:

> There's a proposal to deprecate symbol literals in 2.13, but not to drop them. So this is just an exploratory branch with no intent to merge in 2.13.
>
> In preparation for dropping after 2.13, would it be possible to see what this branch breaks in the community build? I predict since ScalaTest uses symbols and is a root dependency in the ecosystem, that not much of the question would be answered, but I figure it's worth a shot of letting the community build explode once and then inspecting the wreckage for clues.
>
> Also, the branch introduces a new symbol shorthand syntax (sym"foo"), see scala/scala#7495, which no projects will be using, but it would will be good to have community build double-duty check if it introduces problems.

I toyed around with the community build on my own and found that 2.13 didn't offer a lot of feedback.  It's still a work in progress until 2.13.0 is released.  It seems 2.12 might be a better place to experiment.

For 2.12, I've tried dropping symbol literals from the compiler in https://github.com/scala/scala/pull/7585.  Because this change touches a lot of the ecosystem, I discovered I had to change the dbuild configs and fork a number of community libraries.  