### PR TITLE
CB 2.12 fixes

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 2, 2020
-nightly=2.12.13-bin-42f2bd8
+# November 4, 2020
+nightly=2.12.13-bin-2d4985d

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -15,6 +15,7 @@ vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
   uri: "https://github.com/scalacommunitybuild/mdoc.git#23d958c5c8cbce81d59b889be7198003b39236ad"
 
+  extra.sbt-version: ${vars.sbt-1-2-version} # otherwise "NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project"
   extra.exclude: [
     "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"
     "js", "jsdocs", "docs", "unit"  // no Scala.js plz

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -1,13 +1,19 @@
-// https://github.com/scalameta/mdoc.git#364ebde027114563f2c87464c8885a3ab59a658d  # was master
+// https://github.com/scalacommunitybuild/mdoc.git#community-build-2.12
+
+// forked (Nov 2020) to the previously frozen commit, with copying the 2.13 Reporter adaptions to the 2.12 sources
 
 // frozen (September 2019) at an August 2019 commit some time before a sbt-coursier
+//     https://github.com/scalameta/mdoc.git#364ebde027114563f2c87464c8885a3ab59a658d
 // version bump that seems to be confusing dbuild during dependency extraction:
 // java.lang.NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project(Llmcoursier/definitions/Project;)Lcoursier/core/Project;
 //   at coursier.sbtcoursier.ResolutionTasks$.$anonfun$resolutionsTask$3(ResolutionTasks.scala:42)
 
+// official uri:
+//     https://github.com/scalameta/mdoc.git#master
+
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalameta/mdoc.git#364ebde027114563f2c87464c8885a3ab59a658d"
+  uri: "https://github.com/scalacommunitybuild/mdoc.git#23d958c5c8cbce81d59b889be7198003b39236ad"
 
   extra.exclude: [
     "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,10 +1,16 @@
-// https://github.com/scalacenter/scalafix.git#387fd2725cea0252d8beed2400aacd5bd6bb1efb  # was master
+// https://github.com/scalacommunitybuild/scalafix.git#community-build-2.12
 
+// forked (Nov 2020) to fix a failing test
+
+//     https://github.com/scalacenter/scalafix.git#387fd2725cea0252d8beed2400aacd5bd6bb1efb  # was master
 // on 2.12.x, we're leaving fastparse(1)+scalapb+scalameta+scalafix+scalafmt all frozen
+
+// official uri:
+//     https://github.com/scalacenter/scalafix.git#master
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#387fd2725cea0252d8beed2400aacd5bd6bb1efb"
+  uri: "https://github.com/scalacommunitybuild/scalafix.git#363647c8a6f67d8f81b0dde3b3dec9c5b2d638ce"
 
   extra.exclude: ["docs"]
   extra.commands: ${vars.default-commands} [

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -66,7 +66,13 @@ object SuccessReport {
   )
 
   val scala_2_12_13_Failures = Set[String](
-    "scalafix",
+    // The following 2 projects get:
+    //     java.lang.NoSuchMethodError: scala.tools.nsc.Global.reporter()Lscala/tools/nsc/reporters/Reporter;
+    // scala-rewrites depends on scalafix/scalameta which is in a state in the 2.12 CB,
+    //   so it uses binary dependencies instead of rebuilding from source, which is why it hits this
+    // sbt hits this via its use of kind-projector - didn't look why that isn't a just-compiled kind-projector
+    "scala-rewrites", // Global#reporter https://scala-ci.typesafe.com/job/scala-2.12.x-jdk8-integrate-community-build/6206/artifact/logs/scala-rewrites-build.log
+    "sbt",            // Global#reporter https://scala-ci.typesafe.com/job/scala-2.12.x-jdk8-integrate-community-build/6206/artifact/logs/sbt-build.log
   )
 
   val expectedToFail: Set[String] =

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -66,9 +66,6 @@ object SuccessReport {
   )
 
   val scala_2_12_13_Failures = Set[String](
-    "zinc", // fixed pending scala/scala#9298 being merged and nightly.properties bump
-    "silencer",
-    "mdoc",
     "scalafix",
   )
 


### PR DESCRIPTION
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6209/console

```
Lines of Scala code recompiled during this run only:
    15305 scalafix
     2955 sbt
      362 scala-rewrites
      155 shapeless-java-records
    18777 TOTAL
SUCCEEDED: 211
FAILED: 3
BLOCKED, DID NOT RUN: 0
TOTAL: 214
```

This is good to go.