### PR TITLE
show job as green in Jenkins if all failures are expected

### DIFF
--- a/report/Report.scala
+++ b/report/Report.scala
@@ -91,6 +91,7 @@ object SuccessReport {
       println(s"UNEXPECTED SUCCESSES: $us")
     }
     println(s"FAILED $failed DID NOT RUN $didNotRun TOTAL $total")
+    sys.exit(unexpectedFailures.size)
   }
 
 }

--- a/report/build.sbt
+++ b/report/build.sbt
@@ -1,0 +1,2 @@
+// run.sh wants an exit code
+trapExit := false

--- a/run.sh
+++ b/run.sh
@@ -193,4 +193,6 @@ rm -rf target-*/project-builds
 cd report
 sbt -Dsbt.supershell=false -error "run ../dbuild-${DBUILDVERSION}/dbuild.out"
 
-exit $STATUS
+# we've captured $STATUS above, but in this version of the script, it isn't used,
+# instead the reporting stuff is in charge of calling sys.exit if it decides to
+# exit $STATUS


### PR DESCRIPTION
I added the whole expected vs. unexpected failures thing a while
back intending to eventually make this change... and here it is

note that the 2.12.x build has zero expected failures, but that isn't
true of the 2.13.x build and the new 2.11.x build