### PR TITLE
2.13: unfreeze discipline-scalatest

### DIFF
--- a/proj/cats-effect-testing.conf
+++ b/proj/cats-effect-testing.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect-testing: ${vars.base} {
   name: "cats-effect-testing"
-  uri: "https://github.com/djspiewak/cats-effect-testing.git#b109fe56f8377454a7f81fd359c1b898c0f537ae"
+  uri: "https://github.com/djspiewak/cats-effect-testing.git#0181a5647eab1846860e4b287f1e2c3d1bd5abfd"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/cats-mtl.conf
+++ b/proj/cats-mtl.conf
@@ -4,7 +4,7 @@
 
 vars.proj.cats-mtl: ${vars.base} {
   name: "cats-mtl"
-  uri: "https://github.com/typelevel/cats-mtl.git#c5d2c29dd38bfc681246bcec74de896705469f88"
+  uri: "https://github.com/typelevel/cats-mtl.git#2451abf4b58ebae5faed96adcd8d1936185593a2"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-retry.conf
+++ b/proj/cats-retry.conf
@@ -4,7 +4,7 @@
 
 vars.proj.cats-retry: ${vars.base} {
   name: "cats-retry"
-  uri: "https://github.com/cb372/cats-retry.git#7cd9060f6787fc68f871b068c5a71ce17c411efa"
+  uri: "https://github.com/cb372/cats-retry.git#fb0c4f496740dba5f3e245c08f9a58f89ac86b17"
 
   extra.projects: ["coreJVM"]
   // scalatestplus artifact name change

--- a/proj/cats-testkit-scalatest.conf
+++ b/proj/cats-testkit-scalatest.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-testkit-scalatest: ${vars.base} {
   name: "cats-testkit-scalatest"
-  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#1de1782e72828b7e58dd877a14bb50cc0082b4ed"
+  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#cafd0d9209d199f86e5eb13c310b2e79c7b76af3"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats-time.conf
+++ b/proj/cats-time.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-time: ${vars.base} {
   name: "cats-time"
-  uri: "https://github.com/ChristopherDavenport/cats-time.git#245caa038f7a39e05a788e0506a603e75b4433a7"
+  uri: "https://github.com/ChristopherDavenport/cats-time.git#df3427da98da347f42b165631ab3a7dee5c38032"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -6,7 +6,7 @@
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#5c72ffc4d2c05f2c3ac5679cb28e1e9a3ef872e5"
+  uri: "https://github.com/typelevel/cats.git#a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.

--- a/proj/circe-config.conf
+++ b/proj/circe-config.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-config: ${vars.base} {
   name: "circe-config"
-  uri: "https://github.com/circe/circe-config.git#d5287749b13351ac42240c376b99d3555768ad87"
+  uri: "https://github.com/circe/circe-config.git#3d04f3aebb1ee48b98ed189c54087cc9cb87674b"
 
   // dependency is on prelease version with different artifact name, so we must
   // override to the released artifact name

--- a/proj/circe-generic-extras.conf
+++ b/proj/circe-generic-extras.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-generic-extras: ${vars.base} {
   name: "circe-generic-extras"
-  uri: "https://github.com/circe/circe-generic-extras.git#471ea49cf5982ec086e3b13a7972b09ae9442433"
+  uri: "https://github.com/circe/circe-generic-extras.git#c0958d671356a1958866e6b114e2a522bde86ee2"
 
   extra.projects: ["genericExtras"]
   // scalatestplus artifact name change

--- a/proj/circe-jackson.conf
+++ b/proj/circe-jackson.conf
@@ -4,7 +4,7 @@
 
 vars.proj.circe-jackson: ${vars.base} {
   name: "circe-jackson"
-  uri: "https://github.com/circe/circe-jackson.git#a576f73931f5994d9b6dcdcbc63c06ba31215256"
+  uri: "https://github.com/circe/circe-jackson.git#54454355e28a7561b80dbef92db9c5f50990efe8"
 
   // there are some others, but for now, just trying to get github4s green again
   extra.projects: ["jackson28"]

--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -1,11 +1,8 @@
-// https://github.com/circe/circe.git#104602fee8371f92494b05e7e4865358897e3813  # was master
-
-// frozen (February 2020) at a known-green commit; we can probably unfreeze
-// when we move to discipline-scalatest 1.0.0?
+// https://github.com/circe/circe.git#master
 
 vars.proj.circe: ${vars.base} {
   name: "circe"
-  uri: "https://github.com/circe/circe.git#104602fee8371f92494b05e7e4865358897e3813"
+  uri: "https://github.com/circe/circe.git#4f39996dab759a874ef4234042157509a332e201"
 
   extra.projects: [
     // easy

--- a/proj/ciris.conf
+++ b/proj/ciris.conf
@@ -1,13 +1,10 @@
-// https://github.com/vlovgr/ciris.git#1718124c3210f3ac61ade42ed8635a9a6b2c600f  # was master
+// https://github.com/vlovgr/ciris.git#master
 
 // dependency of pfps-shopping-cart
 
-// frozen (February 2020) at known-green commit.
-// we should try to unfreeze when we upgrade discipline-scalatest to 1.0.0
-
 vars.proj.ciris: ${vars.base} {
   name: "ciris"
-  uri: "https://github.com/vlovgr/ciris.git#1718124c3210f3ac61ade42ed8635a9a6b2c600f"
+  uri: "https://github.com/vlovgr/ciris.git#d66b18a6f8914003c23d077470ad6bd312c26997"
 
   extra.exclude: ["docs"]
   // scalatestplus artifact name change

--- a/proj/claimant.conf
+++ b/proj/claimant.conf
@@ -2,7 +2,7 @@
 
 vars.proj.claimant: ${vars.base} {
   name: "claimant"
-  uri: "https://github.com/typelevel/claimant.git#5144840d1150ddacbd13c51d735cd4fe7e02ea30"
+  uri: "https://github.com/typelevel/claimant.git#ec6d34b955e93fac9d04f1de0ff6dbb66260effc"
 
   extra.exclude: ["root", "mcJS", "coreJS"]  // no Scala.js plz
 }

--- a/proj/decline.conf
+++ b/proj/decline.conf
@@ -1,13 +1,10 @@
-// https://github.com/bkirwi/decline.git#f86bfd7abfa3f1f21a956dead14a6272170229af  # was master
-
-// frozen (February 2020) at known-green commit.
-// we should try to unfreeze when we upgrade discipline-scalatest to 1.0.0
+// https://github.com/bkirwi/decline.git#master
 
 // core doesn't depend on refined, but refinedJVM does.
 
 vars.proj.decline: ${vars.base} {
   name: "decline"
-  uri: "https://github.com/bkirwi/decline.git#f86bfd7abfa3f1f21a956dead14a6272170229af"
+  uri: "https://github.com/bkirwi/decline.git#273b855b40b4d0580db8a4ae13a84dc4acb70e12"
 
   extra.projects: ["declineJVM", "refinedJVM"]  // no Scala.js, no doc
 }

--- a/proj/discipline-scalatest.conf
+++ b/proj/discipline-scalatest.conf
@@ -1,10 +1,8 @@
-// https://github.com/typelevel/discipline-scalatest.git#ea5fa6d7567eec475ffd23f043c478d8e4473e19  # was master
-
-// frozen (February 2020) because some newer commit broke cats downstream
+// https://github.com/typelevel/discipline-scalatest.git#master
 
 vars.proj.discipline-scalatest: ${vars.base} {
   name: "discipline-scalatest"
-  uri: "https://github.com/typelevel/discipline-scalatest.git#ea5fa6d7567eec475ffd23f043c478d8e4473e19"
+  uri: "https://github.com/typelevel/discipline-scalatest.git#d4cd8dc9629986093b3c36aecf3ffb1feb85d604"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/discipline-specs2.conf
+++ b/proj/discipline-specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-specs2: ${vars.base} {
   name: "discipline-specs2"
-  uri: "https://github.com/typelevel/discipline-specs2.git#acc238505c4c635c21eb9dff5bf061e27a054da2"
+  uri: "https://github.com/typelevel/discipline-specs2.git#9c4c5174a95fad69ec21309b4b936415177bb907"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/discipline.conf
+++ b/proj/discipline.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline: ${vars.base} {
   name: "discipline"
-  uri: "https://github.com/typelevel/discipline.git#b7cbd3624bb787a01b82567b4cc330335086a174"
+  uri: "https://github.com/typelevel/discipline.git#10c76a3f4002484b37676d060e084773a2070c17"
 
   extra.projects: ["coreJVM"]  // no Scala.js please
   extra.commands: ${vars.default-commands} [

--- a/proj/eff.conf
+++ b/proj/eff.conf
@@ -2,7 +2,7 @@
 
 vars.proj.eff: ${vars.base} {
   name: "eff"
-  uri: "https://github.com/atnos-org/eff.git#621ac1137c578e55abd30c2fd696dd3ab4dc5437"
+  uri: "https://github.com/atnos-org/eff.git#78e92e7cac976b89695b5d7d5ad48f3fb55a8b00"
 
   extra.exclude: [
     "scalaz", "*JS"

--- a/proj/http4s-jwt-auth.conf
+++ b/proj/http4s-jwt-auth.conf
@@ -4,7 +4,7 @@
 
 vars.proj.http4s-jwt-auth: ${vars.base} {
   name: "http4s-jwt-auth"
-  uri: "https://github.com/profunktor/http4s-jwt-auth.git#82432c91d1a61451a324d9b5c0abf514ab34409f"
+  uri: "https://github.com/profunktor/http4s-jwt-auth.git#4d8d1b525f0d9bad9e4e5e0052bc66b76094063e"
 
   extra.projects: ["core"]
 }

--- a/proj/log4cats.conf
+++ b/proj/log4cats.conf
@@ -4,7 +4,7 @@
 
 vars.proj.log4cats: ${vars.base} {
   name: "log4cats"
-  uri: "https://github.com/ChristopherDavenport/log4cats.git#9bd7389f33552532deb61806899737a85cbd01d8"
+  uri: "https://github.com/ChristopherDavenport/log4cats.git#134d6e559287fa2993d74405505b9e75e579646a"
 
   // for now, only adding the modules http4s needs
   extra.projects: ["coreJVM", "testingJVM", "slf4j"]

--- a/proj/monix.conf
+++ b/proj/monix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.monix: ${vars.base} {
   name: "monix"
-  uri: "https://github.com/monix/monix.git#36bffc33d56eed41868cc7d9fe4ed7f62652adb1"
+  uri: "https://github.com/monix/monix.git#1f1272fdc037b5d6e4540306a8160ce3d77c8d51"
 
   // no Scala.js, no benchmarks
   extra.projects: ["coreJVM"]

--- a/proj/natchez.conf
+++ b/proj/natchez.conf
@@ -4,7 +4,7 @@
 
 vars.proj.natchez: ${vars.base} {
   name: "natchez"
-  uri: "https://github.com/tpolecat/natchez.git#e9f59d9999a3e644b0be0f9bc5a9494c00e3ebfb"
+  uri: "https://github.com/tpolecat/natchez.git#2016aa9972d21f140effdd0eb97f1061da15b38c"
 
   // let's try and squeak by with just the minimum, since our present goal is
   // just to get pfps-shopping-cart green

--- a/proj/paiges.conf
+++ b/proj/paiges.conf
@@ -1,11 +1,8 @@
-// https://github.com/typelevel/paiges.git#f503c1d8d4a5c9e6571fb24514c02d433003ce6d  # was master
-
-// frozen (February 2020) because a newer commit didn't compile, I think
-// because of a discipline-scalatest incompatibility
+// https://github.com/typelevel/paiges.git#master
 
 vars.proj.paiges: ${vars.base} {
   name: "paiges"
-  uri: "https://github.com/typelevel/paiges.git#f503c1d8d4a5c9e6571fb24514c02d433003ce6d"
+  uri: "https://github.com/typelevel/paiges.git#39eee1c832e12517f27b0fb96b316171a5072fe4"
 
   extra.projects: ["coreJVM", "catsJVM"]  // but not "benchmark"
 }

--- a/proj/pfps-shopping-cart.conf
+++ b/proj/pfps-shopping-cart.conf
@@ -2,6 +2,6 @@
 
 vars.proj.pfps-shopping-cart: ${vars.base} {
   name: "pfps-shopping-cart"
-  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#4385473fe0db2ed65f7d9fc53528a647b5a96196"
+  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#a3ea32bb31eb224db69c5392b0815f5f9d72c2d7"
 
 }

--- a/proj/redis4cats.conf
+++ b/proj/redis4cats.conf
@@ -4,7 +4,7 @@
 
 vars.proj.redis4cats: ${vars.base} {
   name: "redis4cats"
-  uri: "https://github.com/profunktor/redis4cats.git#80ea5ff25ccd3ce9db462d3969ba654c4319ce1c"
+  uri: "https://github.com/profunktor/redis4cats.git#d9db0302fe842521f3523be04388620a1740c4cf"
 
   // just whatever pfps-shopping-cart needs
   extra.projects: ["redis4cats-core", "redis4cats-effects", "redis4cats-log4cats"]

--- a/proj/scala-pet-store.conf
+++ b/proj/scala-pet-store.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-pet-store: ${vars.base} {
   name: "scala-pet-store"
-  uri: "https://github.com/pauljamescleary/scala-pet-store.git#337be1b6b474bf6d80f3a5b555c0cf7f2854d4b4"
+  uri: "https://github.com/pauljamescleary/scala-pet-store.git#a1dfd57eb95b1f95f80300c7eaea2eb0f5e8506c"
 
   extra.commands: ${vars.default-commands} [
     // just compile the tests, don't run them; details on why at

--- a/proj/simulacrum.conf
+++ b/proj/simulacrum.conf
@@ -2,7 +2,7 @@
 
 vars.proj.simulacrum: ${vars.base} {
   name: "simulacrum"
-  uri: "https://github.com/typelevel/simulacrum.git#4c55c2641234459f6eebe6fcf05990f4455ac86e"
+  uri: "https://github.com/typelevel/simulacrum.git#a53c910484c3fa387bbdd5acf01aa777162a7601"
 
   extra.projects: ["coreJVM", "examplesJVM"] // no Scala.js please
   extra.commands: ${vars.default-commands} [

--- a/proj/skunk.conf
+++ b/proj/skunk.conf
@@ -4,7 +4,7 @@
 
 vars.proj.skunk: ${vars.base} {
   name: "skunk"
-  uri: "https://github.com/tpolecat/skunk.git#7f64db217e48a0fa4040362682f2b41faa22b803"
+  uri: "https://github.com/tpolecat/skunk.git#fa13e5f27b67f713e926d0e99689d6c7b6f28b4b"
 
   extra.exclude: [
     "docs"  // out of scope

--- a/proj/squants.conf
+++ b/proj/squants.conf
@@ -2,7 +2,7 @@
 
 vars.proj.squants: ${vars.base} {
   name: "squants"
-  uri: "https://github.com/typelevel/squants.git#4ab362be4e127733a06bd213d3ad9ff4b0869fef"
+  uri: "https://github.com/typelevel/squants.git#ee85a8f7064b66bb8c297de2cb9189a4ea2f8d1f"
 
   extra.projects: ["squantsJVM"]
 }

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp: ${vars.base} {
   name: "sttp"
-  uri: "https://github.com/softwaremill/sttp.git#12636c33ce4cece7c411a9b48657f2845cebad89"
+  uri: "https://github.com/softwaremill/sttp.git#d1d56cb1991bea3bfe98e0266d50694f176445ae"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["rootJVM"]   // aggregates

--- a/proj/unique.conf
+++ b/proj/unique.conf
@@ -4,7 +4,7 @@
 
 vars.proj.unique: ${vars.base} {
   name: "unique"
-  uri: "https://github.com/ChristopherDavenport/unique.git#dbc701c92d91e877fa5171e62bdef50d6b35d5ab"
+  uri: "https://github.com/ChristopherDavenport/unique.git#cb5bcbe401f3549ff7b2135ca614332f8edc02b9"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
 }

--- a/proj/vault.conf
+++ b/proj/vault.conf
@@ -4,7 +4,7 @@
 
 vars.proj.vault: ${vars.base} {
   name: "vault"
-  uri: "https://github.com/ChristopherDavenport/vault.git#44af6b48a249749772082d6711035656e6bb9986"
+  uri: "https://github.com/ChristopherDavenport/vault.git#04ad6ed3d8906afe975756bdd9887c03d75c61bc"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
 }


### PR DESCRIPTION
and some other repos that we'd frozen as a consequence

in general, advance SHAs in Typelevel repos

this had initially been part of #1079 but there was trouble so I decided to tackle it separately instead

perhaps discipline-scalatest 1.0 is too new and I'll have to set aside this for later. let's find out.