### PR TITLE
2.13: get lift-json and dispatch working again

### DIFF
--- a/proj/dispatch.conf
+++ b/proj/dispatch.conf
@@ -1,9 +1,8 @@
-// https://github.com/dispatch/reboot.git#6dfe0c820de2c8970287b88c770a03dfe27ed7a9  # was 0.14.x
-
-// frozen (April 2019) because of some netty classpath problem (not investigated)
+// https://github.com/dispatch/reboot.git#1.1.x
 
 vars.proj.dispatch: ${vars.base} {
   name: "dispatch"
-  uri: "https://github.com/dispatch/reboot.git#6dfe0c820de2c8970287b88c770a03dfe27ed7a9"
+  uri: "https://github.com/dispatch/reboot.git#3cbdbb3fde623ed2b7a50b9568c981d0648abf5c"
 
+  extra.options: ["-Dsbt.classloader.close=false"]
 }

--- a/proj/lift-json.conf
+++ b/proj/lift-json.conf
@@ -1,14 +1,8 @@
-// https://github.com/lift/framework.git#aedb0d707e5be3853498f588b10c7411454c6356  # was master
-
-// frozen (April 2019) at last green commit, not investigated
+// https://github.com/lift/framework.git#master
 
 vars.proj.lift-json: ${vars.base} {
   name: "lift-json"
-  uri: "https://github.com/lift/framework.git#aedb0d707e5be3853498f588b10c7411454c6356"
+  uri: "https://github.com/lift/framework.git#7979dd8e0238211a552d9bc2e293f90e0370af0f"
 
-  extra.sbt-version: ${vars.sbt-0-13-version}
   extra.projects: ["lift-json"]
-  extra.commands: ${vars.default-commands} [
-    """set libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.2.0""""
-  ]
 }

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -43,7 +43,6 @@ object SuccessReport {
     "curryhoward",      // no 2.13 upgrade (checked Aug 6 2019)
     "doobie",           // needs newer cats-effect, which needs ScalaTest 3.1
     "kittens",          // needs ScalaTest 3.1
-    "lift-json",        // no 2.13 upgrade (checked Aug 6 2019)
     "metaconfig",       // no 2.13 upgrade (checked Aug 6 2019)
     "metrics-scala",    // needs ScalaTest 3.1
     "multibot",         // needs ScalaTest 3.1


### PR DESCRIPTION
in local testing lift-json is already green. dispatch is more of a stretch goal

~~note to self: before merge, make sure to update `dependencies.txt`~~ I'll do it after other open PRs land

also includes the commits from #1021 