### PR TITLE
unfork Akka for 2.13

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -488,8 +488,15 @@ build += {
     ]
   }
 
-  // 2.13: we're forked, and the fork is behind what we use in 2.12,
-  // but we should probably just leave it alone until the Akka team publishes for 2.13.0-M5
+  // frozen (January 2019) at v2.5.20.  this repo is volatile (very
+  // frequent commits) and when it needs to be rebuilt, the testing
+  // takes a long time (especially akka-more) and the downstream
+  // rebuilding takes a long time too.  so in general we want to
+  // freeze at a tag (preferably) or SHA (if we must)
+  // also forked (January 2019), based off v2.5.20, for JDK 11 friendliness,
+  // see https://github.com/scala/community-builds/pull/832 ; and also
+  // because of January 2019 changes to ScalaTest on 3.0.x branch that are
+  // source-incompatible when seen from Java (Akka uses ScalaTest from Java)
   ${vars.base} {
     name: "akka"
     uri:  ${vars.uris.akka-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -12,7 +12,7 @@ vars.uris: {
   akka-http-uri:                "https://github.com/scalacommunitybuild/akka-http.git#community-build-2.12"  # was akka, master
   akka-persistence-cassandra-uri: "https://github.com/scalacommunitybuild/akka-persistence-cassandra.git#community-build-2.12"  # was akka, 2a53c6a0a1f64
   akka-persistence-jdbc-uri:    "https://github.com/dnvriend/akka-persistence-jdbc.git"
-  akka-uri:                     "https://github.com/SethTisue/akka.git#community-build-2.13"  # was MasseGuillaume, 2.13.0-M4
+  akka-uri:                     "https://github.com/scalacommunitybuild/akka.git#community-build-2.12"
   algebra-uri:                  "https://github.com/typelevel/algebra.git"
   argonaut-shapeless-uri:       "https://github.com/alexarchambault/argonaut-shapeless.git"
   argonaut-uri:                 "https://github.com/argonaut-io/argonaut.git"

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -34,7 +34,6 @@ object SuccessReport {
 
   val expectedToFail = Set[String](
     "airframe",
-    "akka",
     "base64",
     "blaze",  // as of Feb 1, doesn't look a 2.13 upgrade has been attempted
     "boopickle",


### PR DESCRIPTION
or rather, use the same fork we use in 2.12