### PR TITLE
Kafka: run tests, use sbt 1.3.0-RC3

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1956,6 +1956,9 @@ build += {
   ${vars.base} {
     name: "kafka"
     uri:  ${vars.uris.kafka-uri}
+    extra.commands: ${vars.default-commands} [
+      """set core / unmanagedSources / excludeFilter := HiddenFileFilter || "ConsumerBounceTest.scala""""
+    ]
   }
 
   ${vars.base} {

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -1956,12 +1956,6 @@ build += {
   ${vars.base} {
     name: "kafka"
     uri:  ${vars.uris.kafka-uri}
-    // failed compilation on 1.3; not investigated
-    //  cannot find symbol; symbol: class MockTime
-    extra.sbt-version: ${vars.sbt-1-2-version}
-    // don't run tests for now as several are known to fail; waiting (July 2019)
-    // on response from Enno about it
-    extra.test-tasks: ["compile"]
   }
 
   ${vars.base} {


### PR DESCRIPTION
1) can we run the tests again?
2) maybe sbt 1.3.0-RC3 already fixed whatever problem we had using
   RC1 or RC2?

let's find out /cc @ennru