### PR TITLE
fix akka-stream on JDK 12

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -648,6 +648,7 @@ build += {
       // and report upstream if it hasn't gone away
       "set excludeFilter in (Test, unmanagedSources) in streamTests := HiddenFileFilter || \"TlsSpec.scala\""
       // prevents: Class jdk.internal.HotSpotIntrinsicCandidate not found - continuing with a stub.
+      "set scalacOptions in Compile in stream --= Seq(\"-release\", \"8\")"
       "set scalacOptions in Jdk9.CompileJdk9 in stream --= Seq(\"-release\", \"11\")"
     ]
     extra.exclude: [

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -647,8 +647,8 @@ build += {
       // has been failing consistently lately, let's recheck it next time we push the tag forward
       // and report upstream if it hasn't gone away
       "set excludeFilter in (Test, unmanagedSources) in streamTests := HiddenFileFilter || \"TlsSpec.scala\""
-      // prevents [akka-stream] [error] Class jdk.internal.HotSpotIntrinsicCandidate not found - continuing with a stub.
-      "set scalacOptions in Compile in stream --= Seq(\"-release\", \"8\")"
+      // prevents: Class jdk.internal.HotSpotIntrinsicCandidate not found - continuing with a stub.
+      "set scalacOptions in Jdk9.CompileJdk9 in stream --= Seq(\"-release\", \"11\")"
     ]
     extra.exclude: [
       // because we already built them in "akka"


### PR DESCRIPTION
currently 8 and 11 are green but 12 is failing.

I have no idea why we need to mess with `-release` like this,
and I fear that finding a single version that works on all
three might be hard, but let's try it