### PR TITLE
2.13: advance Lagom and Akka SHAs

### DIFF
--- a/proj/akka-persistence-cassandra.conf
+++ b/proj/akka-persistence-cassandra.conf
@@ -1,10 +1,10 @@
-// https://github.com/akka/akka-persistence-cassandra.git#v0.100
+// https://github.com/akka/akka-persistence-cassandra.git#v0.103
 
-// frozen (Nov 2019) at version lagom currently expects
+// frozen (April 2019) at version lagom currently expects
 
 vars.proj.akka-persistence-cassandra: ${vars.base} {
   name: "akka-persistence-cassandra"
-  uri: "https://github.com/akka/akka-persistence-cassandra.git#6512e05bae93a99737823c7076db7e55675399e7"
+  uri: "https://github.com/akka/akka-persistence-cassandra.git#9c27779d09a3bbc59769acfd187646b49db0b0fb"
 
   // out of scope
   extra.exclude: ["docs"]

--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -1,14 +1,11 @@
-// https://github.com/akka/akka.git#fa9ceaa5eb3c12ebc1e2ac5a3c121b9d19ef7fc1  # was master
+// https://github.com/akka/akka.git#master
 
 // perhaps eventually there will be a release-2.6 branch for us to track;
 // at present (March 2020) 2.6.x development is happening on master
 
-// frozen (April 2020) at a March 2020 commit before a change to
-// WriteMessagesFailed that broke akka-persistence-cassandra downstream
-
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/akka/akka.git#fa9ceaa5eb3c12ebc1e2ac5a3c121b9d19ef7fc1"
+  uri: "https://github.com/akka/akka.git#2972ba543123ace80569d117010895abbf1ee944"
 
   extra.options: [
     // as per their own .sbtopts file
@@ -37,7 +34,7 @@ vars.proj.akka: ${vars.base} {
 
 vars.proj.akka-stream: ${vars.base} {
   name: "akka-stream"
-  uri: "https://github.com/akka/akka.git#fa9ceaa5eb3c12ebc1e2ac5a3c121b9d19ef7fc1"
+  uri: "https://github.com/akka/akka.git#2972ba543123ace80569d117010895abbf1ee944"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"
@@ -79,7 +76,7 @@ vars.proj.akka-stream: ${vars.base} {
 // tests, and so failures in obscure subprojects don't take out too much of the build
 vars.proj.akka-more: ${vars.base} {
   name: "akka-more"
-  uri: "https://github.com/akka/akka.git#fa9ceaa5eb3c12ebc1e2ac5a3c121b9d19ef7fc1"
+  uri: "https://github.com/akka/akka.git#2972ba543123ace80569d117010895abbf1ee944"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     "-Xmx3g"

--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -96,8 +96,7 @@ vars.proj.akka-more: ${vars.base} {
     // https://github.com/scala/community-builds/issues/373
     "set every apiURL := None"
     // prone to intermittent failure
-    // LocalPubSubSpec & MessageAdapterSpec: https://github.com/akka/akka/issues/28885
-    """set actorTypedTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ActorContextPipeToSelfSpec.scala" || "ActorContextPipeToSelfTest.java" || "ActorContextSpec.scala" || "BubblingSampleTest.java" || "MailboxSelectorSpec.scala" || "LocalPubSubSpec.scala" || "MessageAdapterSpec.scala""""
+    """set actorTypedTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ActorContextPipeToSelfSpec.scala" || "ActorContextPipeToSelfTest.java" || "ActorContextSpec.scala" || "BubblingSampleTest.java" || "MailboxSelectorSpec.scala""""
     """set cluster / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ClusterSpec.scala" || "ClusterHeartbeatReceiverSpec.scala" || "ClusterMessageSerializerSpec.scala""""
     """set clusterTools / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ClusterSingletonLeaseSpec.scala""""
     """set clusterSharding / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "SupervisionSpec.scala" || "ConcurrentStartupShardingSpec.scala""""

--- a/proj/lagom.conf
+++ b/proj/lagom.conf
@@ -5,7 +5,7 @@
 
 vars.proj.lagom: ${vars.base} {
   name: "lagom"
-  uri: "https://github.com/lagom/lagom.git#484f7a98134a9f894e647453438adab685afb626"
+  uri: "https://github.com/lagom/lagom.git#2cffa22cba50ffb9c4e40b23cdac8adf53822d9f"
 
   // these pull in a number of dependent projects
   extra.projects: ["server", "testkit-scaladsl"]


### PR DESCRIPTION
and anything else that needs to come along

motivation: I've been reporting intermittent Akka failures upstream,
so I would like to get on newest Akka in order to test fixes, but
that may require newer akka-persistence-cassandra, which may require
newer Lagom