### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# July 24, 2020
-nightly=2.13.4-bin-a9f2bdb
+# August 17, 2020
+nightly=2.13.4-bin-dd32fe7


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1742/