### PR TITLE
Remove jsoniter-scala from the "expected to fail" list

### DIFF
--- a/report/Report.scala
+++ b/report/Report.scala
@@ -46,7 +46,6 @@ object SuccessReport {
     "grizzled",
     "http4s-parboiled2",
     "jawn-0-10",
-    "jsoniter-scala",  // some minor collections ordering thing?
     "kafka",  // doesn't look a 2.13 upgrade has been attempted
     "lift-json",
     "linter",


### PR DESCRIPTION
Last builds for 2.13.x are successful for jsoniter-scala:
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/1786/console
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/306/console