### PR TITLE
Unfreeze jsoniter-scala

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1790,9 +1790,7 @@ build += {
     ]
   }
 
-  // dependency of scaladex (via akka-http-json);
-  // frozen (March 2019) at a March 2019 commit before a source-incompatible
-  // change that broke akka-http-json
+  // dependency of scaladex (via akka-http-json)
   ${vars.base} {
     name: "jsoniter-scala"
     uri:  ${vars.uris.jsoniter-scala-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -67,7 +67,7 @@ vars.uris: {
   jawn-0-11-uri:                "https://github.com/typelevel/jawn.git"
   jawn-fs2-uri:                 "https://github.com/rossabaker/jawn-fs2.git"
   json4s-uri:                   "https://github.com/json4s/json4s.git#3.6"
-  jsoniter-scala-uri:           "https://github.com/plokhotnyuk/jsoniter-scala.git#8df8df2f7397e1a18251e"  # was master
+  jsoniter-scala-uri:           "https://github.com/plokhotnyuk/jsoniter-scala.git"
   kafka-uri:                    "https://github.com/ennru/kafka.git#build-with-sbt"
   kind-projector-uri:           "https://github.com/non/kind-projector.git"
   kittens-uri:                  "https://github.com/typelevel/kittens.git"


### PR DESCRIPTION
Now akka-http-json is compatible with the master branch of jsoniter-scala:
https://github.com/hseeberger/akka-http-json/commit/55a9f547ada9c6f68c8d18e4831011dcc36881c0