### PR TITLE
2.13: bump Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# January 23, 2020
-nightly=2.13.2-bin-eb1ea8b
+# January 27, 2020
+nightly=2.13.2-bin-3d4c087


### PR DESCRIPTION
time to start bumping this more frequently as we
approach a 2.13.2 release