### PR TITLE
2.11: move to sbt 1.4.0-RC2

### DIFF
--- a/advance
+++ b/advance
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.3.13 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.0-RC2 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to advance all projects:
 //   % ./advance scalacheck

--- a/community.conf
+++ b/community.conf
@@ -43,7 +43,8 @@ vars {
   default-commands: []
   sbt-0-13-version: "0.13.18"
   sbt-1-2-version: "1.2.8"
-  sbt-version: "1.3.13"
+  sbt-1-3-version: "1.3.13"
+  sbt-version: "1.4.0-RC2"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/narrow
+++ b/narrow
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.3.13 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.0-RC2 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to narrow projs.conf to just one project and its dependencies:
 //   % ./narrow scalacheck

--- a/proj/akka-http.conf
+++ b/proj/akka-http.conf
@@ -6,6 +6,8 @@ vars.proj.akka-http: ${vars.base} {
   name: "akka-http"
   uri: "https://github.com/akka/akka-http.git#dd83ffec0973b9f1fe5349622743d757bb1fe6af"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: ["docs", "akka-http-bench-jmh"]
   extra.options: [
     "-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false"

--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -7,6 +7,7 @@ vars.proj.breeze: ${vars.base} {
   name: "breeze"
   uri: "https://github.com/scalanlp/breeze.git#d6d007f69a890da6b8cd1d356761621dea06c8bc"
 
+  extra.exclude: ["benchmarks"]  // out of scope
   // tests don't compile, could be a ScalaCheck 1.13 vs 1.14 thing?
   // see https://github.com/scala/community-builds/pull/722
   extra.run-tests: false

--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -7,7 +7,7 @@ vars.proj.breeze: ${vars.base} {
   name: "breeze"
   uri: "https://github.com/scalanlp/breeze.git#d6d007f69a890da6b8cd1d356761621dea06c8bc"
 
-  extra.exclude: ["benchmarks"]  // out of scope
+  extra.exclude: ["benchmark"]  // out of scope
   // tests don't compile, could be a ScalaCheck 1.13 vs 1.14 thing?
   // see https://github.com/scala/community-builds/pull/722
   extra.run-tests: false

--- a/proj/catalysts.conf
+++ b/proj/catalysts.conf
@@ -7,6 +7,8 @@ vars.proj.catalysts: ${vars.base} {
   name: "catalysts"
   uri: "https://github.com/typelevel/catalysts.git#f8676a187fa56aad78d5046323312823e66bed9a"
 
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // other projects aren't pertinent or errored out (not investigated)
   extra.projects: ["specbaseJVM", "lawkitJVM", "scalatestJVM", "macrosJVM", "platformJVM", "testkitJVM"]
 }

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -6,7 +6,7 @@
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/scalacommunitybuild/cats.git#d93ccc0a55734bee059f1402b11e7c3363b0f938"
+  uri: "https://github.com/scalacommunitybuild/cats.git#591a96dfbedd1029d539d108be00124cd0f97f1a"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.

--- a/proj/coursier.conf
+++ b/proj/coursier.conf
@@ -6,6 +6,8 @@ vars.proj.coursier: ${vars.base} {
   name: "coursier"
   uri: "https://github.com/coursier/coursier.git#dbaf748fadab1937b3d4dfbfed3cc38727d45c1a"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.projects: ["jvm"]
   extra.exclude: [
     // these require scalaz-concurrent (but that dependency will go away when we unfreeze)

--- a/proj/droste.conf
+++ b/proj/droste.conf
@@ -10,6 +10,8 @@ vars.proj.droste: ${vars.base} {
   name: "droste"
   uri: "https://github.com/higherkindness/droste.git#bad7dae60a0c32e66918613068d6713d209cc6b4"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: [
     // out of scope
     "*JS", "docs", "readme", "publish", "coverage"

--- a/proj/enumeratum.conf
+++ b/proj/enumeratum.conf
@@ -8,6 +8,9 @@ vars.proj.enumeratum: ${vars.base} {
   name: "enumeratum"
   uri: "https://github.com/lloydmeta/enumeratum.git#754ac5564a2a22834eae93639460d22e238fa684"
 
+  // looks like just an out-of-date sbt-doctest version, but meh,
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.projects: [
     // for some reason dbuild doesn't seem to pick up on which subprojects
     // depend on each other, so we have to list them individually (even

--- a/proj/fs2.conf
+++ b/proj/fs2.conf
@@ -5,6 +5,9 @@ vars.proj.fs2: ${vars.base} {
   name: "fs2"
   uri: "https://github.com/typelevel/fs2.git#e081648152626f2be832b881c83fb282f1e29602"
 
+  // looks like just an out-of-date sbt-doctest version, but meh,
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.projects: ["coreJVM", "io", "reactiveStreams"]  // no Scala.js, no benchmarks or docs
   extra.commands: ${vars.default-commands} [
     // otherwise sbt-gpg errors on `publish`

--- a/proj/gigahorse.conf
+++ b/proj/gigahorse.conf
@@ -4,6 +4,8 @@ vars.proj.gigahorse: ${vars.base} {
   name: "gigahorse"
   uri: "https://github.com/eed3si9n/gigahorse.git#763b23f0786c6d191712e2152803696a8a13b760"
 
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // as of August 2017, doesn't compile against latest akka-http
   extra.exclude: ["akkaHttp"]
 }

--- a/proj/http4s.conf
+++ b/proj/http4s.conf
@@ -10,6 +10,9 @@ vars.proj.http4s: ${vars.base} {
   name: "http4s"
   uri: "https://github.com/http4s/http4s.git#fe95025ddc3584b26767eac63c430edebc4b0b2f"
 
+  // looks like just an out-of-date sbt-doctest version, but meh,
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.commands: ${vars.default-commands} [
     // UriSpec: didn't compile (October 2018), it didn't seem worth investigating, probably a specs2 change
     // EntityDecoderSpec: test started failing (August 2019), seems like a ScalaCheck issue,

--- a/proj/play-ws.conf
+++ b/proj/play-ws.conf
@@ -6,6 +6,8 @@ vars.proj.play-ws: ${vars.base} {
   name: "play-ws"
   uri: "https://github.com/playframework/play-ws.git#6a9d4bc927de89a063523cc8cc9962fe23a9f694"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // NullPointerException in CachingSpec
   // (https://github.com/scala/community-builds/issues/564)
   extra.exclude: ["integration-tests", "bench"]

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -6,6 +6,8 @@ vars.proj.playframework: ${vars.base} {
   name: "playframework"
   uri: "https://github.com/playframework/playframework.git#1a95fba96cd9262c801eaf30c12adca800f771fc"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin"  // out of scope
     "Play-Integration-Test"  // TODO/WIP, see https://github.com/scala/community-builds/pull/819

--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -6,6 +6,8 @@ vars.proj.spire: ${vars.base} {
   name: "spire"
   uri: "https://github.com/typelevel/spire.git#284f7888071830d7c2ac5d545b622e1eddf6c930"
 
+  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // hopefully avoid intermittent OutOfMemoryErrors during compilation
   extra.options: ["-Xmx2560m"]
   // this is all of spireJVM but omitting "benchmark". just excluding "benchmark" didn't work, idk why

--- a/report/project/build.properties
+++ b/report/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0-RC2


### PR DESCRIPTION
backport from 2.13.x

~~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2048/~~
~~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2050/~~
~~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2053/~~
~~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2054/~~
https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2059/