### PR TITLE
unfreeze elastic4s

### DIFF
--- a/proj/elastic4s.conf
+++ b/proj/elastic4s.conf
@@ -1,19 +1,9 @@
-// https://github.com/sksamuel/elastic4s.git#v5.6.11
-
-// dependency of scaladex.  pinned at exact version scaladex expects
-// (as of October 2020 anyway)
+// https://github.com/sksamuel/elastic4s.git#master
 
 vars.proj.elastic4s: ${vars.base} {
   name: "elastic4s"
   uri: "https://github.com/sksamuel/elastic4s.git#0bb518736cee42e753893ca46f4ad02e56fbc559"
 
-  extra.sbt-version: ${vars.sbt-0-13-version}
   // just what scaladex needs, for now anyway
   extra.projects: ["elastic4s-core", "elastic4s-embedded"]
-  // ScalaTest 3.0, not 3.2
-  extra.commands: ${vars.default-commands} [
-    "removeDependency org.scalatest scalatest"
-    """set libraryDependencies in ThisBuild += "scalacommunitybuild" %% "scalatest" % "0" % Test"""
-  ]
-  deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
 }

--- a/proj/elastic4s.conf
+++ b/proj/elastic4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.elastic4s: ${vars.base} {
   name: "elastic4s"
-  uri: "https://github.com/sksamuel/elastic4s.git#0bb518736cee42e753893ca46f4ad02e56fbc559"
+  uri: "https://github.com/sksamuel/elastic4s.git#7d4d6d916f549599642e3e6c10fc8ccbc04b0012"
 
   // just what scaladex needs, for now anyway
   extra.projects: ["elastic4s-core", "elastic4s-embedded"]


### PR DESCRIPTION
context: I want to cut down on the number of projects in the build that are still on sbt 0.13 and/or ScalaTest 3.0

and if scaladex fails downstream, perhaps I could ask someone at the Scala Center to attempt an upgrade

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2247/