### PR TITLE
try fix sttp build

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2392,8 +2392,9 @@ build += {
     deps.ignore: ["org.spire-math#kind-projector"]
     deps.inject: ${vars.base.deps.inject} ["org.typelevel#kind-projector"]
     extra.commands: ${vars.default-commands} [
-      "removeDependency org.spire-math kind-projector"
       "removeDependency org.scalamacros paradise"
+      "removeDependency org.spire-math kind-projector"
+      """set libraryDependencies in ThisBuild += compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0")"""
     ]
   }
 

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2384,11 +2384,13 @@ build += {
       "scalaz", "zio", "asyncHttpClientBackendZio"
     ]
     // kind-projector org change
+    // TODO remove kind-projector and macro-paradise workarounds https://github.com/softwaremill/sbt-softwaremill/pull/8
     check-missing: false
     deps.ignore: ["org.spire-math#kind-projector"]
     deps.inject: ${vars.base.deps.inject} ["org.typelevel#kind-projector"]
     extra.commands: ${vars.default-commands} [
       "removeDependency org.spire-math kind-projector"
+      "removeDependency org.scalamacros paradise"
     ]
   }
 


### PR DESCRIPTION
`sttp` depends on `sbt-softwaremill` plugin. `sbt-softwaremill` add macro-paradise dependency. 

- https://github.com/softwaremill/sbt-softwaremill/blob/b66791e56d39fab0faf325d9e2266f266d37bed1/src/main/scala/com/softwaremill/SbtSoftwareMill.scala#L143
- https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/2066/

```
[sttp] [error] coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[sttp] [error]     org.scalamacros:paradise_2.13.0-pre-4b38725:2.1.1:
[sttp] [error]         not found:
[sttp] [error]             /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/sttp-bd5460df367f59bd322e6f6bae8beb08e9a6e8a3/.dbuild/local-repo/0/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             /home/jenkins/workspace/scala-2.13.x-integrate-community-build/./target-0.9.16/project-builds/sttp-bd5460df367f59bd322e6f6bae8beb08e9a6e8a3/.dbuild/local-repo/0/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             /home/jenkins/.ivy2/local/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild-ivy/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild-unchecked/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/scala-integration/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error] (jsonCommon / coursierResolutions) coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[sttp] [error]     org.scalamacros:paradise_2.13.0-pre-4b38725:2.1.1:
[sttp] [error]         not found:
[sttp] [error]             /home/jenkins/workspace/scala-2.13.x-integrate-community-build/target-0.9.16/project-builds/sttp-bd5460df367f59bd322e6f6bae8beb08e9a6e8a3/.dbuild/local-repo/0/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             /home/jenkins/workspace/scala-2.13.x-integrate-community-build/./target-0.9.16/project-builds/sttp-bd5460df367f59bd322e6f6bae8beb08e9a6e8a3/.dbuild/local-repo/0/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             /home/jenkins/.ivy2/local/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild-ivy/org.scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/ivys/ivy.xml
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/dbuild-unchecked/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
[sttp] [error]             https://scala-ci.typesafe.com/artifactory/scala-integration/org/scalamacros/paradise_2.13.0-pre-4b38725/2.1.1/paradise_2.13.0-pre-4b38725-2.1.1.pom
```