### PR TITLE
explore making Left and Right have only one type parameter

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 23, 2020
-nightly=2.13.5-bin-867f63a
+# https://github.com/scala/scala/pull/9303
+nightly=2.13.5-bin-9c2a584-SNAPSHOT

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/SethTisue/scala-collection-compat.git#7accaef4f06ffb998ef2aaf74f5659e078d50637"
+  uri: "https://github.com/SethTisue/scala-collection-compat.git#5036bb3d213924cc121192307ba64c53f8d30a84"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -1,8 +1,8 @@
-// https://github.com/scala/scala-collection-compat.git#master
+// https://github.com/SethTisue/scala-collection-compat.git#avoid-left-right-type-params
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#52811e6dcea1e3c936d15103b036411eee523d86"
+  uri: "https://github.com/SethTisue/scala-collection-compat.git#7accaef4f06ffb998ef2aaf74f5659e078d50637"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/SethTisue/scala-collection-compat.git#5036bb3d213924cc121192307ba64c53f8d30a84"
+  uri: "https://github.com/SethTisue/scala-collection-compat.git#bc2c5f8eadefec624921a7cab238e4c72b8b6917"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-parser-combinators.conf
+++ b/proj/scala-parser-combinators.conf
@@ -1,8 +1,8 @@
-// https://github.com/scala/scala-parser-combinators.git#1.2.x
+// https://github.com/SethTisue/scala-parser-combinators.git#version-bumps
 
 vars.proj.scala-parser-combinators: ${vars.base} {
   name: "scala-parser-combinators"
-  uri: "https://github.com/scala/scala-parser-combinators.git#14fa7ee66b2f30ea73630e7a82bf6d4f83e2b21f"
+  uri: "https://github.com/SethTisue/scala-parser-combinators.git#df92b0868d45ea33cbac13414d9e78db83c3ff63"
 
   extra.exclude: ["*JS", "*Native"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scodec-bits.conf
+++ b/proj/scodec-bits.conf
@@ -1,8 +1,8 @@
-// https://github.com/SethTisue/scodec-bits.git#avoid-left-right-type-parms
+// https://github.com/SethTisue/scodec-bits.git#avoid-left-right-type-parms-1.1.x
 
 vars.proj.scodec-bits: ${vars.base} {
   name: "scodec-bits"
-  uri: "https://github.com/SethTisue/scodec-bits.git#4d4567e438ba8a1439f993f97cd7842c6f7a7c95"
+  uri: "https://github.com/SethTisue/scodec-bits.git#6ab718977e142b46799dc5e8479afda8e95a3442"
 
   extra.projects: ["coreJVM"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scodec-bits.conf
+++ b/proj/scodec-bits.conf
@@ -1,8 +1,8 @@
-// https://github.com/scodec/scodec-bits.git#series/1.1.x
+// https://github.com/SethTisue/scodec-bits.git#avoid-left-right-type-parms
 
 vars.proj.scodec-bits: ${vars.base} {
   name: "scodec-bits"
-  uri: "https://github.com/scodec/scodec-bits.git#174c962e6e59d3ca861b5d597400f29fe6fcd093"
+  uri: "https://github.com/SethTisue/scodec-bits.git#4d4567e438ba8a1439f993f97cd7842c6f7a7c95"
 
   extra.projects: ["coreJVM"]
   extra.commands: ${vars.default-commands} [


### PR DESCRIPTION
context is https://github.com/scala/scala/pull/9303, cc @joroKr21

source changes needed so far:

* https://github.com/scala/scala-parser-combinators/pull/329/commits/df92b0868d45ea33cbac13414d9e78db83c3ff63
* https://github.com/SethTisue/scodec-bits/commit/6ab718977e142b46799dc5e8479afda8e95a3442
* https://github.com/scala/scala-collection-compat/pull/398/commits/bc2c5f8eadefec624921a7cab238e4c72b8b6917

so far all of these were small, easy, compatible-either-way changes that can even be considered code improvement

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2251/~ `SUCCEEDED: 90`
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2263/~ 
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2264/ `SUCCEEDED: 110`