### PR TITLE
Add comma for projects in run.sh usage

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,7 @@ dbuild_args=""
 Usage(){
     ex=$1
     shift
-echo >&2 "Usage: `basename $0` [<options>] [projects...]
+echo >&2 "Usage: `basename $0` [<options>] [project,projects...]
 Function: Downloads dbuild if not already installed locally and runs dbuild with defined options.
 
 Options:


### PR DESCRIPTION
I keep forgetting that the syntax for projects in dbuild is comma separation and not the usual space separated arguments.  This is quixotic on my part, but I'm hoping that adding it to the top of the usage section helps me remind me, since I keep missing the "comma"-clue at the bottom of the usage in the "Examples" section.