### PR TITLE
advance akka to 2.6.9

### DIFF
--- a/proj/akka-management.conf
+++ b/proj/akka-management.conf
@@ -4,7 +4,7 @@
 
 vars.proj.akka-management: ${vars.base} {
   name: "akka-management"
-  uri: "https://github.com/akka/akka-management.git#afc2fe534387ccde00999b92174e47b5874a919f"
+  uri: "https://github.com/akka/akka-management.git#8a25c86a6630f2f6116cf533b03e38fac1849712"
 
   // for now anyway, ambition level is just to include anything lagom needs
   extra.projects: ["akka-management", "cluster-bootstrap", "cluster-http"]

--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -1,15 +1,14 @@
-// https://github.com/akka/akka.git#v2.6.8  # was master
+// https://github.com/akka/akka.git#v2.6.9  # was master
 
 // perhaps eventually there will be a release-2.6 branch for us to track;
 // at present (August 2020) 2.6.x development is still happening on master
 
-// we track master when possible, but at present (September 2020) 2.6.9 broke
-// akka-management downstream, so freezing at 2.6.8 for now. reported upstream
-// at https://github.com/akka/akka-management/issues/762
+// pinned at 2.6.9 for now (September 2020) since master has source-incompatible
+// changes to Member that broke akka-management downstream
 
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/akka/akka.git#6b67e865f6455500e997bf506180d6d93a67aee2"
+  uri: "https://github.com/akka/akka.git#ca59d8149c014def7dba92ce224759c3339b6459"
 
   extra.options: [
     // as per their own .sbtopts file
@@ -35,7 +34,7 @@ vars.proj.akka: ${vars.base} {
 
 vars.proj.akka-stream: ${vars.base} {
   name: "akka-stream"
-  uri: "https://github.com/akka/akka.git#6b67e865f6455500e997bf506180d6d93a67aee2"
+  uri: "https://github.com/akka/akka.git#ca59d8149c014def7dba92ce224759c3339b6459"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     // repo readme recommended
@@ -75,7 +74,7 @@ vars.proj.akka-stream: ${vars.base} {
 // tests, and so failures in obscure subprojects don't take out too much of the build
 vars.proj.akka-more: ${vars.base} {
   name: "akka-more"
-  uri: "https://github.com/akka/akka.git#6b67e865f6455500e997bf506180d6d93a67aee2"
+  uri: "https://github.com/akka/akka.git#ca59d8149c014def7dba92ce224759c3339b6459"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     // repo readme recommended


### PR DESCRIPTION
references https://github.com/akka/akka-management/issues/762

~~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1861/~~
~~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1862/~~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1863/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1864/