### PR TITLE
Jsoniter-scala is allowing publishing with JDK 11 now

### DIFF
--- a/report/Report.scala
+++ b/report/Report.scala
@@ -40,7 +40,6 @@ object SuccessReport {
         Set(
           "coursier",  // needs scala/bug#11125 workaround
           "doobie",  // needs scala/bug#11125 workaround
-          "jsoniter-scala",  // "Cancelling publish, please use JDK 1.8" -- can we override?
           "lagom",  // "javadoc: error - invalid flag: -d"
           "sbt-util",  // needs scala/bug#11125 workaround
           "scala-debugger",  // "object FieldInfo is not a member of package sun.reflect"


### PR DESCRIPTION
I moved checking for JDK 8 to the release process: https://github.com/plokhotnyuk/jsoniter-scala/commit/c84626a8958483c7c36680ac98f60df1eecc5ca1