### PR TITLE
[WIP] use ScalaTest 3.1 branch

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -206,13 +206,26 @@ build += {
   }
 
   // see also scalatest-tests
-  // forked for: build tweak, JDK 11 friendliness, comment out a test
-  // fork refreshed (from 3.0.x branch) January 2019
   ${vars.base} {
     name: "scalatest"
     uri:  ${vars.uris.scalatest-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.projects: ["scalatest", "scalactic"]
+  }
+
+  ${vars.base} {
+    name: "scalatestplus-junit"
+    uri:  ${vars.uris.scalatestplus-junit-uri}
+  }
+
+  ${vars.base} {
+    name: "scalatestplus-testng"
+    uri:  ${vars.uris.scalatestplus-testng-uri}
+  }
+
+  ${vars.base} {
+    name: "scalatestplus-scalacheck"
+    uri:  ${vars.uris.scalatestplus-scalacheck-uri}
+    extra.projects: ["scalatestPlusScalaCheckJVM"]
   }
 
   ${vars.base} {

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -227,6 +227,11 @@ build += {
     name: "scalatestplus-scalacheck"
     uri:  ${vars.uris.scalatestplus-scalacheck-uri}
     extra.projects: ["scalatestPlusScalaCheckJVM"]
+    // scala.MatchError: ff6da566+20190524-1028-SNAPSHOT (of class java.lang.String)
+    //   at com.typesafe.dbuild.project.build.LocalBuildRunner$.prepareDepsArtifacts(LocalBuildRunner.scala:106)
+    extra.settings: ${vars.base.extra.settings} [
+      "version in ThisBuild := \"1.0.0\""
+    ]
   }
 
   ${vars.base} {

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -504,14 +504,8 @@ build += {
     extra.exclude: [
       // we already built these above
       "scalatest", "scalactic", "scalacticMacro"
-      // no Scala.js plz
-      "commonTestJS", "examplesJS", "scalacticJS", "scalacticMacroJS", "scalacticTestJS"
-      "scalatestAppJS", "scalatestJS", "scalatestTestJS"
-      // or Dotty
-      "scalatestTestDotty", "scalacticTestDotty", "commonTestDotty", "scalatestDotty", "scalacticDotty"
-      // or Scala Native
-      "scalatestAppNative", "scalacticTestNative", "scalatestTestNative", "commonTestNative",
-      "scalatestNative", "scalacticNative", "scalacticMacroNative"
+      // out of scope
+      "*JS", "*Native", "*Dotty"
       // [scalatest-tests] [info] *** 5 SUITES ABORTED ***
       // [scalatest-tests] [info] *** 29 TESTS FAILED ***
       // (not reinvestigated in a long time)

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -497,20 +497,24 @@ build += {
   }
 
   // this is almost 1M lines of code, but it needn't be green (or be compiled at all)
-  // for dependent projects to proceed, so let's keep it separate.  forked (December 2017)
-  // because of trouble with scalacticMacro -- the latter has publishing disabled
+  // for dependent projects to proceed, so let's keep it separate
   ${vars.base} {
     name: "scalatest-tests"
     uri:  ${vars.uris.scalatest-uri}
-    extra.sbt-version: ${vars.sbt-0-13-version}
     extra.exclude: [
       // we already built these above
       "scalatest", "scalactic", "scalacticMacro"
       // no Scala.js plz
       "commonTestJS", "examplesJS", "scalacticJS", "scalacticMacroJS", "scalacticTestJS"
       "scalatestAppJS", "scalatestJS", "scalatestTestJS"
+      // or Dotty
+      "scalatestTestDotty", "scalacticTestDotty", "commonTestDotty", "scalatestDotty", "scalacticDotty"
+      // or Scala Native
+      "scalatestAppNative", "scalacticTestNative", "scalatestTestNative", "commonTestNative",
+      "scalatestNative", "scalacticNative", "scalacticMacroNative"
       // [scalatest-tests] [info] *** 5 SUITES ABORTED ***
       // [scalatest-tests] [info] *** 29 TESTS FAILED ***
+      // (not reinvestigated in a long time)
       "examples"
     ]
     // needs extra heap to even compile
@@ -527,7 +531,7 @@ build += {
     uri:  ${vars.uris.scala-swing-uri}
     extra.commands: ${vars.default-commands} [
       // work around https://github.com/scala/community-builds/issues/575
-      // (in a community build context, we don't need MiMa to run)
+      // (in a community build context", we don't need MiMa to run)
       "set every ScalaModulePlugin.mimaPreviousVersion := None"
     ]
   }

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -313,8 +313,6 @@ build += {
     deps.ignore: ["org.wartremover#wartremover"]
   }
 
-  // frozen (April 2019) at April 2019 commit before source-incompatible upgrade
-  // to ScalaTest 3.1
   ${vars.base} {
     name: "discipline"
     uri:  ${vars.uris.discipline-uri}

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -511,6 +511,9 @@ build += {
     ]
     // needs extra heap to even compile
     extra.options: ["-Xmx3072m"]
+    // this is part of the scalactic jar so we don't need it as a separate dependency
+    deps.ignore: ["org.scalactic#scalacticmacro"]
+    check-missing: false
   }
 
   ${vars.base} {

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -322,11 +322,9 @@ build += {
   ${vars.base} {
     name: "discipline"
     uri:  ${vars.uris.discipline-uri}
-    extra.projects: ["disciplineJVM"]  // no Scala.js please
+    extra.projects: ["disciplineJVM", "scalaTestDisciplineJVM", "specs2DisciplineJVM"]  // no Scala.js please
   }
 
-  // frozen (March 2018) at a March 2018 commit before an sbt-catalysts version
-  // bump -- the new version wouldn't resolve, not sure why
   ${vars.base} {
     name: "catalysts"
     uri:  ${vars.uris.catalysts-uri}

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -501,7 +501,10 @@ build += {
     uri:  ${vars.uris.scalatest-uri}
     extra.exclude: [
       // we already built these above
-      "scalatest", "scalactic", "scalacticMacro"
+      "scalatest", "scalactic"
+      // I don't understand why we can't exclude this too, since we already
+      // built it once, but oh well :-/
+      // "scalacticMacro"
       // out of scope
       "*JS", "*Native", "*Dotty"
       // [scalatest-tests] [info] *** 5 SUITES ABORTED ***
@@ -511,9 +514,6 @@ build += {
     ]
     // needs extra heap to even compile
     extra.options: ["-Xmx3072m"]
-    // this is part of the scalactic jar so we don't need it as a separate dependency
-    deps.ignore: ["org.scalactic#scalacticmacro"]
-    check-missing: false
   }
 
   ${vars.base} {

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -152,7 +152,7 @@ vars.uris: {
   scalastyle-uri:               "https://github.com/scalastyle/scalastyle.git"
   scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"
   scalatestplus-junit-uri:      "https://github.com/scalatest/scalatestplus-junit.git"
-  scalatestplus-scalacheck-uri: "https://github.com/scalatest/scalatestplus-scalacheck.git#feature-scala-2.13.0-RC1-support"
+  scalatestplus-scalacheck-uri: "https://github.com/scalatest/scalatestplus-scalacheck.git"
   scalatestplus-testng-uri:     "https://github.com/scalatest/scalatestplus-testng.git"
   scalatest-uri:                "https://github.com/cheeseng/scalatest.git#3.1-scala-2.13.0-RC1"  # or 3.1.x?
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -36,7 +36,7 @@ vars.uris: {
   coursier-uri:                 "https://github.com/coursier/coursier.git#dbaf748fada"  # was master
   curryhoward-uri:              "https://github.com/Chymyst/curryhoward.git"
   decline-uri:                  "https://github.com/bkirwi/decline.git"
-  discipline-uri:               "https://github.com/typelevel/discipline.git#cc79369"  # was master
+  discipline-uri:               "https://github.com/typelevel/discipline.git"
   dispatch-uri:                 "https://github.com/dispatch/reboot.git#6dfe0c8"  # was 0.14.x
   doobie-uri:                   "https://github.com/tpolecat/doobie.git#series/0.6.x"
   doodle-uri:                   "https://github.com/underscoreio/doodle.git#develop"
@@ -152,10 +152,10 @@ vars.uris: {
   scalasti-uri:                 "https://github.com/scalacommunitybuild/scalasti.git#community-build-2.12"  # was bmc, release-2.1.4
   scalastyle-uri:               "https://github.com/scalastyle/scalastyle.git"
   scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"
-  scalatestplus-junit-uri:     "https://github.com/scalatest/scalatestplus-junit.git"
-  scalatestplus-scalacheck-uri: "https://github.com/scalatest/scalatestplus-scalacheck.git"
-  scalatestplus-testng-uri:    "https://github.com/scalatest/scalatestplus-testng.git"
-  scalatest-uri:                "https://github.com/scalatest/scalatest.git#3.1.x"
+  scalatestplus-junit-uri:      "https://github.com/scalatest/scalatestplus-junit.git"
+  scalatestplus-scalacheck-uri: "https://github.com/scalatest/scalatestplus-scalacheck.git#feature-scala-2.13.0-RC1-support"
+  scalatestplus-testng-uri:     "https://github.com/scalatest/scalatestplus-testng.git"
+  scalatest-uri:                "https://github.com/cheeseng/scalatest.git#3.1-scala-2.13.0-RC1"  # or 3.1.x?
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"
   scalikejdbc-uri:              "https://github.com/scalikejdbc/scalikejdbc.git"
   scallop-uri:                  "https://github.com/scallop/scallop.git#develop"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -24,7 +24,7 @@ vars.uris: {
   breeze-uri:                   "https://github.com/scalanlp/breeze.git"
   cachecontrol-uri:             "https://github.com/playframework/cachecontrol.git#1.1.x"
   case-app-uri:                 "https://github.com/scalacommunitybuild/case-app.git#community-build-2.12"  # was alexarchambault, master
-  catalysts-uri:                "https://github.com/typelevel/catalysts.git#f8676a18"  # was master
+  catalysts-uri:                "https://github.com/typelevel/catalysts.git"
   cats-effect-uri:              "https://github.com/typelevel/cats-effect.git#v1.2.0"  # was master
   cats-uri:                     "https://github.com/scalacommunitybuild/cats.git#community-build-2.12"  # was typelevel, v1.6.0
   circe-config-uri:             "https://github.com/circe/circe-config.git"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -152,7 +152,10 @@ vars.uris: {
   scalasti-uri:                 "https://github.com/scalacommunitybuild/scalasti.git#community-build-2.12"  # was bmc, release-2.1.4
   scalastyle-uri:               "https://github.com/scalastyle/scalastyle.git"
   scalatags-uri:                "https://github.com/lihaoyi/scalatags.git"
-  scalatest-uri:                "https://github.com/scalacommunitybuild/scalatest.git#community-build-2.12"  # was scalatest, 3.0.x
+  scalatestplus-junit-uri:     "https://github.com/scalatest/scalatestplus-junit.git"
+  scalatestplus-scalacheck-uri: "https://github.com/scalatest/scalatestplus-scalacheck.git"
+  scalatestplus-testng-uri:    "https://github.com/scalatest/scalatestplus-testng.git"
+  scalatest-uri:                "https://github.com/scalatest/scalatest.git#3.1.x"
   scalatex-uri:                 "https://github.com/lihaoyi/scalatex.git"
   scalikejdbc-uri:              "https://github.com/scalikejdbc/scalikejdbc.git"
   scallop-uri:                  "https://github.com/scallop/scallop.git#develop"


### PR DESCRIPTION
previously #898 

the repos that are likely to break are those that use ScalaTest's ScalaCheck integration, which has moved to a separate repo (scalatestplus-scalacheck) and new package (`org.scalatestplus`)

moving to cats master (2.x) will probably be necessary