### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 29, 2020
-nightly=2.13.4-bin-200c122
+# November 4, 2020
+nightly=2.13.4-bin-7101549

--- a/proj/scala-stm.conf
+++ b/proj/scala-stm.conf
@@ -4,6 +4,7 @@ vars.proj.scala-stm: ${vars.base} {
   name: "scala-stm"
   uri: "https://github.com/scala-stm/scala-stm.git#485e30b36c673fabd862260faa387a66ba6454ca"
 
+  extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [
     // prone to intermittent failure
     """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "TMapSuite.scala""""

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,11 +1,14 @@
-// https://github.com/scalacenter/scalafix.git#2447708096981e179f63fb5648eb67f190e9196f  # was master
+// https://github.com/scalacommunitybuild/scalafix.git#community-build-2.13  # was master; was 2447708096981e179f63fb5648eb67f190e9196f
 
 // frozen (October 2020); newer commit caused breakage downstream
 // (in simulacrum-scalafix-more)
 
+// forked (November 2020) from 24477080, to adapt to
+// scala/scala#9292 (CharSequence)
+
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#2447708096981e179f63fb5648eb67f190e9196f"
+  uri: "https://github.com/scalacommunitybuild/scalafix.git#ae44ac75960f1b986665066498d18f37b31d38b3"
 
   extra.exclude: [
     // out of scope

--- a/proj/scalatest-3-0.conf
+++ b/proj/scalatest-3-0.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalatest-3-0: ${vars.base} {
   name: "scalatest-3-0"
-  uri: "https://github.com/scalacommunitybuild/scalatest.git#fef9ecb765d18417a28b9f0fa88b9816d6f1ec94"
+  uri: "https://github.com/scalacommunitybuild/scalatest.git#77f0381ab128b3f3b4873cbc8d1d73aafad56a8c"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.projects: ["scalatest"]

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -1,12 +1,15 @@
-// https://github.com/scalatest/scalatest.git#df4981ed793b66576d8f634443fe4aa91a971908  # was 3.2.x-new
+// https://github.com/SethTisue/scalatest.git#charsequence  # was scalatest, 3.2.x-new
 
 // frozen (October 2020) at a known-green commit before compile errors started
 // (missing source file) -- we should try to unfreeze at some point and report
 // it upstream if the problem hasn't gone away
 
+// temporarily forked (October 2020) to adapt to scala/scala#9292;
+// fork point: df4981ed793b66576d8f634443fe4aa91a971908
+
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"
-  uri: "https://github.com/scalatest/scalatest.git#df4981ed793b66576d8f634443fe4aa91a971908"
+  uri: "https://github.com/SethTisue/scalatest.git#2f6a176cdc95890efa1c8cb3de2e6485c8e4b48f"
 
   extra.projects: ["scalatest", "scalactic", "scalatestFunSuite"]
 }
@@ -16,7 +19,7 @@ vars.proj.scalatest: ${vars.base} {
 
 vars.proj.scalatest-tests: ${vars.base} {
   name: "scalatest-tests"
-  uri: "https://github.com/scalatest/scalatest.git#df4981ed793b66576d8f634443fe4aa91a971908"
+  uri: "https://github.com/SethTisue/scalatest.git#2f6a176cdc95890efa1c8cb3de2e6485c8e4b48f"
 
   // not investigated. build is big/fragile, cost/benefit probably isn't there
   extra.sbt-version: ${vars.sbt-1-3-version}

--- a/proj/scoverage.conf
+++ b/proj/scoverage.conf
@@ -1,13 +1,17 @@
-// https://github.com/lrytz/scalac-scoverage-plugin.git#scala-2.13.1
+// https://github.com/scalacommunitybuild/scalac-scoverage-plugin.git#community-build-2.13  # was lrytz, scala-2.13.1; was scoverage, master
 
 // 2.13: using Lukas's branch until this is merged:
 // https://github.com/scoverage/scalac-scoverage-plugin/pull/279
+// (but the PR has now languished for ages)
+
+// then forked (November 2020) off Lukas's branch, to adapt to
+// scala/scala#9292 (CharSequence)
 
 vars.proj.scoverage: ${vars.base} {
   name: "scoverage"
-  uri: "https://github.com/lrytz/scalac-scoverage-plugin.git#f25a06ac3c2f59c3955a67c6868878ff6e32ba3d"
+  uri: "https://github.com/scalacommunitybuild/scalac-scoverage-plugin.git#ddf42b4551be8f3026ec787fabced88e4e5a9de7"
 
-  extra.exclude: ["scalac-scoverage-runtimeJS"] // no Scala.js please
+  extra.exclude: ["*JS"]
   // [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].
   // January 2018: failure's continued existence confirmed
   // see https://github.com/scala/community-builds/pull/387


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2092/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2093/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2094/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2095/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2096/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2097/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2098/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2106/