### PR TITLE
unfork scalafix and run tests

### DIFF
--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,26 +1,10 @@
-// https://github.com/scalacommunitybuild/scalafix.git#community-build-2.13  # was master; was 2447708096981e179f63fb5648eb67f190e9196f
-
-// frozen (October 2020); newer commit caused breakage downstream
-// (in simulacrum-scalafix-more)
-
-// forked (November 2020) from 24477080, to adapt to
-// scala/scala#9292 (CharSequence). submitted upstream:
-// https://github.com/scalacenter/scalafix/pull/1279
+// https://github.com/scalacenter/scalafix.git#master
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacommunitybuild/scalafix.git#ae44ac75960f1b986665066498d18f37b31d38b3"
+  uri: "https://github.com/scalacenter/scalafix.git#69c0369ab49c41b0473ca68fe0a8ade396d3157e"
 
-  extra.exclude: [
-    // out of scope
-    "docs"
-    // it would really be better if we could build and run the tests, but this
-    // subproject is defined in a really peculiar way that confuses dbuild.
-    // the build overrides compileInputs and resourceGenerators to refer
-    // to the source directories from other subprojects... I don't understand it.
-    // for now anyway, giving up.
-    "unit"
-  ]
+  extra.exclude: ["docs"]
   // testkit wants ScalaTest 3.0
   deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -8,4 +8,10 @@ vars.proj.scalafix: ${vars.base} {
   uri: "https://github.com/SethTisue/scalafix.git#cce54f38507ebe70eb847bf202c62290b4ae0724"
 
   extra.exclude: ["docs"]
+  // testkit needs ScalaTest 3.0, but unit needs 3.2. weird...
+  deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
+  extra.commands: ${vars.default-commands} [
+    """set testkit / libraryDependencies ~= (_.filterNot(_.toString.contains("scalatest")))"""
+    """set testkit / libraryDependencies += "scalacommunitybuild" %% "scalatest" % "0""""
+  ]
 }

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,14 +1,25 @@
 // https://github.com/scalacenter/scalafix.git#master
 
+// this is split into two because of the weirdness where the testkit
+// subproject wants ScalaTest 3.0, but the unit subproject wants 3.2,
+// as per discussion on https://github.com/scala/community-build/pull/1290
+
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
   uri: "https://github.com/scalacenter/scalafix.git#81220161f7353dc4a1c2e2b95204dfdfaec96bc9"
 
-  extra.exclude: ["docs"]
-  // testkit needs ScalaTest 3.0, but unit needs 3.2. weird...
+  extra.exclude: ["docs", "unit"]
   deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
   extra.commands: ${vars.default-commands} [
-    """set testkit / libraryDependencies ~= (_.filterNot(_.toString.contains("scalatest")))"""
     """set testkit / libraryDependencies += "scalacommunitybuild" %% "scalatest" % "0""""
   ]
+}
+
+vars.proj.scalafix-tests: ${vars.base} {
+  name: "scalafix-tests"
+  uri: "https://github.com/scalacenter/scalafix.git#81220161f7353dc4a1c2e2b95204dfdfaec96bc9"
+
+  extra.projects: ["unit"]
+  // these were built above already
+  extra.exclude: ["test*", "interfaces", "core", "rules", "reflect", "cli"]
 }

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,8 +1,11 @@
-// https://github.com/scalacenter/scalafix.git#master
+// https://github.com/SethTisue/scalafix.git#avoid-arraycharsequence  # was scalacenter, master
+
+// temporarily forked pending merge of
+// https://github.com/scalacenter/scalafix/pull/1279
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#69c0369ab49c41b0473ca68fe0a8ade396d3157e"
+  uri: "https://github.com/SethTisue/scalafix.git#cce54f38507ebe70eb847bf202c62290b4ae0724"
 
   extra.exclude: ["docs"]
   // testkit wants ScalaTest 3.0

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -8,10 +8,4 @@ vars.proj.scalafix: ${vars.base} {
   uri: "https://github.com/SethTisue/scalafix.git#cce54f38507ebe70eb847bf202c62290b4ae0724"
 
   extra.exclude: ["docs"]
-  // testkit wants ScalaTest 3.0
-  deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
-  extra.commands: ${vars.default-commands} [
-    "removeDependency org.scalatest scalatest"
-    """set testkit / libraryDependencies += "scalacommunitybuild" %% "scalatest" % "0""""
-  ]
 }

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,11 +1,8 @@
-// https://github.com/SethTisue/scalafix.git#avoid-arraycharsequence  # was scalacenter, master
-
-// temporarily forked pending merge of
-// https://github.com/scalacenter/scalafix/pull/1279
+// https://github.com/scalacenter/scalafix.git#master
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/SethTisue/scalafix.git#cce54f38507ebe70eb847bf202c62290b4ae0724"
+  uri: "https://github.com/scalacenter/scalafix.git#81220161f7353dc4a1c2e2b95204dfdfaec96bc9"
 
   extra.exclude: ["docs"]
   // testkit needs ScalaTest 3.0, but unit needs 3.2. weird...

--- a/projs.conf
+++ b/projs.conf
@@ -199,6 +199,7 @@ build += {
   ${vars.proj.scalachess}
   ${vars.proj.scaladex}
   ${vars.proj.scalafix}
+  ${vars.proj.scalafix-tests}
   ${vars.proj.scalafmt}
   ${vars.proj.scalafx}
   ${vars.proj.scalaj-http}


### PR DESCRIPTION
it's sad if we aren't running Scalafix's tests. let's at least try: maybe there's a fat, delicious, slow-moving rabbit not too far down the hole

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2146/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2147/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2148/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2150/