### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# March 4, 2020
-nightly=2.13.2-bin-7da8ce2
+# March 9, 2020
+nightly=2.13.2-bin-e4645f7

--- a/proj/acyclic.conf
+++ b/proj/acyclic.conf
@@ -4,7 +4,7 @@
 
 vars.proj.acyclic: ${vars.base} {
   name: "acyclic"
-  uri: "https://github.com/scalacommunitybuild/acyclic.git#9245fb7917104d40db02a8543cc9c902b80c3f93"
+  uri: "https://github.com/scalacommunitybuild/acyclic.git#250ed1bc03969b08cd93e242b3bd7a4822637aef"
 
   extra.projects: ["acyclic"]
   // TODO reenable tests

--- a/proj/acyclic.conf
+++ b/proj/acyclic.conf
@@ -1,8 +1,12 @@
-// https://github.com/lihaoyi/acyclic.git#d9d1875c67e947758dcb2718f1c2c47af3a8edbb
+// https://github.com/scalacommunitybuild/acyclic.git#community-build-2.13  # was master
 
-// frozen (June 2019) at April 2019 commit just before sbt->mill move
+// forked for 2.13.2 compatibility (also had to add an sbt build)
+
 vars.proj.acyclic: ${vars.base} {
   name: "acyclic"
-  uri: "https://github.com/lihaoyi/acyclic.git#d9d1875c67e947758dcb2718f1c2c47af3a8edbb"
+  uri: "https://github.com/scalacommunitybuild/acyclic.git#9245fb7917104d40db02a8543cc9c902b80c3f93"
 
+  extra.projects: ["acyclic"]
+  // TODO reenable tests
+  extra.test-tasks: ["compile"]
 }

--- a/proj/splain.conf
+++ b/proj/splain.conf
@@ -1,13 +1,13 @@
-// https://github.com/tek/splain.git#master
+// https://github.com/scalacommunitybuild/splain.git#community-build-2.13  # was tek, master
+
+// forked for 2.13.2 compatibility, we can presumably unfork once they
+// add the support themselves
 
 vars.proj.splain: ${vars.base} {
   name: "splain"
-  uri: "https://github.com/tek/splain.git#92d30d9cb2506d9a60b10233ec7917bfe7350d29"
+  uri: "https://github.com/scalacommunitybuild/splain.git#f5db726076d8f8cda24410ce4d4f9282d9e9ef05"
 
   extra.commands: [
     "set every gpgWarnOnFailure := true"
-    // sensitive to exact format of error message; we can remove the exclusions
-    // once the repo has upgraded to 2.13.2
-    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ErrorsSpec.scala" || "ErrorsCompatSpec.scala""""
   ]
 }


### PR DESCRIPTION
because 2.13.2 is getting ever closer, and because a 2.12-to-2.13 merge just landed and this is actually part of validating those 2.12 changes

~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3284/~~
~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3285/~~
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3286/