### PR TITLE
Don't "check-missing: false", drop scripted-plugin!

### DIFF
--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -5,8 +5,10 @@ vars.proj.munit: ${vars.base} {
   uri: "https://github.com/scalameta/munit.git#ba5d46b03559b0d7c3f0f11f644bf1dd0ab5e353"
 
   extra.exclude: ["docs", "plugin", "*JS", "*Native"]
-  // ignore missing org.scala-sbt#scripted-plugin
-  check-missing: false
+  extra.settings: ${vars.base.extra.settings} [
+    // ignore missing org.scala-sbt#scripted-plugin
+    """LocalProject("plugin") / dependencyOverrides ~= (_.filter(!_.toString.contains("scripted-plugin")))"""
+  ]
   extra.commands: ${vars.default-commands} [
     // use right version-specific source directories regardless of our weird dbuild Scala version numbers
     """set munitJVM / Compile / unmanagedSourceDirectories += baseDirectory.value / "munit" / "shared" / "src" / "main" / "scala-2.13""""


### PR DESCRIPTION
In the run up to sbt 1.2, there was a feature ([1][]) that made sbt's
"main" module ("org.scala-sbt#main") depend on the scripted plugin.
During the RC cycle a hackaround ([2][]) was added to force the right
`scripted-plugin` to be used.

Do to the fact that `scripted-plugin` is cross-versioned (because there
was an attempt ([3][]) to make sbt publish cross-versioned, which later
was reverted ([4][]), but not without leaving `scripted-plugin`
cross-versioned, for no good reason I think) this causes the name and
crossVersion-based approximation check within dbuild ([5][]) to suddenly
hard-fail the build because of the `dependencyOverrides` on
`scripted-plugin`.

Obviously, this isn't specific to munit.  It was just the first, small
project that had the "check-missing: false" workaround.  Let's validate
and then propagate.

[1]: https://github.com/sbt/sbt/pull/3875
[2]: https://github.com/sbt/sbt/pull/4258/commits/b3342118f8d43377adb8fe3a24276f9f652991ac
[3]: https://github.com/sbt/sbt/pull/2577/commits/3f08158bb6a2486021a23dee01ff9af08bf8223f
[4]: https://github.com/sbt/sbt/pull/2586
[5]: https://github.com/lightbend/dbuild/blob/v0.9.16/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala#L190-L191