### PR TITLE
[2.11] Replace the unchecked code in alterKeyImpl

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -52,17 +52,17 @@ vars {
 // let us work around https://github.com/lightbend/dbuild/issues/144
 vars.default-commands += """
 set commands ++= {
-  def alterSetting[T](s: State, setting: SettingKey[T])(fn: T => T) = alterKeyImpl(s, setting)(fn)
-  def alterTask[T](s: State, task: TaskKey[T])(fn: T => T) = alterKeyImpl(s, task)(fn)
-  def alterKeyImpl[T](s: State, scopedKey: Scoped)(fn: T => T) = {
+  def alterSetting[T](s: State, setting: SettingKey[T])(fn: T => T) = alterKey(s, setting)(fn)
+  def alterTask[T](s: State, task: TaskKey[T])(fn: T => T) = alterKey(s, task)(fn)
+  def alterKey[T](s: State, st: ScopedTaskable[T])(fn: T => T) = {
     val extracted = sbt.Project extract s
     import extracted._
     val r = sbt.Project.relation(extracted.structure, true)
     val allDefs = r._1s.toSeq
-    val scopes = allDefs.filter(_.key == scopedKey.key).map(_.scope).distinct
-    val redefined = (scopedKey: @unchecked) match {
-      case setting: SettingKey[T @unchecked] => scopes.map(scope => setting in scope ~= fn)
-      case task: TaskKey[T @unchecked]       => scopes.map(scope => task in scope ~= fn)
+    val scopes = allDefs.filter(_.key == st.key).map(_.scope).distinct
+    val redefined = st match {
+      case setting: SettingKey[T] => scopes.map(scope => setting in scope ~= fn)
+      case task: TaskKey[T]       => scopes.map(scope => task in scope ~= fn)
     }
     val session = extracted.session.appendRaw(redefined)
     BuiltinCommands.reapply(session, structure, s)


### PR DESCRIPTION
I learnt some more about sbt's modeling.

I renamed it alterKey, but kept the alterSetting/alterTask aliases.