### PR TITLE
2.13: fix playframework on JDK 13

### DIFF
--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -1,8 +1,12 @@
-// https://github.com/playframework/playframework.git#2.7.x
+// https://github.com/scalacommunitybuild/playframework.git#community-build-2.13  # was playframework, 2.7.x
+
+// forked for JDK 13 friendliness, pending merge and publishing
+// and adoption downstream of:
+// https://github.com/playframework/interplay/pull/94
 
 vars.proj.playframework: ${vars.base} {
   name: "playframework"
-  uri: "https://github.com/playframework/playframework.git#9d1f8291b5e63eb307a899612a1b4b3c338239ad"
+  uri: "https://github.com/scalacommunitybuild/playframework.git#2b734fce5aea16a34d64b4df1e938861a6f1a839"
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin"  // out of scope
     "Play-Integration-Test"  // TODO/WIP, see https://github.com/scala/community-builds/pull/819


### PR DESCRIPTION
let's try to fix https://scala-ci.typesafe.com/job/scala-2.13.x-jdk13-integrate-community-build/420/artifact/logs/playframework-build.log