### PR TITLE
Bump scala to 06392a5

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ export LANG="en_US.UTF-8"
 export HOME="$(pwd)"
 
 # Defaults
-scala_version_default="2.13.0-pre-2ef2f9f"  # May 9
+scala_version_default="2.13.0-pre-06392a5"  # May 14 -- RC2 candidate?
 scala_version="$scala_version_default"
 root_dir=$(pwd)
 config_dir="configs"


### PR DESCRIPTION
Merge after:

 - [x] scala/scala#8049 is merged, and
 - [x] https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/scala-compiler/2.13.0-pre-06392a5/ exists (after Travis has [published it](https://travis-ci.org/scala/scala/jobs/532100381))