### PR TITLE
ignore sttp dependency on scala-clippy

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2370,6 +2370,10 @@ build += {
       // significant. it's fine, we don't need to have every last subproject
       "monix", "okhttpBackendMonix", "asyncHttpClientBackendMonix"
     ]
+    // ignore missing scala-clippy (a failed attempt to add scala-clippy to the
+    // community build is at https://github.com/scala/community-builds/pull/871)
+    check-missing: false
+    deps.ignore: ["com.softwaremill.clippy#plugin"]
   }
 
   // dependency of scrooge-shapes.


### PR DESCRIPTION
#871 didn't work out. if this doesn't work out either, I'll freeze sttp at an older commit before the scala-clippy dependency was added.

but hopefully this will work out.

/cc @adamw