### PR TITLE
http4s-websocket is an archived project

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1250,13 +1250,6 @@ build += {
     extra.exclude: ["coreJS", "testingJS"]
   }
 
-  ${vars.base} {
-    name: "http4s-websocket"
-    uri:  ${vars.uris.http4s-websocket-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
-    extra.projects: ["http4sWebsocketJVM"]  // no Scala.js plz
-  }
-
   // frozen (February 2019) at v0.14.0-M12 tag since that's the version http4s wants
   ${vars.base} {
     name: "blaze"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -62,7 +62,6 @@ vars.uris: {
   grizzled-uri:                 "https://github.com/bmc/grizzled-scala.git#316d56d87baa476"  # was master
   http4s-parboiled2-uri:        "https://github.com/http4s/parboiled2.git"
   http4s-uri:                   "https://github.com/SethTisue/http4s.git#kind-projector-org-change"  # was http4s, master
-  http4s-websocket-uri:         "https://github.com/http4s/http4s-websocket.git"
   jackson-module-scala-uri:     "https://github.com/FasterXML/jackson-module-scala.git"
   jawn-0-10-uri:                "https://github.com/scalacommunitybuild/jawn.git#community-build-2.12-0.10"  # was non, v0.10.4
   jawn-0-11-uri:                "https://github.com/typelevel/jawn.git"


### PR DESCRIPTION
http4s/http4s ingested the interesting parts of this, and http4s/blaze dropped it as a dependency.  This repo isn't being maintained anymore.