### PR TITLE
newer jackson-module-scala

### DIFF
--- a/proj/jackson-module-scala.conf
+++ b/proj/jackson-module-scala.conf
@@ -1,8 +1,8 @@
-// https://github.com/FasterXML/jackson-module-scala.git#2.10
+// https://github.com/FasterXML/jackson-module-scala.git#2.11
 
-// tracking branch for version Akka expects
+// we typically track a release branch
 
-// downstream projects expecting a different jackson version than the
+// downstream projects (Akka et al) expecting a different jackson version than the
 // one we have here are prone to errors such as:
 // com.fasterxml.jackson.databind.JsonMappingException:
 //   Scala module 2.8.8-dbuildx1c5888e4b2a136333f7edb02dbe6dc5abbfa7de1 requires Jackson Databind version >= 2.8.0 and < 2.9.0
@@ -11,7 +11,7 @@
 
 vars.proj.jackson-module-scala: ${vars.base} {
   name: "jackson-module-scala"
-  uri: "https://github.com/FasterXML/jackson-module-scala.git#d9a74ab159e510b3326fa68fd779ce9634fa7fb9"
+  uri: "https://github.com/FasterXML/jackson-module-scala.git#d18bcbcbef750d90312e683518045a660aa4262b"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   // ScalaTest 3.0, not 3.2


### PR DESCRIPTION
context: I want to cut down on the number of projects in the build that are still on sbt 0.13 and/or ScalaTest 3.0

going from 2.10 to 2.11 doesn't get us there. going to 2.12 would, but I want to try the smaller step first, since this is historically a fragile area

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2248/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2252/