### PR TITLE
Remove expression-evaluator from the `jdk14Failures` list

### DIFF
--- a/report/Report.scala
+++ b/report/Report.scala
@@ -44,7 +44,6 @@ object SuccessReport {
 
   val jdk14Failures = Set[String](
     "breeze",  // Unsupported class file major version
-    "expression-evaluator",  // Unsupported class file major version
     "jawn-0-11",  // Unsupported class file major version
     "log4s",  // Unsupported class file major version
     "playframework",  // https://github.com/playframework/playframework/issues/9586


### PR DESCRIPTION
Now it compiles even with JDK 15.