### PR TITLE
Adapt Scalameta for 2.12.13 changes

### DIFF
--- a/proj/scalameta.conf
+++ b/proj/scalameta.conf
@@ -7,7 +7,7 @@
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalacommunitybuild/scalameta.git#7c707d09940e70e7a6e605f1474bdd614004dda1"
+  uri: "https://github.com/scalacommunitybuild/scalameta.git#2d12d1830ccca0bfe273b03a7f3160716f99366d"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   // allow building on JDK 11

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -67,8 +67,9 @@ object SuccessReport {
   )
 
   val scala_2_12_13_Failures = Set[String](
-    "scalameta",
     "zinc",
+    "silencer",
+    "mdoc",
   )
 
   val expectedToFail: Set[String] =


### PR DESCRIPTION
Passed in https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6192/ and then I added mdoc and silencer to the exclusion list.