### PR TITLE
2.11 (JDK 8 only): add scala-collection-compat

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -70,7 +70,7 @@ vars: {
   // tracking upstream (the ideal)
   akka-ref                     : "akka/akka.git#release-2.3"
   scala-async-ref              : "scala/scala-async.git#2.11.x"  // master dropped 2.11 support
-  scala-parser-combinators-ref : "scala/scala-parser-combinators.git#1.0.x"
+  scala-parser-combinators-ref : "scala/scala-parser-combinators.git#1.1.x"
   scala-partest-ref            : "scala/scala-partest.git#1.0.x"
   scala-partest-interface-ref  : "scala/scala-partest-interface.git"
   scala-xml-ref                : "scala/scala-xml.git"

--- a/common.conf
+++ b/common.conf
@@ -76,6 +76,7 @@ vars: {
   scala-xml-ref                : "scala/scala-xml.git"
   scala-swing-ref              : "scala/scala-swing.git#2.0.x"
   scala-records-ref            : "scala-records/scala-records.git"
+  scala-collection-compat-ref  : "scala/scala-collection-compat.git"
   twitter-util-ref             : "twitter/util.git#302235a473d20735e5327d785e19b0f489b4a59f"  // freeze at November 2016 commit before move to ScalaTest 3.0
   // freeze before December 2016 commit that requires newer json4s (which we have frozen)
   jawn-ref                     : "non/jawn.git#8534fafa1d8d6930f1187aa1217b2c309b387017"
@@ -339,6 +340,13 @@ build += {
     name: "scala-records"
     uri: "https://github.com/"${vars.scala-records-ref}
     extra.exclude: ["coreJS"]
+  }
+
+  ${vars.base} {
+    name: "scala-collection-compat"
+    uri: "https://github.com/"${vars.scala-collection-compat-ref}
+    extra.sbt-version: "1.2.8"
+    extra.projects: ["compat211"]  // no Scala.js or Scalafix rules plz
   }
 
   ${vars.base} {


### PR DESCRIPTION
we aren't normally adding stuff to the 2.11 community build anymore,
but this seems worth making an exception for