### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 13, 2020
-nightly=2.12.13-bin-2166efc
+# November 18, 2020
+nightly=2.12.13-bin-5ee239e

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -1,8 +1,11 @@
-// https://github.com/lightbend/mima.git#master
+// https://github.com/SethTisue/mima.git#adapt-to-2.12.13  # was lightbend, master
+
+// temporarily forked pending merge of
+// https://github.com/lightbend/mima/pull/580
 
 vars.proj.mima: ${vars.base} {
   name: "mima"
-  uri: "https://github.com/lightbend/mima.git#b40d3644f61442102262cf01359a5a4df7942068"
+  uri: "https://github.com/SethTisue/mima.git#9cf0bd289a3c4b945ac1eb28aaf2b00f8c1b4137"
 
   extra.exclude: ["sbtplugin"]  // out of scope
   // `IntegrationTest/test` doesn't work but `it:test` does. dbuild limitation I guess

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -1,11 +1,8 @@
-// https://github.com/SethTisue/mima.git#adapt-to-2.12.13  # was lightbend, master
-
-// temporarily forked pending merge of
-// https://github.com/lightbend/mima/pull/580
+// https://github.com/lightbend/mima.git#master
 
 vars.proj.mima: ${vars.base} {
   name: "mima"
-  uri: "https://github.com/SethTisue/mima.git#9cf0bd289a3c4b945ac1eb28aaf2b00f8c1b4137"
+  uri: "https://github.com/lightbend/mima.git#ac9cae2a3fa47e1360e137eb822b71e2b1cb3755"
 
   extra.exclude: ["sbtplugin"]  // out of scope
   // `IntegrationTest/test` doesn't work but `it:test` does. dbuild limitation I guess

--- a/proj/scala-parser-combinators.conf
+++ b/proj/scala-parser-combinators.conf
@@ -6,7 +6,7 @@
 
 vars.proj.scala-parser-combinators: ${vars.base} {
   name: "scala-parser-combinators"
-  uri: "https://github.com/scalacommunitybuild/scala-parser-combinators.git#c220aebcb159f22e8d9dec2a6194d94edfc6b5b2"
+  uri: "https://github.com/scalacommunitybuild/scala-parser-combinators.git#4b2add24303a685c698949952e5603a1509a0be7"
 
   extra.exclude: ["*JS", "*Native"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-parser-combinators.conf
+++ b/proj/scala-parser-combinators.conf
@@ -3,6 +3,7 @@
 // forked (October 2020) to upgrade sbt-osgi for JDK 15. I could do it on the real
 // 1.1.x branch but I'm loath to touch it, since 1.2.x is the one under active
 // development
+// adjusted (November 2020) for CharSequence changes in 2.12.13
 
 vars.proj.scala-parser-combinators: ${vars.base} {
   name: "scala-parser-combinators"

--- a/proj/scala-refactoring.conf
+++ b/proj/scala-refactoring.conf
@@ -3,9 +3,11 @@
 // forked (August 2019) to fix some bad Scala-version-checking code, as per
 // https://github.com/scala/scala-dev/issues/644#issuecomment-520562911
 // adjusted (Nov 2020) for the Reporter changes in 2.12.13
+// adjusted (Nov 2020) for the ArrayCharSequence change in 2.12.13
+
 vars.proj.scala-refactoring: ${vars.base} {
   name: "scala-refactoring"
-  uri: "https://github.com/scalacommunitybuild/scala-refactoring.git#ff7dccfe99c0d12079340627f5a9774026010994"
+  uri: "https://github.com/scalacommunitybuild/scala-refactoring.git#13f187bc647dbcb596774fc7cceaa38d6a43379d"
 
   extra.commands: ${vars.default-commands} [
     // these started failing recently, see

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -1,12 +1,10 @@
-// https://github.com/scalacommunitybuild/scalafix.git#community-build-2.12
+// https://github.com/scalacommunitybuild/scalafix.git#community-build-2.12  # was scalacenter, master
 
-// forked (Nov 2020) to fix a failing test
-
-//     https://github.com/scalacenter/scalafix.git#387fd2725cea0252d8beed2400aacd5bd6bb1efb  # was master
 // on 2.12.x, we're leaving fastparse(1)+scalapb+scalameta+scalafix+scalafmt all frozen
 
-// official uri:
-//     https://github.com/scalacenter/scalafix.git#master
+// forked (Nov 2020) to fix a failing test
+//     https://github.com/scalacenter/scalafix.git#387fd2725cea0252d8beed2400aacd5bd6bb1efb  # was master
+// adjusted (November 2020) to adapt to ArrayCharSequence unimplicitifying
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"

--- a/proj/scalafix.conf
+++ b/proj/scalafix.conf
@@ -10,7 +10,7 @@
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacommunitybuild/scalafix.git#363647c8a6f67d8f81b0dde3b3dec9c5b2d638ce"
+  uri: "https://github.com/scalacommunitybuild/scalafix.git#6d2179653124b7be62e10b80112f6802a3247484"
 
   extra.exclude: ["docs"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -5,7 +5,7 @@
 
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"
-  uri: "https://github.com/scalacommunitybuild/scalatest.git#676c4123d48276a0bd4bbf62d683ad0df7a1a04e"
+  uri: "https://github.com/scalacommunitybuild/scalatest.git#4941c9fd882c90d6cfd4aa7e467864f63d736e0e"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.projects: ["scalatest", "scalactic"]
@@ -17,7 +17,7 @@ vars.proj.scalatest: ${vars.base} {
 
 vars.proj.scalatest-tests: ${vars.base} {
   name: "scalatest-tests"
-  uri: "https://github.com/scalacommunitybuild/scalatest.git#676c4123d48276a0bd4bbf62d683ad0df7a1a04e"
+  uri: "https://github.com/scalacommunitybuild/scalatest.git#4941c9fd882c90d6cfd4aa7e467864f63d736e0e"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.exclude: [

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -2,6 +2,7 @@
 
 // forked for: build tweak, JDK 11 friendliness, comment out a test
 // fork refreshed (from 3.0.x branch) January 2019
+// adjusted (November 2020) to adapt to ArrayCharSequence unimplicitifying
 
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"

--- a/proj/scoverage.conf
+++ b/proj/scoverage.conf
@@ -1,10 +1,12 @@
-// https://github.com/scoverage/scalac-scoverage-plugin.git#228da98caee8ac7123408feb98b33b85fcf43cda  # was master
+// https://github.com/scalacommunitybuild/scalac-scoverage-plugin.git#community-build-2.12  # was scoverage, master
 
 // frozen (September 2020) at a known-green commit just before a ScalaTest 3.1 or 3.2 upgrade
+// (228da98caee8ac7123408feb98b33b85fcf43cda)
+// then forked (November 2020) to adapt to ArrayCharSequence unimplicitifying
 
 vars.proj.scoverage: ${vars.base} {
   name: "scoverage"
-  uri: "https://github.com/scoverage/scalac-scoverage-plugin.git#228da98caee8ac7123408feb98b33b85fcf43cda"
+  uri: "https://github.com/scalacommunitybuild/scalac-scoverage-plugin.git#05b837dd2db0d50c565fef95e3f9fc4ecedf0c2a"
 
   extra.exclude: ["scalac-scoverage-runtimeJS"] // no Scala.js please
   // [info] java.io.FileNotFoundException: Could not locate [~/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.0.jar].


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6264/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6267/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6268/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6272/
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6273/