### PR TITLE
2.13: unfork ScalaTest

### DIFF
--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -1,15 +1,8 @@
-// https://github.com/SethTisue/scalatest.git#charsequence  # was scalatest, 3.2.x-new
-
-// frozen (October 2020) at a known-green commit before compile errors started
-// (missing source file) -- we should try to unfreeze at some point and report
-// it upstream if the problem hasn't gone away
-
-// temporarily forked (October 2020) to adapt to scala/scala#9292;
-// fork point: df4981ed793b66576d8f634443fe4aa91a971908
+// https://github.com/scalatest/scalatest.git#3.2.x-new
 
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"
-  uri: "https://github.com/SethTisue/scalatest.git#2f6a176cdc95890efa1c8cb3de2e6485c8e4b48f"
+  uri: "https://github.com/scalatest/scalatest.git#a7abc641d39141bc845fc90a420a6cdde6fc07e0"
 
   extra.projects: ["scalatest", "scalactic", "scalatestFunSuite"]
 }
@@ -19,7 +12,7 @@ vars.proj.scalatest: ${vars.base} {
 
 vars.proj.scalatest-tests: ${vars.base} {
   name: "scalatest-tests"
-  uri: "https://github.com/SethTisue/scalatest.git#2f6a176cdc95890efa1c8cb3de2e6485c8e4b48f"
+  uri: "https://github.com/scalatest/scalatest.git#a7abc641d39141bc845fc90a420a6cdde6fc07e0"
 
   // not investigated. build is big/fragile, cost/benefit probably isn't there
   extra.sbt-version: ${vars.sbt-1-3-version}


### PR DESCRIPTION
needs testing on JDK 15 primarily

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk15-integrate-community-build/1409/ queued