### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# March 9, 2020
-nightly=2.13.2-bin-e4645f7
+# March 18, 2020
+nightly=2.13.2-bin-b4428c8

--- a/proj/specs2.conf
+++ b/proj/specs2.conf
@@ -13,6 +13,9 @@ vars.proj.specs2: ${vars.base} {
   extra.commands: ${vars.default-commands} [
     // makes "configuration not public" errors downstream go away
     "set every publishMavenStyle := false"
+    // overly sensitive test; we should be able to remove the exclusion after
+    // upstream moves to 2.13.2
+    """set coreJVM / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "NotNullStringsSpec.scala""""
   ]
 }
 


### PR DESCRIPTION
with new `Vector`

note to self: once I merge this, post to https://contributors.scala-lang.org/t/coming-soon-scala-2-12-11-scala-2-13-2/4003/19

~~https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3301/~~
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3302/