### PR TITLE
move to ScalaCheck 1.15

### DIFF
--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -1,8 +1,11 @@
-// https://github.com/scalanlp/breeze.git#master
+// https://github.com/SethTisue/breeze.git#scalacheck-1.15
+
+// temporarily forked (November 2020) for ScalaCheck 1.15 upgrade, pending merge of
+// https://github.com/scalanlp/breeze/pull/795
 
 vars.proj.breeze: ${vars.base} {
   name: "breeze"
-  uri: "https://github.com/scalanlp/breeze.git#40b99f6a6fbd8454ff8874d6ed34e860f49b6662"
+  uri: "https://github.com/SethTisue/breeze.git#6247c10daefc43bacc9131a218c42d206956027b"
 
   extra.exclude: ["benchmark"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck.conf
+++ b/proj/scalacheck.conf
@@ -1,8 +1,8 @@
-// https://github.com/typelevel/scalacheck.git#1.14.x
+// https://github.com/typelevel/scalacheck.git#master
 
 vars.proj.scalacheck: ${vars.base} {
   name: "scalacheck"
-  uri: "https://github.com/typelevel/scalacheck.git#c63b932c0a1fedfea7a6c494f3870a301a48e3fe"
+  uri: "https://github.com/typelevel/scalacheck.git#567ad167533b3f1395250ffd7128d9dc47bab074"
 
   extra.projects: ["jvm"]  // no Scala.js please
 }


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2115/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2117/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2118/