### PR TITLE
newer http4s SHA

### DIFF
--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2366,9 +2366,9 @@ build += {
 
   // this is a big build with a ton of subprojects.  we needn't be shy
   // about disabling fragile ones, ones with obscure dependencies we don't have, etc.
-  // frozen May 2019 at a May 2019 commit just before a blaze test started failing; I see
-  // the failure in their own CI (perhaps it was a semantic merge conflict?), so probably
-  // we'll be able to unfreeze promptly
+  // frozen (August 2019) at June 2019 commit, because:
+  //   "library org.typelevel#discipline-specs2 is not provided",
+  // and to get it we'd need newer discipline which needs ScalaTest 3.1
   ${vars.base} {
     name: "http4s"
     uri:  ${vars.uris.http4s-uri}

--- a/configs/community.dbuild
+++ b/configs/community.dbuild
@@ -2384,9 +2384,6 @@ build += {
     extra.exclude: [
       // outside our purview
       "bench", "docs", "website", "argonaut"
-      // requires com.eed3si9n#treehugger, which would be nice to add actually, but I'm
-      // not going to tackle it right now, maybe some other time
-      "mimedb-generator"
       // doesn't appear to have caught up with fs2-reactive-streams no longer being in a separate repo
       // (October 2018)
       "async-http-client"

--- a/configs/project-refs.conf
+++ b/configs/project-refs.conf
@@ -60,7 +60,7 @@ vars.uris: {
   grizzled-uri:                 "https://github.com/bmc/grizzled-scala.git#316d56d87baa476"  # was master
   kits-uri:                     "https://github.com/halcat0x15a/kits.git"
   http4s-parboiled2-uri:        "https://github.com/http4s/parboiled2.git"
-  http4s-uri:                   "https://github.com/http4s/http4s.git#cf6288fc80cceb6613d6459e"  # was master
+  http4s-uri:                   "https://github.com/http4s/http4s.git#fe95025ddc3584b267"  # was master
   jackson-module-scala-uri:     "https://github.com/FasterXML/jackson-module-scala.git"
   jawn-0-10-uri:                "https://github.com/scalacommunitybuild/jawn.git#community-build-2.12-0.10"  # was non, v0.10.4
   jawn-0-11-uri:                "https://github.com/typelevel/jawn.git"


### PR DESCRIPTION
goals here:
1) get on same SHA as 2.13 build has, which is good because
1a) reduce unnecessary 2.12/2.13 differences
1b) it's newer, better to move forward if we can, even though we can't unfreeze entirely until we have ScalaTest 3.1
2) see if EntityDecoderSpec still fails, as it has in recent runs
   (probably ScalaCheck's fault, but we can pursue that next)