### PR TITLE
2.13.0-RC1 branch from ashawley/scala-xml

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -174,8 +174,6 @@ build += {
 
   projects: [
 
-  // forked (February 2019) to adapt to scala/scala#7624
-  // 2.13: forked for 2.13.0-RC1 compat, we should be able to unfork once we publish for RC1
   ${vars.base} {
     name: "scala-xml"
     uri:  ${vars.uris.scala-xml-uri}

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -139,7 +139,7 @@ vars.uris: {
   scala-stm-uri:                "https://github.com/nbronson/scala-stm.git"
   scala-swing-uri:              "https://github.com/scala/scala-swing.git#work"
   scala-xml-quote-uri:          "https://github.com/allanrenucci/scala-xml-quote.git#bintray"
-  scala-xml-uri:                "https://github.com/scalacommunitybuild/scala-xml.git#community-build-2.13"
+  scala-xml-uri:                "https://github.com/ashawley/scala-xml.git#2.13.0-RC1" # was scala, master
   scalacheck-shapeless-uri:     "https://github.com/alexarchambault/scalacheck-shapeless.git"
   scalacheck-uri:               "https://github.com/scalacommunitybuild/scalacheck.git#community-build-2.13"  # was rickynils, master; was ricknyils, 1.14.0_sonatype
   scalachess-uri:               "https://github.com/ornicar/scalachess.git"


### PR DESCRIPTION
Want to test updates to scala-xml for 2.13.0-RC1.  

This fork also includes the current changes on master.