### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 23, 2020
-nightly=2.13.4-bin-991ff8a
+# October 29, 2020
+nightly=2.13.4-bin-200c122

--- a/proj/twirl.conf
+++ b/proj/twirl.conf
@@ -1,8 +1,12 @@
-// https://github.com/playframework/twirl.git#master
+// https://github.com/scalacommunitybuild/twirl.git#community-build-2.13  # was playframework, master
+
+// forked (October 2020) to fix a test that is sensitive to an exhaustiveness warning
+// introduced in 2.13.4.  we should be able to unfork once 2.13.4 is released and
+// upstream upgrades
 
 vars.proj.twirl: ${vars.base} {
   name: "twirl"
-  uri: "https://github.com/playframework/twirl.git#a769228cd036e2757c3b1ced0ac7dc590d9d5170"
+  uri: "https://github.com/scalacommunitybuild/twirl.git#2a9329b994672d4157740bb18c933f3b175b347c"
 
   extra.exclude: ["plugin", "apiJS"]
   deps.ignore: ["org.scala-sbt#scripted-plugin"]


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2070/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2071/