### PR TITLE
Remove publish from droste.conf excludes

### DIFF
--- a/proj/droste.conf
+++ b/proj/droste.conf
@@ -12,7 +12,7 @@ vars.proj.droste: ${vars.base} {
 
   extra.exclude: [
     // out of scope
-    "*JS", "docs", "readme", "publish", "coverage"
+    "*JS", "docs", "readme", "coverage"
     // [error] **** Missing dependency: the library io.github.stanch#reftree
     "reftree"
   ]


### PR DESCRIPTION
Project extraction failed with 1.4.0-SNAPSHOT.