### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 9, 2020
-nightly=2.12.13-bin-9a51b6d
+# October 22, 2020
+nightly=2.12.13-bin-2ab9556

--- a/proj/acyclic.conf
+++ b/proj/acyclic.conf
@@ -1,8 +1,8 @@
 // https://github.com/lihaoyi/acyclic.git#d9d1875c67e947758dcb2718f1c2c47af3a8edbb
 
-// frozen (June 2019) at April 2019 commit just before sbt->mill move
+// forked (Oct  2020) for Reporter changes (configurable warnings) compatibility (also had to add an sbt build) // - same as 2.13
 vars.proj.acyclic: ${vars.base} {
   name: "acyclic"
-  uri: "https://github.com/lihaoyi/acyclic.git#d9d1875c67e947758dcb2718f1c2c47af3a8edbb"
+  uri: "https://github.com/scalacommunitybuild/acyclic.git#2e722a0ae253d4c7be31169e8f2397f50d5d876f"
 
 }

--- a/proj/acyclic.conf
+++ b/proj/acyclic.conf
@@ -1,4 +1,4 @@
-// https://github.com/lihaoyi/acyclic.git#d9d1875c67e947758dcb2718f1c2c47af3a8edbb
+// https://github.com/scalacommunitybuild/acyclic.git#2e722a0ae253d4c7be31169e8f2397f50d5d876f
 
 // forked (Oct  2020) for Reporter changes (configurable warnings) compatibility (also had to add an sbt build) // - same as 2.13
 vars.proj.acyclic: ${vars.base} {

--- a/proj/silencer.conf
+++ b/proj/silencer.conf
@@ -1,4 +1,4 @@
-// https://github.com/ghik/silencer.git#787144f5557421017263c1ea36c22f4c078d24cb  # was master
+// https://github.com/dwijnand/silencer.git#c8996a5832a4116c941f895e6069743524107aa4
 
 // frozen (May 2019) at May 2019 commit just before ScalaTest 3.1 upgrade
 // forked (Oct 2020) to dnw's backport-Reporter-changes-in-2.12 branch

--- a/proj/silencer.conf
+++ b/proj/silencer.conf
@@ -5,7 +5,7 @@
 
 vars.proj.silencer: ${vars.base} {
   name: "silencer"
-  uri: "https://github.com/dwijnand/silencer.git#3d3795aacb9c587d0d806cdb7c5fb5191cb40726"
+  uri: "https://github.com/dwijnand/silencer.git#c8996a5832a4116c941f895e6069743524107aa4"
 
   // a test will need adjusting once 2.12.12 is out, as per
   // https://github.com/scala/community-build/pull/1159

--- a/proj/silencer.conf
+++ b/proj/silencer.conf
@@ -1,10 +1,11 @@
 // https://github.com/ghik/silencer.git#787144f5557421017263c1ea36c22f4c078d24cb  # was master
 
 // frozen (May 2019) at May 2019 commit just before ScalaTest 3.1 upgrade
+// forked (Oct 2020) to dnw's backport-Reporter-changes-in-2.12 branch
 
 vars.proj.silencer: ${vars.base} {
   name: "silencer"
-  uri: "https://github.com/ghik/silencer.git#787144f5557421017263c1ea36c22f4c078d24cb"
+  uri: "https://github.com/dwijnand/silencer.git#3d3795aacb9c587d0d806cdb7c5fb5191cb40726"
 
   // a test will need adjusting once 2.12.12 is out, as per
   // https://github.com/scala/community-build/pull/1159

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -66,14 +66,23 @@ object SuccessReport {
     "twitter-util",  // Unrecognized VM option 'AggressiveOpts'
   )
 
+  val scala_2_12_13_Failures = Set[String](
+    "scalameta",
+    "zinc",
+    "linter",
+    "splain",
+    "scala-rewrites",
+    "scala-refactoring",
+  )
+
   val expectedToFail: Set[String] =
     System.getProperty("java.specification.version") match {
       case "1.8" =>
-        jdk8Failures
+        jdk8Failures ++ scala_2_12_13_Failures
       case "11" =>
-        jdk8Failures ++ jdk11Failures
+        jdk8Failures ++ jdk11Failures ++ scala_2_12_13_Failures
       case _ =>
-        jdk11Failures ++ jdk15Failures
+        jdk11Failures ++ jdk15Failures ++ scala_2_12_13_Failures
     }
 
   def apply(log: io.Source): Option[Int] = {


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6145/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6146/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6163/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6167/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6169/ - that fixed silencer, next let's try acyclic
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6171/