### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# September 28, 2020
-nightly=2.13.4-bin-8c86b7d
+# October 9, 2020
+nightly=2.13.4-bin-8b9858e


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/1991/