### PR TITLE
new Scala 2.13 SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# February 5, 2020
-nightly=2.13.2-bin-0d111e1
+# February 12, 2020
+nightly=2.13.2-bin-be9e4d2

--- a/proj/splain.conf
+++ b/proj/splain.conf
@@ -6,8 +6,8 @@ vars.proj.splain: ${vars.base} {
 
   extra.commands: [
     "set every gpgWarnOnFailure := true"
-    // sensitive to exact format of error message; we can remove the exclusion
+    // sensitive to exact format of error message; we can remove the exclusions
     // once the repo has upgraded to 2.13.2
-    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ErrorsSpec.scala""""
+    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ErrorsSpec.scala" || "ErrorsCompatSpec.scala""""
   ]
 }

--- a/proj/splain.conf
+++ b/proj/splain.conf
@@ -6,5 +6,8 @@ vars.proj.splain: ${vars.base} {
 
   extra.commands: [
     "set every gpgWarnOnFailure := true"
+    // sensitive to exact format of error message; we can remove the exclusion
+    // once the repo has upgraded to 2.13.2
+    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ErrorsSpec.scala""""
   ]
 }


### PR DESCRIPTION
* be9e4d2b07 - Merge pull request scala/scala#8705 from eed3si9n/wip/deprecate-class-shadowing (6 hours ago) <Lukas Rytz>
* f573c4e8dc - Merge pull request scala/scala#8706 from som-snytt/revert/reversion (11 hours ago) <Lukas Rytz>
* d7cfc0bef4 - Merge pull request scala/scala#8701 from som-snytt/test/9027 (11 hours ago) <Lukas Rytz>
* ff7b95cc34 - Merge pull request scala/scala#8700 from som-snytt/issue/terse-mode (12 hours ago) <Lukas Rytz>
* 44375946aa - Merge pull request scala/scala#8597 from som-snytt/issue/11460 (12 hours ago) <Lukas Rytz>
* 1a699f4339 - Merge pull request scala/scala#8710 from SethTisue/remove-bad-jline-comment (17 hours ago) <Lukas Rytz>
* fd1a71b627 - Merge pull request scala/scala#8697 from dotty-staging/dotty-release-0.22.0-RC1 (35 hours ago) <Lukas Rytz>
* 57f2e57009 - Merge pull request scala/scala#8708 from dwijnand/OutputSetting-is-not-setByUser (2 days ago) <Lukas Rytz>
* 32033dade0 - Merge pull request scala/scala#8020 from som-snytt/issue/tweak-underscore (2 days ago) <Lukas Rytz>
* af10c8aa1f - Merge pull request scala/scala#8709 from lrytz/fix-build (2 days ago) <Lukas Rytz>
* 1bde691873 - Merge pull request scala/scala#8651 from smarter/variance-alias (2 days ago) <Lukas Rytz>
* 0278b1cbd5 - Merge pull request scala/scala#8653 from som-snytt/topic/linting (2 days ago) <Lukas Rytz>
* d1b3235438 - Merge pull request scala/scala#8702 from ashawley/issue-9027 (5 days ago) <som-snytt>
* ea6d2d9d72 - Merge pull request scala/scala#8704 from SethTisue/cherry-pick-pr-8703 (5 days ago) <Seth Tisue>
* fb0c104454 - Merge pull request scala/scala#7798 from psilospore/11416 (7 days ago) <Seth Tisue>
* 5b7baea8ee - Merge pull request scala/scala#8698 from lrytz/ij (7 days ago) <Seth Tisue>
