### PR TITLE
unfreeze mercator

### DIFF
--- a/proj/mercator.conf
+++ b/proj/mercator.conf
@@ -4,7 +4,7 @@
 
 vars.proj.mercator: ${vars.base} {
   name: "mercator"
-  uri: "https://github.com/propensive/mercator.git#433fdfc760db2535548f274de8c83c34feb86948"
+  uri: "https://github.com/propensive/mercator.git#771f7d8c7683b26864c897b8f8898dc5eeceb286"
 
   extra.projects: ["coreJVM", "tests"]
 }

--- a/proj/mercator.conf
+++ b/proj/mercator.conf
@@ -1,9 +1,6 @@
-// https://github.com/propensive/mercator.git#433fdfc760db2535548f274de8c83c34feb86948  # was master
+// https://github.com/propensive/mercator.git#master
 
 // dependency of magnolia, avro4s
-
-// frozen (January 2020) at a known-green commit before compilation started
-// failing; reported upstream at https://github.com/propensive/mercator/issues/19
 
 vars.proj.mercator: ${vars.base} {
   name: "mercator"


### PR DESCRIPTION
if this works, I should merge it forward onto 2.13.x as well

fyi @propensive

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6243/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6245/