### PR TITLE
2.13: re-enable linker subproject in scala-js

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -443,8 +443,7 @@ build += {
       "-Xmx2048m"
     ]
     // not really sure how this list was arrived at
-    // "linker" was disabled for 2.13.x because it requires parallel collections
-    extra.projects: ["io", "logging", "testSuite"]
+    extra.projects: ["io", "logging", "testSuite", "linker"]
     extra.commands: ${vars.default-commands} [
       // - We disable source map tests to save ourselves a `npm install source-map-support` on the workers.
       //   Although only `testSuite` actually has tests, dbuild will try to run the tests for all projects


### PR DESCRIPTION
now that scala-parallel-collections are ported to new collections

sequel to #829 

/cc @sjrd 