### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 23, 2020
-nightly=2.13.5-bin-867f63a
+# December 4, 2020
+nightly=2.13.5-bin-d45a673


### PR DESCRIPTION
~oh oops this hasn't published yet: https://travis-ci.org/github/scala/scala/builds/747666653~

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2255/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2256/