### PR TITLE
2.13: advance project SHAs

### DIFF
--- a/proj/advxml.conf
+++ b/proj/advxml.conf
@@ -2,6 +2,6 @@
 
 vars.proj.advxml: ${vars.base} {
   name: "advxml"
-  uri: "https://github.com/geirolz/advxml.git#6702e7e00c50fe30ac99cbc4d113c0f6f95efe94"
+  uri: "https://github.com/geirolz/advxml.git#54998978e5e683e03ef69416f0c5d27fd9f4d25a"
 
 }

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#547a331a37e9044af1fdd259d765032edfdff94e"
+  uri: "https://github.com/wvlet/airframe.git#e381bfa5f239218f1e15f48771b73c103de86936"
 
   extra.projects: ["communityBuild"]  // no Scala.js plz
   extra.exclude: ["jmx"]  // on JDK 11: java.lang.ClassNotFoundException: sun.management.Agent

--- a/proj/akka-http-cors.conf
+++ b/proj/akka-http-cors.conf
@@ -4,7 +4,7 @@
 
 vars.proj.akka-http-cors: ${vars.base} {
   name: "akka-http-cors"
-  uri: "https://github.com/lomigmegard/akka-http-cors.git#985b9f2d0a73bfa571d58dc98241490182d69c3f"
+  uri: "https://github.com/lomigmegard/akka-http-cors.git#f2755f5c02fcf022611d3c9d39f2d959008f99fa"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["akka-http-cors"]

--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -5,7 +5,7 @@
 
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/akka/akka.git#0d5f592ebb13d5ec47694465eaa1f0dc726bd351"
+  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
 
   extra.options: [
     // as per their own .sbtopts file
@@ -34,7 +34,7 @@ vars.proj.akka: ${vars.base} {
 
 vars.proj.akka-stream: ${vars.base} {
   name: "akka-stream"
-  uri: "https://github.com/akka/akka.git#0d5f592ebb13d5ec47694465eaa1f0dc726bd351"
+  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"
@@ -77,7 +77,7 @@ vars.proj.akka-stream: ${vars.base} {
 // tests, and so failures in obscure subprojects don't take out too much of the build
 vars.proj.akka-more: ${vars.base} {
   name: "akka-more"
-  uri: "https://github.com/akka/akka.git#0d5f592ebb13d5ec47694465eaa1f0dc726bd351"
+  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"

--- a/proj/cats-effect-testing.conf
+++ b/proj/cats-effect-testing.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect-testing: ${vars.base} {
   name: "cats-effect-testing"
-  uri: "https://github.com/djspiewak/cats-effect-testing.git#b109fe56f8377454a7f81fd359c1b898c0f537ae"
+  uri: "https://github.com/djspiewak/cats-effect-testing.git#0181a5647eab1846860e4b287f1e2c3d1bd5abfd"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/cats-mtl.conf
+++ b/proj/cats-mtl.conf
@@ -4,7 +4,7 @@
 
 vars.proj.cats-mtl: ${vars.base} {
   name: "cats-mtl"
-  uri: "https://github.com/typelevel/cats-mtl.git#c5d2c29dd38bfc681246bcec74de896705469f88"
+  uri: "https://github.com/typelevel/cats-mtl.git#2451abf4b58ebae5faed96adcd8d1936185593a2"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-mtl.conf
+++ b/proj/cats-mtl.conf
@@ -1,10 +1,12 @@
-// https://github.com/typelevel/cats-mtl.git#master
+// https://github.com/typelevel/cats-mtl.git#c5d2c29dd38bfc681246bcec74de896705469f88  # master
 
 // dependency of pfps-shopping-cart (via meow-mtl)
 
+// frozen (February 2020) before a discipline-scalatest 1.0 upgrade
+
 vars.proj.cats-mtl: ${vars.base} {
   name: "cats-mtl"
-  uri: "https://github.com/typelevel/cats-mtl.git#2451abf4b58ebae5faed96adcd8d1936185593a2"
+  uri: "https://github.com/typelevel/cats-mtl.git#c5d2c29dd38bfc681246bcec74de896705469f88"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-retry.conf
+++ b/proj/cats-retry.conf
@@ -1,10 +1,12 @@
-// https://github.com/cb372/cats-retry.git#master
+// https://github.com/cb372/cats-retry.git#7cd9060f6787fc68f871b068c5a71ce17c411efa  # was master
 
-// dependency of pfps-shopping-cart]
+// dependency of pfps-shopping-cart
+
+// frozen (February 2020) before a discipline-scalatest 1.0 upgrade
 
 vars.proj.cats-retry: ${vars.base} {
   name: "cats-retry"
-  uri: "https://github.com/cb372/cats-retry.git#2dad3a4f934446306459527f34823fd611e7992d"
+  uri: "https://github.com/cb372/cats-retry.git#7cd9060f6787fc68f871b068c5a71ce17c411efa"
 
   extra.projects: ["coreJVM"]
   // scalatestplus artifact name change

--- a/proj/cats-retry.conf
+++ b/proj/cats-retry.conf
@@ -4,7 +4,7 @@
 
 vars.proj.cats-retry: ${vars.base} {
   name: "cats-retry"
-  uri: "https://github.com/cb372/cats-retry.git#7cd9060f6787fc68f871b068c5a71ce17c411efa"
+  uri: "https://github.com/cb372/cats-retry.git#2dad3a4f934446306459527f34823fd611e7992d"
 
   extra.projects: ["coreJVM"]
   // scalatestplus artifact name change

--- a/proj/cats-testkit-scalatest.conf
+++ b/proj/cats-testkit-scalatest.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-testkit-scalatest: ${vars.base} {
   name: "cats-testkit-scalatest"
-  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#1de1782e72828b7e58dd877a14bb50cc0082b4ed"
+  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#07d7a1e7c7930bce58f4a18b714c9cf306f178e7"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats-testkit-scalatest.conf
+++ b/proj/cats-testkit-scalatest.conf
@@ -1,8 +1,10 @@
-// https://github.com/typelevel/cats-testkit-scalatest.git#master
+// https://github.com/typelevel/cats-testkit-scalatest.git#1de1782e72828b7e58dd877a14bb50cc0082b4ed
+
+// frozen (February 2020) before a discipline-scalatest 1.0 upgrade
 
 vars.proj.cats-testkit-scalatest: ${vars.base} {
   name: "cats-testkit-scalatest"
-  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#07d7a1e7c7930bce58f4a18b714c9cf306f178e7"
+  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#1de1782e72828b7e58dd877a14bb50cc0082b4ed"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats-time.conf
+++ b/proj/cats-time.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-time: ${vars.base} {
   name: "cats-time"
-  uri: "https://github.com/ChristopherDavenport/cats-time.git#245caa038f7a39e05a788e0506a603e75b4433a7"
+  uri: "https://github.com/ChristopherDavenport/cats-time.git#f675a96349fe39272e1a1a593e6cbbbe52b96693"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -1,12 +1,14 @@
-// https://github.com/typelevel/cats.git#master
+// https://github.com/typelevel/cats.git#5c72ffc4d2c05f2c3ac5679cb28e1e9a3ef872e5  # was master
 
 // tracking master instead of 2.1.x makes me nervous, but 2.1.x wants
 // scalatestplus-scalacheck under a different artifact name.  perhaps the fix
 // for that could be backported to 2.1.x?
 
+// frozen (February 2020) at January 2020 commit before discipline-scalatest 1.0 upgrade
+
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#e6e24fc3c41f8cb524a5628678804b33f7858f54"
+  uri: "https://github.com/typelevel/cats.git#5c72ffc4d2c05f2c3ac5679cb28e1e9a3ef872e5"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -6,7 +6,7 @@
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#5c72ffc4d2c05f2c3ac5679cb28e1e9a3ef872e5"
+  uri: "https://github.com/typelevel/cats.git#e6e24fc3c41f8cb524a5628678804b33f7858f54"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.

--- a/proj/circe-config.conf
+++ b/proj/circe-config.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-config: ${vars.base} {
   name: "circe-config"
-  uri: "https://github.com/circe/circe-config.git#d5287749b13351ac42240c376b99d3555768ad87"
+  uri: "https://github.com/circe/circe-config.git#9f13569650bb57085ff7e78e83a413fa22449821"
 
   // dependency is on prelease version with different artifact name, so we must
   // override to the released artifact name

--- a/proj/circe-generic-extras.conf
+++ b/proj/circe-generic-extras.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-generic-extras: ${vars.base} {
   name: "circe-generic-extras"
-  uri: "https://github.com/circe/circe-generic-extras.git#471ea49cf5982ec086e3b13a7972b09ae9442433"
+  uri: "https://github.com/circe/circe-generic-extras.git#f8d286d7662f50b82f4b135e01697c57eae13365"
 
   extra.projects: ["genericExtras"]
   // scalatestplus artifact name change

--- a/proj/circe-jackson.conf
+++ b/proj/circe-jackson.conf
@@ -4,7 +4,7 @@
 
 vars.proj.circe-jackson: ${vars.base} {
   name: "circe-jackson"
-  uri: "https://github.com/circe/circe-jackson.git#a576f73931f5994d9b6dcdcbc63c06ba31215256"
+  uri: "https://github.com/circe/circe-jackson.git#54454355e28a7561b80dbef92db9c5f50990efe8"
 
   // there are some others, but for now, just trying to get github4s green again
   extra.projects: ["jackson28"]

--- a/proj/claimant.conf
+++ b/proj/claimant.conf
@@ -2,7 +2,7 @@
 
 vars.proj.claimant: ${vars.base} {
   name: "claimant"
-  uri: "https://github.com/typelevel/claimant.git#5144840d1150ddacbd13c51d735cd4fe7e02ea30"
+  uri: "https://github.com/typelevel/claimant.git#7ec8d2235f97aa610b4f5a8423a94e5aba3e50a6"
 
   extra.exclude: ["root", "mcJS", "coreJS"]  // no Scala.js plz
 }

--- a/proj/discipline-specs2.conf
+++ b/proj/discipline-specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-specs2: ${vars.base} {
   name: "discipline-specs2"
-  uri: "https://github.com/typelevel/discipline-specs2.git#acc238505c4c635c21eb9dff5bf061e27a054da2"
+  uri: "https://github.com/typelevel/discipline-specs2.git#810256c797395546aeb7ed0ccce46241c7084c59"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/discipline.conf
+++ b/proj/discipline.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline: ${vars.base} {
   name: "discipline"
-  uri: "https://github.com/typelevel/discipline.git#b7cbd3624bb787a01b82567b4cc330335086a174"
+  uri: "https://github.com/typelevel/discipline.git#2d933d23332e71c63718c4fb5678fb7be4c0a667"
 
   extra.projects: ["coreJVM"]  // no Scala.js please
   extra.commands: ${vars.default-commands} [

--- a/proj/eff.conf
+++ b/proj/eff.conf
@@ -2,7 +2,7 @@
 
 vars.proj.eff: ${vars.base} {
   name: "eff"
-  uri: "https://github.com/atnos-org/eff.git#621ac1137c578e55abd30c2fd696dd3ab4dc5437"
+  uri: "https://github.com/atnos-org/eff.git#78e92e7cac976b89695b5d7d5ad48f3fb55a8b00"
 
   extra.exclude: [
     "scalaz", "*JS"

--- a/proj/euler.conf
+++ b/proj/euler.conf
@@ -7,7 +7,7 @@
 
 vars.proj.euler: ${vars.base} {
   name: "euler"
-  uri: "https://github.com/SethTisue/Project-Euler.git#72a6321864836e7c4bcd5a0a6e0b0fa40c806dca"
+  uri: "https://github.com/SethTisue/Project-Euler.git#1ae6443212295de1ab1da56cb088668fb05ee8ed"
 
   // some solutions are heap-hungry; serial execution avoids intermittent OOM
   extra.commands: ${vars.default-commands} [

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -3,7 +3,7 @@
 // dependency of scopt
 vars.proj.expecty: ${vars.base} {
   name: "expecty"
-  uri: "https://github.com/eed3si9n/expecty.git#4eb183a121ea817464ead7aa3c65f28238f1f8d3"
+  uri: "https://github.com/eed3si9n/expecty.git#7a110daa8734ce6252ba90ab0441f1977f93d6c2"
 
   extra.projects: ["expectyJVM"]
 }

--- a/proj/expression-evaluator.conf
+++ b/proj/expression-evaluator.conf
@@ -4,6 +4,6 @@
 
 vars.proj.expression-evaluator: ${vars.base} {
   name: "expression-evaluator"
-  uri: "https://github.com/plokhotnyuk/expression-evaluator.git#59031534349a32ee319bc4b541e4971ca1d7d4fa"
+  uri: "https://github.com/plokhotnyuk/expression-evaluator.git#c2b69c43999c9d50597539470e2f353e8681548f"
 
 }

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#cfab0580fd9a4fe7721d7fd08550b8540973ab18"
+  uri: "https://github.com/lightbend/genjavadoc.git#f5973ac0cb8bacf41ed2e315f764ec87855e32a5"
 
 }

--- a/proj/github4s.conf
+++ b/proj/github4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.github4s: ${vars.base} {
   name: "github4s"
-  uri: "https://github.com/47deg/github4s.git#aabb34533e0d75bcfda10477b4f4b28e3d74fe2f"
+  uri: "https://github.com/47deg/github4s.git#a776769394bd97b77cd210a877ab725c052f185e"
 
   extra.projects: ["github4s", "catsEffect"]
   deps.ignore: ["com.github.mpilquist#simulacrum"]

--- a/proj/http4s-jwt-auth.conf
+++ b/proj/http4s-jwt-auth.conf
@@ -4,7 +4,7 @@
 
 vars.proj.http4s-jwt-auth: ${vars.base} {
   name: "http4s-jwt-auth"
-  uri: "https://github.com/profunktor/http4s-jwt-auth.git#82432c91d1a61451a324d9b5c0abf514ab34409f"
+  uri: "https://github.com/profunktor/http4s-jwt-auth.git#6f559a29a238b8652252fd3b08165957f194a05b"
 
   extra.projects: ["core"]
   extra.commands: ${vars.default-commands} [

--- a/proj/jsoniter-scala.conf
+++ b/proj/jsoniter-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jsoniter-scala: ${vars.base} {
   name: "jsoniter-scala"
-  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#6aa039e9024e1e19cef925ed5a19f069f3fc54bb"
+  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#c955f2a612527a0a26e02ae0db32b2ebb2118505"
 
   extra.exclude: ["jsoniter-scala-benchmark"]
 }

--- a/proj/jwt-scala.conf
+++ b/proj/jwt-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jwt-scala: ${vars.base} {
   name: "jwt-scala"
-  uri: "https://github.com/pauldijou/jwt-scala.git#2c356e53c868c9c98d948318cc650efc3e92abb2"
+  uri: "https://github.com/pauldijou/jwt-scala.git#77b9e5196d4b497f269c1f217eb3f9a14c4a29cb"
 
   // only what http4s-jwt-auth needs
   extra.projects: ["coreProject"]

--- a/proj/kind-projector.conf
+++ b/proj/kind-projector.conf
@@ -2,6 +2,6 @@
 
 vars.proj.kind-projector: ${vars.base} {
   name: "kind-projector"
-  uri: "https://github.com/typelevel/kind-projector.git#6d11bc33e60832cc9c842b4e1eea665cc0eeedcf"
+  uri: "https://github.com/typelevel/kind-projector.git#56a819090bd342f1b471fdf9ec18684fc5f6879f"
 
 }

--- a/proj/kittens.conf
+++ b/proj/kittens.conf
@@ -2,7 +2,7 @@
 
 vars.proj.kittens: ${vars.base} {
   name: "kittens"
-  uri: "https://github.com/typelevel/kittens.git#997128f84117676e6020519fafec531d40c45f90"
+  uri: "https://github.com/typelevel/kittens.git#0e051593802789086fb62f7e8fef38a4bf1e3092"
 
   extra.projects: ["coreJVM"]  // sorry, Scala.js
 }

--- a/proj/lagom.conf
+++ b/proj/lagom.conf
@@ -5,7 +5,7 @@
 
 vars.proj.lagom: ${vars.base} {
   name: "lagom"
-  uri: "https://github.com/lagom/lagom.git#3c8cf50cf1e66df764cff771c8f67f476978abd5"
+  uri: "https://github.com/lagom/lagom.git#ceb77044f782311e807e2f2b57e39c86189794f3"
 
   // these pull in a number of dependent projects
   extra.projects: ["server", "testkit-scaladsl"]

--- a/proj/lightbend-emoji.conf
+++ b/proj/lightbend-emoji.conf
@@ -2,7 +2,7 @@
 
 vars.proj.lightbend-emoji: ${vars.base} {
   name: "lightbend-emoji"
-  uri: "https://github.com/lightbend/lightbend-emoji.git#129bb210632bc4d65169ca4afba6e4b48bf294e7"
+  uri: "https://github.com/lightbend/lightbend-emoji.git#b6ca4da2fb528f46fff7b6d640d7f493b86d3966"
 
   extra.options: ["-Dsbt.sbtbintray=false"]
 }

--- a/proj/log4cats.conf
+++ b/proj/log4cats.conf
@@ -4,7 +4,7 @@
 
 vars.proj.log4cats: ${vars.base} {
   name: "log4cats"
-  uri: "https://github.com/ChristopherDavenport/log4cats.git#9bd7389f33552532deb61806899737a85cbd01d8"
+  uri: "https://github.com/ChristopherDavenport/log4cats.git#134d6e559287fa2993d74405505b9e75e579646a"
 
   // for now, only adding the modules http4s needs
   extra.projects: ["coreJVM", "testingJVM", "slf4j"]

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalameta/mdoc.git#12ae9fd70ce22c400c3d53e007851d1ca5363709"
+  uri: "https://github.com/scalameta/mdoc.git#b4a8caca6799776c74b648f0e11949bf4783ebbb"
 
   extra.exclude: [
     "js", "jsdocs", "docs", "unit", "plugin"

--- a/proj/metaconfig.conf
+++ b/proj/metaconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.metaconfig: ${vars.base} {
   name: "metaconfig"
-  uri: "https://github.com/olafurpg/metaconfig.git#2d3fcbdb0b1b035c92f38a61ea5967c5b6b20d96"
+  uri: "https://github.com/olafurpg/metaconfig.git#3797fb852f635d707a6490b90d0a43c55a1f9d5b"
 
   extra.exclude: ["docs", "*JS"]
   // I guess dbuild is getting confused by the extra _1.14

--- a/proj/metrics-scala.conf
+++ b/proj/metrics-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.metrics-scala: ${vars.base} {
   name: "metrics-scala"
-  uri: "https://github.com/erikvanoosten/metrics-scala.git#7390dde78b99a0713c0a026e9e3901fdcb095c86"
+  uri: "https://github.com/erikvanoosten/metrics-scala.git#8694bc1ff38b72a64ec38f9f5694cfa5ea2bb581"
 
   // our Akka version is 2.6; as of January 2020 there is only a
   // a metricsAkka25 project, no Akka26, but perhaps it will be source-compatible?

--- a/proj/monix.conf
+++ b/proj/monix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.monix: ${vars.base} {
   name: "monix"
-  uri: "https://github.com/monix/monix.git#36bffc33d56eed41868cc7d9fe4ed7f62652adb1"
+  uri: "https://github.com/monix/monix.git#1b2ff5c3e8a11d0798e9d995e10bad67da642593"
 
   // no Scala.js, no benchmarks
   extra.projects: ["coreJVM"]

--- a/proj/monocle.conf
+++ b/proj/monocle.conf
@@ -2,7 +2,7 @@
 
 vars.proj.monocle: ${vars.base} {
   name: "monocle"
-  uri: "https://github.com/julien-truffaut/Monocle.git#dc69cf487db92d5f04c0daf5567dae79770183c3"
+  uri: "https://github.com/julien-truffaut/Monocle.git#c02a2d34e82e257a3d4bc368a8661582b7ef9f17"
 
   // try to enable more subprojects?
   extra.projects: ["coreJVM", "macrosJVM", "lawJVM", "genericJVM"]

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#2eea6beec5f77d3fd0c62c90cf9070084a7a1139"
+  uri: "https://github.com/scalameta/munit.git#ba5d46b03559b0d7c3f0f11f644bf1dd0ab5e353"
 
   extra.exclude: ["docs", "plugin", "*JS", "*Native"]
   // ignore missing org.scala-sbt#scripted-plugin

--- a/proj/natchez.conf
+++ b/proj/natchez.conf
@@ -4,7 +4,7 @@
 
 vars.proj.natchez: ${vars.base} {
   name: "natchez"
-  uri: "https://github.com/tpolecat/natchez.git#e9f59d9999a3e644b0be0f9bc5a9494c00e3ebfb"
+  uri: "https://github.com/tpolecat/natchez.git#041f61ee2e1d4fb461951564da1fc4884a02b9a4"
 
   // let's try and squeak by with just the minimum, since our present goal is
   // just to get pfps-shopping-cart green

--- a/proj/parboiled2.conf
+++ b/proj/parboiled2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled2: ${vars.base} {
   name: "parboiled2"
-  uri: "https://github.com/sirthias/parboiled2.git#aea9c61659ea12cf0d62f932ed2a1083d59180ed"
+  uri: "https://github.com/sirthias/parboiled2.git#9e751de4b5c4e2a887ed1c909dd417c3b2bc5164"
 
   extra.projects: ["parboiledJVM", "examples"]
   extra.commands: ${vars.default-commands} [

--- a/proj/pfps-shopping-cart.conf
+++ b/proj/pfps-shopping-cart.conf
@@ -1,6 +1,12 @@
 // https://github.com/gvolpe/pfps-shopping-cart.git#4385473fe0db2ed65f7d9fc53528a647b5a96196  # was master
 
-// TODO -- explain why frozen
+// frozen because a more recent commit resulted in:
+//   exception during macro expansion:
+//   java.lang.AssertionError: assertion failed: List(package eu, package eu)
+//   at scala.reflect.internal.SymbolTable.throwAssertionError(SymbolTable.scala:170)
+//   at scala.reflect.internal.Symbols$Symbol.suchThat(Symbols.scala:2020)
+//   at scala.reflect.internal.Symbols$ClassSymbol.companionModule0(Symbols.scala:3372)
+// I should look into it, but I don't want to hold this advance-the-SHAs PR over it
 
 vars.proj.pfps-shopping-cart: ${vars.base} {
   name: "pfps-shopping-cart"

--- a/proj/pfps-shopping-cart.conf
+++ b/proj/pfps-shopping-cart.conf
@@ -1,7 +1,9 @@
-// https://github.com/gvolpe/pfps-shopping-cart.git#master
+// https://github.com/gvolpe/pfps-shopping-cart.git#4385473fe0db2ed65f7d9fc53528a647b5a96196  # was master
+
+// TODO -- explain why frozen
 
 vars.proj.pfps-shopping-cart: ${vars.base} {
   name: "pfps-shopping-cart"
-  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#29ca21ccbb307732c409ca496e936a9bfef74655"
+  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#4385473fe0db2ed65f7d9fc53528a647b5a96196"
 
 }

--- a/proj/pfps-shopping-cart.conf
+++ b/proj/pfps-shopping-cart.conf
@@ -2,6 +2,6 @@
 
 vars.proj.pfps-shopping-cart: ${vars.base} {
   name: "pfps-shopping-cart"
-  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#4385473fe0db2ed65f7d9fc53528a647b5a96196"
+  uri: "https://github.com/gvolpe/pfps-shopping-cart.git#29ca21ccbb307732c409ca496e936a9bfef74655"
 
 }

--- a/proj/play-doc.conf
+++ b/proj/play-doc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.play-doc: ${vars.base} {
   name: "play-doc"
-  uri: "https://github.com/playframework/play-doc.git#ee7c61d599fdd70e7358b4f6a2f72749c4834257"
+  uri: "https://github.com/playframework/play-doc.git#169c3da0d6938474b896b4843afa32a282bd6c26"
 
 }

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -2,7 +2,7 @@
 
 vars.proj.playframework: ${vars.base} {
   name: "playframework"
-  uri: "https://github.com/playframework/playframework.git#80c9990fa85642ee6d1f5fb49b510cb2edb06ca9"
+  uri: "https://github.com/playframework/playframework.git#40c61b4eda215354d943bbe5ec9eb7aec623fc53"
 
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin", "Sbt-Scripted-Tools"  // out of scope

--- a/proj/portable-scala-reflect.conf
+++ b/proj/portable-scala-reflect.conf
@@ -2,7 +2,7 @@
 
 vars.proj.portable-scala-reflect: ${vars.base} {
   name: "portable-scala-reflect"
-  uri: "https://github.com/portable-scala/portable-scala-reflect.git#4cd24b9b8d05e46e353d7f296c19e891bbdd04dc"
+  uri: "https://github.com/portable-scala/portable-scala-reflect.git#4d024001eaa8fd2649f591c188696f03b65ad9f9"
 
   extra.projects: ["portable-scala-reflectJVM"]  // no Scala.js plz
 }

--- a/proj/pureconfig.conf
+++ b/proj/pureconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.pureconfig: ${vars.base} {
   name: "pureconfig"
-  uri: "https://github.com/pureconfig/pureconfig.git#770eec9713037d9839a22ee58c8b13226fa362f8"
+  uri: "https://github.com/pureconfig/pureconfig.git#ecc96bfe1aa9a8d05b41d24d06591b5f64f42300"
 
   extra.projects: ["core", "generic"]  // also pulls in macros, generic-base
 }
@@ -13,7 +13,7 @@ vars.proj.pureconfig: ${vars.base} {
 
 vars.proj.pureconfig-more: ${vars.base} {
   name: "pureconfig-more"
-  uri: "https://github.com/pureconfig/pureconfig.git#770eec9713037d9839a22ee58c8b13226fa362f8"
+  uri: "https://github.com/pureconfig/pureconfig.git#ecc96bfe1aa9a8d05b41d24d06591b5f64f42300"
 
   extra.exclude: [
     // we already built these above

--- a/proj/redis4cats.conf
+++ b/proj/redis4cats.conf
@@ -4,7 +4,7 @@
 
 vars.proj.redis4cats: ${vars.base} {
   name: "redis4cats"
-  uri: "https://github.com/profunktor/redis4cats.git#80ea5ff25ccd3ce9db462d3969ba654c4319ce1c"
+  uri: "https://github.com/profunktor/redis4cats.git#d8cc9be80d61c9afbebf9736290756ec9a44a1d2"
 
   // just whatever pfps-shopping-cart needs
   extra.projects: ["redis4cats-core", "redis4cats-effects", "redis4cats-log4cats"]

--- a/proj/scala-async.conf
+++ b/proj/scala-async.conf
@@ -2,6 +2,6 @@
 
 vars.proj.scala-async: ${vars.base} {
   name: "scala-async"
-  uri: "https://github.com/scala/scala-async.git#55c363deacd1e9c3fe55e487bf6537a52b9957dc"
+  uri: "https://github.com/scala/scala-async.git#96af4170b0f614ca33ba35c52f508413e4f4c744"
 
 }

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#3d98110108be944bb10302a468a1f5389b05919d"
+  uri: "https://github.com/scala/scala-collection-compat.git#1f591c4d8666c86ba58329f683b478acdd396290"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-contrib.conf
+++ b/proj/scala-collection-contrib.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-contrib: ${vars.base} {
   name: "scala-collection-contrib"
-  uri: "https://github.com/scala/scala-collection-contrib.git#b77e613ab558a0c83cae28e0670e414b9883e846"
+  uri: "https://github.com/scala/scala-collection-contrib.git#7d8b250fc91133a8217b98b4310b76a003b8e371"
 
   extra.projects: ["collectionContrib"]   // just JVM
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-java-time.conf
+++ b/proj/scala-java-time.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-java-time: ${vars.base} {
   name: "scala-java-time"
-  uri: "https://github.com/cquiroz/scala-java-time.git#a840bb95ecc18891738a51a335235ef5182d101d"
+  uri: "https://github.com/cquiroz/scala-java-time.git#dfd3c7295890ae15a0fa47f0034841850a9d09ec"
 
   extra.projects: ["scalajavatimeJVM", "scalajavatimeTZDBJVM", "scalajavatimeTestsJVM"]  // no Scala.js plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-pet-store.conf
+++ b/proj/scala-pet-store.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-pet-store: ${vars.base} {
   name: "scala-pet-store"
-  uri: "https://github.com/pauljamescleary/scala-pet-store.git#337be1b6b474bf6d80f3a5b555c0cf7f2854d4b4"
+  uri: "https://github.com/pauljamescleary/scala-pet-store.git#6ed2d05f0b4b1dcb6f321e796d0edf8992b8134f"
 
   extra.commands: ${vars.default-commands} [
     // just compile the tests, don't run them; details on why at

--- a/proj/scala-xml.conf
+++ b/proj/scala-xml.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-xml: ${vars.base} {
   name: "scala-xml"
-  uri: "https://github.com/scala/scala-xml.git#8f1a541a0fc8f461de0397d88a6b633ff45cfec1"
+  uri: "https://github.com/scala/scala-xml.git#c323a319056d2fcb55c9a7524aaa142ca36002e8"
 
   extra.projects: ["xml"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck-shapeless.conf
+++ b/proj/scalacheck-shapeless.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalacheck-shapeless: ${vars.base} {
   name: "scalacheck-shapeless"
-  uri: "https://github.com/alexarchambault/scalacheck-shapeless.git#17af46d7f750554ca4a9e8f686d4b8b9fb63ea6d"
+  uri: "https://github.com/alexarchambault/scalacheck-shapeless.git#c7a2e5cd6ff61b842725870e58e196955ae4a783"
 
   extra.exclude: ["*JS"]
   // hopefully avoid intermittent OutOfMemoryErrors with default 1.5G heap?

--- a/proj/scalafmt.conf
+++ b/proj/scalafmt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#0374b4236399f40741c6d1d6aee3924c3529ae5d"
+  uri: "https://github.com/scalameta/scalafmt.git#3062fc35edebed4b7062392464520e58fd0dbbb6"
 
   extra.projects: ["coreJVM", "cli", "tests"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalamock.conf
+++ b/proj/scalamock.conf
@@ -4,7 +4,7 @@
 
 vars.proj.scalamock: ${vars.base} {
   name: "scalamock"
-  uri: "https://github.com/paulbutcher/ScalaMock.git#4e07bab2bc3000720050a67fedadc96c0a4aee47"
+  uri: "https://github.com/paulbutcher/ScalaMock.git#868ab1e2b7048aff6d8662f1e1fa7e47fbc4aafb"
 
   extra.projects: ["scalamockJVM", "examples"]
 }

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#3a881ff48884281abb5d83ba83c0af581541e421"
+  uri: "https://github.com/scalaprops/scalaprops.git#5704e4ff00c04bc2cbaa6952071489b6b2144d32"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/scalastyle.conf
+++ b/proj/scalastyle.conf
@@ -6,10 +6,4 @@ vars.proj.scalastyle: ${vars.base} {
   name: "scalastyle"
   uri: "https://github.com/beautiful-scala/scalastyle.git#289ef405f14f5fc2f7cb6694c12909e0461844ed"
 
-  // ScalaTest 3.0, not 3.1
-  deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
-  extra.commands: ${vars.default-commands} [
-    "removeDependency org.scalatest scalatest"
-    """set libraryDependencies in ThisBuild += "scalacommunitybuild" %% "scalatest" % "0" % Test"""
-  ]
 }

--- a/proj/scalastyle.conf
+++ b/proj/scalastyle.conf
@@ -4,7 +4,7 @@
 
 vars.proj.scalastyle: ${vars.base} {
   name: "scalastyle"
-  uri: "https://github.com/beautiful-scala/scalastyle.git#dc1b2c7354e0c1a5258fe1314c78db2e0d493690"
+  uri: "https://github.com/beautiful-scala/scalastyle.git#289ef405f14f5fc2f7cb6694c12909e0461844ed"
 
   // ScalaTest 3.0, not 3.1
   deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]

--- a/proj/scalikejdbc.conf
+++ b/proj/scalikejdbc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalikejdbc: ${vars.base} {
   name: "scalikejdbc"
-  uri: "https://github.com/scalikejdbc/scalikejdbc.git#9c304ace352d8be049443b01399dbeabaa34a659"
+  uri: "https://github.com/scalikejdbc/scalikejdbc.git#846ea74656c115822d807a3c6f60759e3921e4b1"
 
   // don't build sbt plugin
   extra.exclude: ["mapper-generator"]

--- a/proj/simulacrum.conf
+++ b/proj/simulacrum.conf
@@ -2,7 +2,7 @@
 
 vars.proj.simulacrum: ${vars.base} {
   name: "simulacrum"
-  uri: "https://github.com/typelevel/simulacrum.git#4c55c2641234459f6eebe6fcf05990f4455ac86e"
+  uri: "https://github.com/typelevel/simulacrum.git#bb6c359a9320db29d74ad58ee3df4dfc6a550de2"
 
   extra.projects: ["coreJVM", "examplesJVM"] // no Scala.js please
   extra.commands: ${vars.default-commands} [

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#54c3cc9d0a7fa9fafb21b0c5d4e5d321846cbbd0"
+  uri: "https://github.com/fthomas/singleton-ops.git#a23603daac88cf788492a36068787bb89215955c"
 
   extra.projects: ["singleton_opsJVM"]
   extra.commands: ${vars.default-commands} [

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -5,10 +5,4 @@ vars.proj.singleton-ops: ${vars.base} {
   uri: "https://github.com/fthomas/singleton-ops.git#a23603daac88cf788492a36068787bb89215955c"
 
   extra.projects: ["singleton_opsJVM"]
-  extra.commands: ${vars.default-commands} [
-    "set every bintrayReleaseOnPublish := false"
-  ]
-  extra.options: [
-    "-Dbintray.user=dummy", "-Dbintray.pass=dummy"
-  ]
 }

--- a/proj/skunk.conf
+++ b/proj/skunk.conf
@@ -4,7 +4,7 @@
 
 vars.proj.skunk: ${vars.base} {
   name: "skunk"
-  uri: "https://github.com/tpolecat/skunk.git#7f64db217e48a0fa4040362682f2b41faa22b803"
+  uri: "https://github.com/tpolecat/skunk.git#b52af98f3a672484b5d478e7a046355287efdab4"
 
   extra.exclude: [
     "docs"  // out of scope

--- a/proj/slick.conf
+++ b/proj/slick.conf
@@ -2,7 +2,7 @@
 
 vars.proj.slick: ${vars.base} {
   name: "slick"
-  uri: "https://github.com/slick/slick.git#af8195056a75dc6e8bcef75d02df7ef69a241c91"
+  uri: "https://github.com/slick/slick.git#eecc74fa1ba8e477e6fbd991b5b9bbb87b8f3918"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   deps.inject: ${vars.base.deps.inject} [

--- a/proj/specs2.conf
+++ b/proj/specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.specs2: ${vars.base} {
   name: "specs2"
-  uri: "https://github.com/etorreborre/specs2.git#2f4ce3f0521a4a1373e88020c61b58e2cfc72f01"
+  uri: "https://github.com/etorreborre/specs2.git#1e960d6960daf7ebfa7c871858a4cb733a957281"
 
   // I don't see a project that aggregates JVM-only stuff, so...
   extra.projects: [
@@ -22,7 +22,7 @@ vars.proj.specs2: ${vars.base} {
 
 vars.proj.specs2-more: ${vars.base} {
   name: "specs2-more"
-  uri: "https://github.com/etorreborre/specs2.git#2f4ce3f0521a4a1373e88020c61b58e2cfc72f01"
+  uri: "https://github.com/etorreborre/specs2.git#1e960d6960daf7ebfa7c871858a4cb733a957281"
 
   extra.projects: [
     "shapelessJVM", "catsJVM", "examplesJVM"

--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -2,7 +2,7 @@
 
 vars.proj.spire: ${vars.base} {
   name: "spire"
-  uri: "https://github.com/typelevel/spire.git#5ce7cbbcba68cbefce1ac32d12625d647998b992"
+  uri: "https://github.com/typelevel/spire.git#9ee11e4d6f2c3bbc70f58c5550a360d378db7012"
 
   // hopefully avoid intermittent OutOfMemoryErrors during compilation
   extra.options: ["-Xmx2560m"]

--- a/proj/splain.conf
+++ b/proj/splain.conf
@@ -2,7 +2,7 @@
 
 vars.proj.splain: ${vars.base} {
   name: "splain"
-  uri: "https://github.com/tek/splain.git#58fd21121ab80b7f8c61d2a75ae9bef8f45bfe46"
+  uri: "https://github.com/tek/splain.git#0d855f2e5ddf914368993585ddd6732177a1a4d6"
 
   extra.commands: [
     "set every gpgWarnOnFailure := true"

--- a/proj/squants.conf
+++ b/proj/squants.conf
@@ -2,7 +2,7 @@
 
 vars.proj.squants: ${vars.base} {
   name: "squants"
-  uri: "https://github.com/typelevel/squants.git#4ab362be4e127733a06bd213d3ad9ff4b0869fef"
+  uri: "https://github.com/typelevel/squants.git#ee85a8f7064b66bb8c297de2cb9189a4ea2f8d1f"
 
   extra.projects: ["squantsJVM"]
 }

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp: ${vars.base} {
   name: "sttp"
-  uri: "https://github.com/softwaremill/sttp.git#12636c33ce4cece7c411a9b48657f2845cebad89"
+  uri: "https://github.com/softwaremill/sttp.git#d1d56cb1991bea3bfe98e0266d50694f176445ae"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["rootJVM"]   // aggregates

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -1,8 +1,11 @@
-// https://github.com/softwaremill/sttp.git#master
+// https://github.com/softwaremill/sttp.git#12636c33ce4cece7c411a9b48657f2845cebad89  # master
+
+// frozen at a known-green commit before http4s-related compile errors
+// (presumably because we have http4s frozen?)
 
 vars.proj.sttp: ${vars.base} {
   name: "sttp"
-  uri: "https://github.com/softwaremill/sttp.git#d1d56cb1991bea3bfe98e0266d50694f176445ae"
+  uri: "https://github.com/softwaremill/sttp.git#12636c33ce4cece7c411a9b48657f2845cebad89"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["rootJVM"]   // aggregates

--- a/proj/twirl.conf
+++ b/proj/twirl.conf
@@ -2,7 +2,7 @@
 
 vars.proj.twirl: ${vars.base} {
   name: "twirl"
-  uri: "https://github.com/playframework/twirl.git#3cbd18d5fe8746d12204c50127b72681191dbb70"
+  uri: "https://github.com/playframework/twirl.git#d53d267637409da895c5f522cc17534470bc9602"
 
   extra.exclude: ["plugin", "apiJS"]
   deps.ignore: ["org.scala-sbt#scripted-plugin"]

--- a/proj/twitter-util.conf
+++ b/proj/twitter-util.conf
@@ -5,7 +5,7 @@
 
 vars.proj.twitter-util: ${vars.base} {
   name: "twitter-util"
-  uri: "https://github.com/twitter/util.git#ccfb944bec034945a9736d8f9a2106155c62e567"
+  uri: "https://github.com/twitter/util.git#d523c0c50de551814d4eb8485d68db52e8c14c51"
 
   extra.exclude: [
     // this isn't really necessary and would pull in a JMH dependency

--- a/proj/unique.conf
+++ b/proj/unique.conf
@@ -4,7 +4,7 @@
 
 vars.proj.unique: ${vars.base} {
   name: "unique"
-  uri: "https://github.com/ChristopherDavenport/unique.git#dbc701c92d91e877fa5171e62bdef50d6b35d5ab"
+  uri: "https://github.com/ChristopherDavenport/unique.git#cb5bcbe401f3549ff7b2135ca614332f8edc02b9"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
 }

--- a/proj/vault.conf
+++ b/proj/vault.conf
@@ -4,7 +4,7 @@
 
 vars.proj.vault: ${vars.base} {
   name: "vault"
-  uri: "https://github.com/ChristopherDavenport/vault.git#44af6b48a249749772082d6711035656e6bb9986"
+  uri: "https://github.com/ChristopherDavenport/vault.git#04ad6ed3d8906afe975756bdd9887c03d75c61bc"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
 }

--- a/proj/verify.conf
+++ b/proj/verify.conf
@@ -2,7 +2,7 @@
 
 vars.proj.verify: ${vars.base} {
   name: "verify"
-  uri: "https://github.com/scala/nanotest-strawman.git#b44234556a540633fdcbaffe63b82b2808ec425f"
+  uri: "https://github.com/scala/nanotest-strawman.git#58004d26d9c6188411a153a82617f9ec620b502b"
 
   extra.projects: ["verifyJVM"]
 }

--- a/proj/wartremover.conf
+++ b/proj/wartremover.conf
@@ -2,7 +2,7 @@
 
 vars.proj.wartremover: ${vars.base} {
   name: "wartremover"
-  uri: "https://github.com/wartremover/wartremover.git#3452ca24d1a6e3f139e63b17df0a4a8fd476630a"
+  uri: "https://github.com/wartremover/wartremover.git#3735ee1f32edd8ab70399b6f51c94078f8a2cbad"
 
   extra.exclude: ["sbt-plugin"]
   deps.ignore: ["org.scala-sbt#scripted-plugin"]


### PR DESCRIPTION
the last time I did a once-monthly advancing-of-the-SHAs, it got tricky because so much was changing all at once and it made blame assignment tricky. but also, doing it too often is pointless churn. maybe twice a month is the sweet spot? let's see.

~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3193/~~
~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3194/~~
~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3195/~~
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3196/