### PR TITLE
2.12: upgrade sbt (to 1.4.5) & advance project SHAs

### DIFF
--- a/advance
+++ b/advance
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.4 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.5 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to advance all projects:
 //   % ./advance scalacheck

--- a/community.conf
+++ b/community.conf
@@ -48,7 +48,7 @@ vars {
   sbt-0-13-version: "0.13.18"
   sbt-1-2-version: "1.2.8"
   sbt-1-3-version: "1.3.13"
-  sbt-version: "1.4.4"
+  sbt-version: "1.4.5"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/narrow
+++ b/narrow
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.4 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.5 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to narrow projs.conf to just one project and its dependencies:
 //   % ./narrow scalacheck

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#ba279f283b79af2af45de8abebd71134e67dddce"
+  uri: "https://github.com/wvlet/airframe.git#2849c01dfc459cd8a8166805c279cbda6542c565"
 
   check-missing: false  // ignore missing scripted-plugin
   extra.projects: ["communityBuild"]  // no Scala.js plz

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -1,8 +1,13 @@
 // https://github.com/wvlet/airframe.git#master
 
+// at next advance, we'll have to do something about
+//   https://github.com/wvlet/airframe/pull/1380 ,
+// which is leading to:
+//   sbt.librarymanagement.ResolveException: Error downloading org.wvlet.airframe:airspec_2.11.12-bin-2e2f65a:20.12.1
+
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#2849c01dfc459cd8a8166805c279cbda6542c565"
+  uri: "https://github.com/wvlet/airframe.git#bd13085beb3e8b117d4035f4ba2612bba27315e0"
 
   check-missing: false  // ignore missing scripted-plugin
   extra.projects: ["communityBuild"]  // no Scala.js plz

--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -2,7 +2,7 @@
 
 vars.proj.breeze: ${vars.base} {
   name: "breeze"
-  uri: "https://github.com/scalanlp/breeze.git#5d58bb95c064b4908cbf2167aa6fa111cd83ccf3"
+  uri: "https://github.com/scalanlp/breeze.git#b5baea31136c2e86ffa0286a2d5d652274d68505"
 
   // here on the 2.12.x branch, it's fine to just stay on 1.3
   extra.sbt-version: ${vars.sbt-1-3-version}

--- a/proj/claimant.conf
+++ b/proj/claimant.conf
@@ -2,7 +2,7 @@
 
 vars.proj.claimant: ${vars.base} {
   name: "claimant"
-  uri: "https://github.com/typelevel/claimant.git#576bb520f357d6e5dfc157bd7acb474c7bde3677"
+  uri: "https://github.com/typelevel/claimant.git#a5458f7a0498f78c0b4d53de8cbe4c4bdf22567d"
 
   extra.exclude: ["root", "mcJS", "coreJS"]  // no Scala.js plz
 }

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#8bba1c22bae16816e67f5aa70dd1028f1446f48f"
+  uri: "https://github.com/lightbend/genjavadoc.git#c09f215337645ad31bb99248aee4240f77614004"
 
 }

--- a/proj/implicitbox.conf
+++ b/proj/implicitbox.conf
@@ -4,7 +4,7 @@
 
 vars.proj.implicitbox: ${vars.base} {
   name: "implicitbox"
-  uri: "https://github.com/monix/implicitbox.git#5e3a24141d61483433a4205901f73bd335e77633"
+  uri: "https://github.com/monix/implicitbox.git#cd9b48d653793555b135de7972f6c4413038eff7"
 
   extra.projects: ["implicitboxJVM"]
 }

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mima: ${vars.base} {
   name: "mima"
-  uri: "https://github.com/lightbend/mima.git#f0a002eb1b3b3bae04c8df7bfd1772d1da53c58c"
+  uri: "https://github.com/lightbend/mima.git#9f04e95d98a83456f250dddfd7c787dd29ff0a40"
 
   extra.exclude: ["sbtplugin"]  // out of scope
   // `IntegrationTest/test` doesn't work but `it:test` does. dbuild limitation I guess

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#5f384b548960ee7731649f5f900eb1d854e7827a"
+  uri: "https://github.com/scalameta/munit.git#c44d728beaac6867742004c0847ba6a1ff905a67"
 
   // https://github.com/sbt/sbt/issues/5934
   extra.sbt-version: ${vars.sbt-1-3-version}

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -4,6 +4,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#6a16b5ab546cc8c348a1c79e1c907b2498a65988"
+  uri: "https://github.com/nscala-time/nscala-time.git#a406f4a5604ca03d6ed978e7fb34a777d46ce338"
 
 }

--- a/proj/play-file-watch.conf
+++ b/proj/play-file-watch.conf
@@ -4,7 +4,7 @@
 
 vars.proj.play-file-watch: ${vars.base} {
   name: "play-file-watch"
-  uri: "https://github.com/playframework/play-file-watch.git#8770d2203c31a27abbc5ebd134314bcde7d97e00"
+  uri: "https://github.com/playframework/play-file-watch.git#a5b6ff983a7125587bd342b479fc2bffe5a9b9da"
 
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#52811e6dcea1e3c936d15103b036411eee523d86"
+  uri: "https://github.com/scala/scala-collection-compat.git#a98ec84104b9475d1d43e49ef51df29f68ef289e"
 
   extra.projects: ["compat212", "binary-compat"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-hedgehog.conf
+++ b/proj/scala-hedgehog.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-hedgehog: ${vars.base} {
   name: "scala-hedgehog"
-  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#b47fe15f7e7a907f1c6203df8c6b7a4f400a4b48"
+  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#7dbe116652a7f941b612d36582bdddf6dcee83a0"
 
   extra.exclude: ["*JS"]
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#21854da685d0990e205c35a9d5217560e6ba2861"
+  uri: "https://github.com/scalaprops/scalaprops.git#5aaa8a49a19abf32b0f983baaf8a10066f668720"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#4219fe0af428b8abf76cc12ac0d9cb03ad8d31f9"
+  uri: "https://github.com/ekrich/sconfig.git#08d69fc615420283cda8ed7e6f7225f1c1442320"
 
   extra.exclude: ["sconfigNative", "sconfigJS"]
   // use right version-specific source directories regardless of our weird dbuild Scala version numbers

--- a/proj/shapeless-java-records.conf
+++ b/proj/shapeless-java-records.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless-java-records: ${vars.base} {
   name: "shapeless-java-records"
-  uri: "https://github.com/xuwei-k/shapeless-java-records.git#79d2c0582bcf8924e9593f57a81a3711d7bbd9ef"
+  uri: "https://github.com/xuwei-k/shapeless-java-records.git#8b10ada3ab5d3ce9922b6ed902d0ad8f7cc0ec5f"
 
   extra.options: ["--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions"]
 }

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#7ac5802f9b5a2a83767030f759a58b193af1220a"
+  uri: "https://github.com/fthomas/singleton-ops.git#1265076289fe204f9f8064e1e075a78ad0710254"
 
   extra.projects: ["singleton_opsJVM"]
 }

--- a/proj/slick.conf
+++ b/proj/slick.conf
@@ -2,7 +2,7 @@
 
 vars.proj.slick: ${vars.base} {
   name: "slick"
-  uri: "https://github.com/slick/slick.git#f81a69c798b76bb44e16045abddbd9c8922f5f64"
+  uri: "https://github.com/slick/slick.git#e26ccf77c2bcccafbb7ab54730c7c39e1305e1cf"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   deps.inject: ${vars.base.deps.inject} [

--- a/proj/ssl-config.conf
+++ b/proj/ssl-config.conf
@@ -2,7 +2,7 @@
 
 vars.proj.ssl-config: ${vars.base} {
   name: "ssl-config"
-  uri: "https://github.com/lightbend/ssl-config.git#54bc97340eda0e84b2e7102994aa1d4d155dd145"
+  uri: "https://github.com/lightbend/ssl-config.git#449e325d131d12d5e63be330a2a457bb1a06573e"
 
   extra.projects: ["sslConfigCore"]
   // repeated hangs during testing; see

--- a/proj/treehugger.conf
+++ b/proj/treehugger.conf
@@ -4,6 +4,5 @@ vars.proj.treehugger: ${vars.base} {
   name: "treehugger"
   uri: "https://github.com/eed3si9n/treehugger.git#bf6afbde14956fa6c5a850317ec37cbb934615fa"
 
-  extra.sbt-version: ${vars.sbt-0-13-version}
   extra.exclude: ["root"]
 }

--- a/proj/treehugger.conf
+++ b/proj/treehugger.conf
@@ -2,7 +2,7 @@
 
 vars.proj.treehugger: ${vars.base} {
   name: "treehugger"
-  uri: "https://github.com/eed3si9n/treehugger.git#6378ba6347f3db30e3991d114f384ff20d78d545"
+  uri: "https://github.com/eed3si9n/treehugger.git#bf6afbde14956fa6c5a850317ec37cbb934615fa"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.exclude: ["root"]

--- a/proj/verify.conf
+++ b/proj/verify.conf
@@ -2,7 +2,7 @@
 
 vars.proj.verify: ${vars.base} {
   name: "verify"
-  uri: "https://github.com/scala/nanotest-strawman.git#5d0b57a1a0c993b0d778c6e93fdce76ec9ebfad2"
+  uri: "https://github.com/scala/nanotest-strawman.git#074f87a47ffe79b725effcf807ab4ec17cdd407a"
 
   extra.projects: ["verifyJVM"]
 }

--- a/report/project/build.properties
+++ b/report/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.4.5


### PR DESCRIPTION
normally I would do these separately but the 1.4.5 changes seem minor, so fingers crossed we can just do it together

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6335/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6338/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6342/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6343/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6345/