### PR TITLE
advance sttp SHA

### DIFF
--- a/proj/sttp-model.conf
+++ b/proj/sttp-model.conf
@@ -4,7 +4,7 @@
 
 vars.proj.sttp-model: ${vars.base} {
   name: "sttp-model"
-  uri: "https://github.com/softwaremill/sttp-model.git#601a3fd29626b84745392256d18c30347efc634d"
+  uri: "https://github.com/softwaremill/sttp-model.git#83b2af653ac1c26924a5fadf7b12612b7ad3e04d"
 
   // just what sttp needs
   extra.projects: ["core"]

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp: ${vars.base} {
   name: "sttp"
-  uri: "https://github.com/softwaremill/sttp.git#75fb8673b5e4d7e01a125e6c137df3f0e306c59b"
+  uri: "https://github.com/softwaremill/sttp.git#12636c33ce4cece7c411a9b48657f2845cebad89"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["rootJVM"]   // aggregates

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -10,7 +10,7 @@ vars.proj.sttp: ${vars.base} {
     // it's fine, we don't need to have every last subproject
     "monix", "okhttpBackendMonix", "asyncHttpClientBackendMonix", "httpClientBackendMonix"
     "scalaz", "zio", "asyncHttpClientBackendZio", "asyncHttpClientBackendScalaz",
-    "asyncHttpClientBackendZio-streams", "circe"
+    "asyncHttpClientBackendZio-streams", "circe", "examples"
   ]
   extra.commands: ${vars.default-commands} [
      // without this, we have seen several different errors:

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -12,4 +12,10 @@ vars.proj.sttp: ${vars.base} {
     "scalaz", "zio", "asyncHttpClientBackendZio", "asyncHttpClientBackendScalaz",
     "asyncHttpClientBackendZio-streams", "circe"
   ]
+  extra.commands: ${vars.default-commands} [
+     // without this, we have seen several different errors:
+     // * java.lang.LinkageError: loader constraint violation: loader sbt.internal.ManagedClassLoader$ZombieClassLoader @45e802a3 wants to load class akka.actor.DeathPactException
+     // * scala.MatchError: org.apache.logging.log4j.simple.SimpleLoggerContext@6f982081 (of class org.apache.logging.log4j.simple.SimpleLoggerContext
+     "set every closeClassLoaders := false"
+  ]
 }


### PR DESCRIPTION
in the hopes it might fix the intermittent failures at shutdown
time that have plagued us:

scala.MatchError:
  org.apache.logging.log4j.simple.SimpleLoggerContext@2e7dba36 (of class
  org.apache.logging.log4j.simple.SimpleLoggerContext)