### PR TITLE
2.13: advance Akka SHA, re-enable fixed tests

### DIFF
--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -1,11 +1,11 @@
 // https://github.com/akka/akka.git#master
 
 // perhaps eventually there will be a release-2.6 branch for us to track;
-// at present (January 2020) 2.6.x development is happening on master
+// at present (March 2020) 2.6.x development is happening on master
 
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
+  uri: "https://github.com/akka/akka.git#3157b0199b32b98bfef8c110e7e0f37d02566766"
 
   extra.options: [
     // as per their own .sbtopts file
@@ -27,15 +27,14 @@ vars.proj.akka: ${vars.base} {
     "set scalacOptions in Compile in actor --= Seq(\"-release\", \"8\")"
     // prone to intermittent failure
     // ForkJoinPoolStarvationSpec (fails on JDK 13 only, I think?) reported upstream: https://github.com/akka/akka/issues/28505
-    // ActorSystemSpec: https://github.com/akka/akka/issues/28648
-    """set actorTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "BackoffSupervisorSpec.scala" || "MetricsBasedResizerSpec.scala" || "EventStreamSpec.scala" || "ForkJoinPoolStarvationSpec.scala" || "ActorSystemSpec.scala""""
+    """set actorTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "BackoffSupervisorSpec.scala" || "MetricsBasedResizerSpec.scala" || "EventStreamSpec.scala" || "ForkJoinPoolStarvationSpec.scala""""
     """set testkit / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CoronerSpec.scala""""
   ]
 }
 
 vars.proj.akka-stream: ${vars.base} {
   name: "akka-stream"
-  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
+  uri: "https://github.com/akka/akka.git#3157b0199b32b98bfef8c110e7e0f37d02566766"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"
@@ -59,9 +58,7 @@ vars.proj.akka-stream: ${vars.base} {
     "set scalacOptions in Compile in stream --= Seq(\"-release\", \"8\")"
     "set scalacOptions in Jdk9.CompileJdk9 in stream --= Seq(\"-release\", \"11\")"
     // intermittent failure (and, TcpSpec consistently fails on JDK 14, and TcpHelper depends on it)
-    // LazyFlowSpec/FlowFlatMapPrefixSpec reported upstream:
-    //   https://github.com/akka/akka/issues/28620
-    """set streamTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "RestartSpec.scala" || "TlsSpec.scala" || "InputStreamSinkSpec.scala" || "ActorRefBackpressureSourceSpec.scala" || "FlowDelaySpec.scala" || "TcpSpec.scala" || "TcpHelper.scala" || "LazyFlowSpec.scala" || "FlowFlatMapPrefixSpec.scala""""
+    """set streamTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "RestartSpec.scala" || "TlsSpec.scala" || "InputStreamSinkSpec.scala" || "ActorRefBackpressureSourceSpec.scala" || "FlowDelaySpec.scala" || "TcpSpec.scala" || "TcpHelper.scala""""
     // so many intermittent failures I got tired of excluding them individually
     "set remote / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
   ]
@@ -77,7 +74,7 @@ vars.proj.akka-stream: ${vars.base} {
 // tests, and so failures in obscure subprojects don't take out too much of the build
 vars.proj.akka-more: ${vars.base} {
   name: "akka-more"
-  uri: "https://github.com/akka/akka.git#56c13dcde5f3b91a15ae854017d29a5740981adf"
+  uri: "https://github.com/akka/akka.git#3157b0199b32b98bfef8c110e7e0f37d02566766"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"

--- a/proj/scalatestplus-mockito.conf
+++ b/proj/scalatestplus-mockito.conf
@@ -1,7 +1,7 @@
-// https://github.com/scalatest/scalatestplus-mockito.git#release-3.1.0.0-for-mockito-1.10
+// https://github.com/scalatest/scalatestplus-mockito.git#release-3.1.0.0-for-mockito-3.2
 
 vars.proj.scalatestplus-mockito: ${vars.base} {
   name: "scalatestplus-mockito"
-  uri: "https://github.com/scalatest/scalatestplus-mockito.git#3a6902c60df03b598999c449ed0617025a5b20af"
+  uri: "https://github.com/scalatest/scalatestplus-mockito.git#a419a2085b7fb0dacd453e672bb206cad5497c59"
 
 }


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3253/