### PR TITLE
Update PureConfig config to use the official repo

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2277,14 +2277,9 @@ build += {
     uri:  ${vars.uris.circe-config-uri}
   }
 
-  # forked (November 2017, refreshed January 2018) to remove a build.sbt thing that
-  # adds Ammonite, because it isn't a true dependency and we don't want the complication
-  # of Ammonite's own dependency tree (in particular, the jawn versions conflict).
-  # plus in September 2018 we pulled Ammonite from the community build entirely
   ${vars.base} {
     name: "pureconfig"
     uri:  ${vars.uris.pureconfig-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
     deps.inject: ${vars.base.deps.inject} [
       // I guess dbuild is getting confused by the extra _1.13
       "com.github.alexarchambault#scalacheck-shapeless_1.13"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -103,7 +103,7 @@ vars.uris: {
   playframework-uri:            "https://github.com/playframework/playframework.git#2.7.x"
   portable-scala-reflect-uri:   "https://github.com/portable-scala/portable-scala-reflect.git"
   pprint-uri:                   "https://github.com/lihaoyi/pprint.git"
-  pureconfig-uri:               "https://github.com/scalacommunitybuild/pureconfig.git#community-build-2.12"  # was pureconfig, master
+  pureconfig-uri:               "https://github.com/pureconfig/pureconfig.git"
   refined-uri:                  "https://github.com/fthomas/refined.git"
   sbinary-uri:                  "https://github.com/sbt/sbinary.git"
   sbt-io-uri:                   "https://github.com/sbt/io.git#v1.2.1"


### PR DESCRIPTION
We removed Ammonite from our build quite some time ago, so there shouldn't be a problem with using the official repo directly now. Our builds on `master` rarely fail and when they do it's not because of compilation or unit test failures, so it should also be safe to use the `master` branch.