### PR TITLE
2.11: sbt 1.4.0-RC2 vs 1.4.0

### DIFF
--- a/proj/akka-http.conf
+++ b/proj/akka-http.conf
@@ -6,8 +6,6 @@ vars.proj.akka-http: ${vars.base} {
   name: "akka-http"
   uri: "https://github.com/akka/akka-http.git#dd83ffec0973b9f1fe5349622743d757bb1fe6af"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
-  extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: ["docs", "akka-http-bench-jmh"]
   extra.options: [
     "-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false"

--- a/proj/catalysts.conf
+++ b/proj/catalysts.conf
@@ -7,8 +7,6 @@ vars.proj.catalysts: ${vars.base} {
   name: "catalysts"
   uri: "https://github.com/typelevel/catalysts.git#f8676a187fa56aad78d5046323312823e66bed9a"
 
-  // here on the 2.11.x branch, it's fine to just stay on 1.3
-  extra.sbt-version: ${vars.sbt-1-3-version}
   // other projects aren't pertinent or errored out (not investigated)
   extra.projects: ["specbaseJVM", "lawkitJVM", "scalatestJVM", "macrosJVM", "platformJVM", "testkitJVM"]
 }

--- a/proj/catalysts.conf
+++ b/proj/catalysts.conf
@@ -7,6 +7,9 @@ vars.proj.catalysts: ${vars.base} {
   name: "catalysts"
   uri: "https://github.com/typelevel/catalysts.git#f8676a187fa56aad78d5046323312823e66bed9a"
 
+  // looks like just an out-of-date sbt-doctest version, but meh,
+  // here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // other projects aren't pertinent or errored out (not investigated)
   extra.projects: ["specbaseJVM", "lawkitJVM", "scalatestJVM", "macrosJVM", "platformJVM", "testkitJVM"]
 }

--- a/proj/coursier.conf
+++ b/proj/coursier.conf
@@ -6,7 +6,7 @@ vars.proj.coursier: ${vars.base} {
   name: "coursier"
   uri: "https://github.com/coursier/coursier.git#dbaf748fadab1937b3d4dfbfed3cc38727d45c1a"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  // failed extraction on 1.4.0; fine to stay on 1.3, here on the 2.11.x branch
   extra.sbt-version: ${vars.sbt-1-3-version}
   extra.projects: ["jvm"]
   extra.exclude: [

--- a/proj/droste.conf
+++ b/proj/droste.conf
@@ -10,7 +10,7 @@ vars.proj.droste: ${vars.base} {
   name: "droste"
   uri: "https://github.com/higherkindness/droste.git#bad7dae60a0c32e66918613068d6713d209cc6b4"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  // failed extraction on 1.4.0; fine to stay on 1.3, here on the 2.11.x branch
   extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: [
     // out of scope

--- a/proj/gigahorse.conf
+++ b/proj/gigahorse.conf
@@ -4,8 +4,6 @@ vars.proj.gigahorse: ${vars.base} {
   name: "gigahorse"
   uri: "https://github.com/eed3si9n/gigahorse.git#763b23f0786c6d191712e2152803696a8a13b760"
 
-  // here on the 2.11.x branch, it's fine to just stay on 1.3
-  extra.sbt-version: ${vars.sbt-1-3-version}
   // as of August 2017, doesn't compile against latest akka-http
   extra.exclude: ["akkaHttp"]
 }

--- a/proj/gigahorse.conf
+++ b/proj/gigahorse.conf
@@ -4,6 +4,9 @@ vars.proj.gigahorse: ${vars.base} {
   name: "gigahorse"
   uri: "https://github.com/eed3si9n/gigahorse.git#763b23f0786c6d191712e2152803696a8a13b760"
 
+  // hits issue with json4s having inlined scala stdlib (can't find ticket)
+  // but here on the 2.11.x branch, it's fine to just stay on 1.3
+  extra.sbt-version: ${vars.sbt-1-3-version}
   // as of August 2017, doesn't compile against latest akka-http
   extra.exclude: ["akkaHttp"]
 }

--- a/proj/play-ws.conf
+++ b/proj/play-ws.conf
@@ -6,8 +6,6 @@ vars.proj.play-ws: ${vars.base} {
   name: "play-ws"
   uri: "https://github.com/playframework/play-ws.git#6a9d4bc927de89a063523cc8cc9962fe23a9f694"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
-  extra.sbt-version: ${vars.sbt-1-3-version}
   // NullPointerException in CachingSpec
   // (https://github.com/scala/community-builds/issues/564)
   extra.exclude: ["integration-tests", "bench"]

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -6,7 +6,7 @@ vars.proj.playframework: ${vars.base} {
   name: "playframework"
   uri: "https://github.com/playframework/playframework.git#1a95fba96cd9262c801eaf30c12adca800f771fc"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
+  // failed extraction on 1.4.0; fine to stay on 1.3, here on the 2.11.x branch
   extra.sbt-version: ${vars.sbt-1-3-version}
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin"  // out of scope

--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -6,8 +6,6 @@ vars.proj.spire: ${vars.base} {
   name: "spire"
   uri: "https://github.com/typelevel/spire.git#284f7888071830d7c2ac5d545b622e1eddf6c930"
 
-  // failed extraction on 1.4.0-RC2; fine to stay on 1.3, here on the 2.11.x branch
-  extra.sbt-version: ${vars.sbt-1-3-version}
   // hopefully avoid intermittent OutOfMemoryErrors during compilation
   extra.options: ["-Xmx2560m"]
   // this is all of spireJVM but omitting "benchmark". just excluding "benchmark" didn't work, idk why


### PR DESCRIPTION
~~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2069/~~
https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2071/