### PR TITLE
2.12: new Scala SHA with -release fix

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 7, 2020
-nightly=2.12.12-bin-90b48a1
+# May 11, 2020
+nightly=2.12.12-bin-4dd0abe

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 11, 2020
-nightly=2.12.12-bin-4dd0abe
+# May 13, 2020
+nightly=2.12.12-bin-8d19363

--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -21,9 +21,6 @@ vars.proj.akka: ${vars.base} {
     "set skip in publish in actorTests := false"
     // makes "configuration not public" errors downstream go away
     "set every publishMavenStyle := false"
-    // idk why, but prevents dbuild-only sun.misc.Unsafe compile errors;
-    // see https://github.com/scala/community-builds/issues/757
-    "set scalacOptions in Compile in actor --= Seq(\"-release\", \"8\")"
     // prone to intermittent failure
     """set actorTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "BackoffSupervisorSpec.scala" || "MetricsBasedResizerSpec.scala" || "EventStreamSpec.scala""""
     """set testkit / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CoronerSpec.scala""""
@@ -51,9 +48,6 @@ vars.proj.akka-stream: ${vars.base} {
     // has been failing consistently lately, let's recheck it next time we push the tag forward
     // and report upstream if it hasn't gone away
     "set excludeFilter in (Test, unmanagedSources) in streamTests := HiddenFileFilter || \"TlsSpec.scala\""
-    // prevents: Class jdk.internal.HotSpotIntrinsicCandidate not found - continuing with a stub.
-    "set scalacOptions in Compile in stream --= Seq(\"-release\", \"8\")"
-    "set scalacOptions in Jdk9.CompileJdk9 in stream --= Seq(\"-release\", \"11\")"
     // intermittent failure (and, TcpSpec consistently fails on JDK 14)
     """set streamTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "RestartSpec.scala" || "TlsSpec.scala" || "InputStreamSinkSpec.scala" || "ActorRefBackpressureSourceSpec.scala" || "TcpSpec.scala""""
     // so many intermittent failures I got tired of excluding them individually

--- a/proj/spray-json.conf
+++ b/proj/spray-json.conf
@@ -4,8 +4,4 @@ vars.proj.spray-json: ${vars.base} {
   name: "spray-json"
   uri: "https://github.com/spray/spray-json.git#76fcf7f3472097f23fc8719508c4a447e9552b27"
 
-  extra.commands: ${vars.default-commands} [
-    // work around https://github.com/scala/bug/issues/11682
-    """set Compile / doc / scalacOptions --= Seq("-release", "8")"""
-  ]
 }


### PR DESCRIPTION
testing https://github.com/scala/scala/pull/8849

I'll need to validate this on all three JDKs (8, 11, 14)

the spray-json change should almost certainly go through — less sure about the akka one, could be something else entirely. might also have been fixed since then by some other change entirely :-)