### PR TITLE
Disable Scala.js' `linker` project.

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -461,7 +461,8 @@ build += {
       "-Xmx2048m"
     ]
     // not really sure how this list was arrived at
-    extra.projects: ["io", "logging", "linker", "testSuite"]
+    // "linker" was disabled for 2.13.x because it requires parallel collections
+    extra.projects: ["io", "logging", "testSuite"]
     extra.commands: ${vars.default-commands} [
       // - We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
       //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects


### PR DESCRIPTION
It requires the parallel collections, which are not yet available for 2.13.x.

This should allow scala-js to successfully complete, now. We've updated Scala.js' `master` to work with the latest 2.13.x nightly.