### PR TITLE
2.13: upgrade sbt (to 1.4.5) & advance project SHAs

### DIFF
--- a/advance
+++ b/advance
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.4 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.5 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to advance all projects:
 //   % ./advance scalacheck

--- a/community.conf
+++ b/community.conf
@@ -32,7 +32,7 @@ vars {
   sbt-0-13-version: "0.13.18"
   sbt-1-2-version: "1.2.8"
   sbt-1-3-version: "1.3.13"
-  sbt-version: "1.4.4"
+  sbt-version: "1.4.5"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/narrow
+++ b/narrow
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.4 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
+#!/usr/bin/env sbt -sbt-create -Dsbt.version=1.4.5 -Dsbt.main.class=sbt.ScriptMain -Dsbt.supershell=false -error
 
 // to narrow projs.conf to just one project and its dependencies:
 //   % ./narrow scalacheck

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#ba279f283b79af2af45de8abebd71134e67dddce"
+  uri: "https://github.com/wvlet/airframe.git#2849c01dfc459cd8a8166805c279cbda6542c565"
 
   check-missing: false  // ignore missing scripted-plugin
   extra.projects: ["communityBuild"]  // no Scala.js plz

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -1,8 +1,13 @@
 // https://github.com/wvlet/airframe.git#master
 
+// at next advance, we'll have to do something about
+//   https://github.com/wvlet/airframe/pull/1380 ,
+// which is leading to:
+//   sbt.librarymanagement.ResolveException: Error downloading org.wvlet.airframe:airspec_2.11.12-bin-2e2f65a:20.12.1
+
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#2849c01dfc459cd8a8166805c279cbda6542c565"
+  uri: "https://github.com/wvlet/airframe.git#bd13085beb3e8b117d4035f4ba2612bba27315e0"
 
   check-missing: false  // ignore missing scripted-plugin
   extra.projects: ["communityBuild"]  // no Scala.js plz

--- a/proj/akka-http-cors.conf
+++ b/proj/akka-http-cors.conf
@@ -4,7 +4,7 @@
 
 vars.proj.akka-http-cors: ${vars.base} {
   name: "akka-http-cors"
-  uri: "https://github.com/lomigmegard/akka-http-cors.git#b0fc53fbe388840828df19c82fe02c2b6126bc7f"
+  uri: "https://github.com/lomigmegard/akka-http-cors.git#653ea90a399a30d4bd855151c4d2c93b329bb053"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["akka-http-cors"]

--- a/proj/akka-http-json.conf
+++ b/proj/akka-http-json.conf
@@ -5,7 +5,7 @@
 
 vars.proj.akka-http-json: ${vars.base} {
   name: "akka-http-json"
-  uri: "https://github.com/hseeberger/akka-http-json.git#1d8458625c344f8f843b0a4a01d59bd53cb79b4d"
+  uri: "https://github.com/hseeberger/akka-http-json.git#fc968ac7976a2156a4be1631424a42037b3fccb3"
 
   // we might try to re-enable this when we have newer akka-http; right now
   // the tests don't compile and it looks like an akka-http version problem

--- a/proj/akka-http-session.conf
+++ b/proj/akka-http-session.conf
@@ -6,7 +6,7 @@
 
 vars.proj.akka-http-session: ${vars.base} {
   name: "akka-http-session"
-  uri: "https://github.com/softwaremill/akka-http-session.git#9eb612cf74c3e3b55472ad44f561c6542f7b8e79"
+  uri: "https://github.com/softwaremill/akka-http-session.git#18ab37af8adbd32156a0b90e0e85172d06b8275f"
 
   extra.projects: ["core"]
   extra.options: ["-Dakka.fail-mixed-versions=false"]

--- a/proj/algebra.conf
+++ b/proj/algebra.conf
@@ -2,7 +2,7 @@
 
 vars.proj.algebra: ${vars.base} {
   name: "algebra"
-  uri: "https://github.com/typelevel/algebra.git#606d47a67265711c23599e6a220e318cdadad879"
+  uri: "https://github.com/typelevel/algebra.git#d99f52acc2204a20d6f948f3e1952d3fd2230d00"
 
   extra.projects: ["coreJVM", "lawsJVM"]  // no Scala.js, no benchmarks, no docs
 }

--- a/proj/bijection.conf
+++ b/proj/bijection.conf
@@ -2,7 +2,7 @@
 
 vars.proj.bijection: ${vars.base} {
   name: "bijection"
-  uri: "https://github.com/twitter/bijection.git#333b0e32e203016c086a08faf8cc3b4e3e1338ea"
+  uri: "https://github.com/twitter/bijection.git#bc540043cba86b505f4d6da8949f5faf8e8ec740"
 
   // at the moment let's just do the part scalafix needs. there are a bunch
   // of integration modules, but my hunch is they are likelier to cause

--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -2,7 +2,7 @@
 
 vars.proj.breeze: ${vars.base} {
   name: "breeze"
-  uri: "https://github.com/scalanlp/breeze.git#5d58bb95c064b4908cbf2167aa6fa111cd83ccf3"
+  uri: "https://github.com/scalanlp/breeze.git#b5baea31136c2e86ffa0286a2d5d652274d68505"
 
   extra.exclude: ["benchmark"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-effect-testing.conf
+++ b/proj/cats-effect-testing.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect-testing: ${vars.base} {
   name: "cats-effect-testing"
-  uri: "https://github.com/djspiewak/cats-effect-testing.git#fe810669df8d6650b07317463b3ef0eabd79bd92"
+  uri: "https://github.com/djspiewak/cats-effect-testing.git#78ce2add7d84089d9f804612fb471c7b1c6c82da"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/cats-effect.conf
+++ b/proj/cats-effect.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect: ${vars.base} {
   name: "cats-effect"
-  uri: "https://github.com/typelevel/cats-effect.git#3f36df80b7b1fee77a2aa10cd2b3d34083b11278"
+  uri: "https://github.com/typelevel/cats-effect.git#e6daea1dd09f79339673387d5861a57e89c4f641"
 
   extra.projects: ["coreJVM", "lawsJVM"]  // no Scala.js plz
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-mtl.conf
+++ b/proj/cats-mtl.conf
@@ -4,7 +4,7 @@
 
 vars.proj.cats-mtl: ${vars.base} {
   name: "cats-mtl"
-  uri: "https://github.com/typelevel/cats-mtl.git#5b5dd285d42a275ab4123fdac1003b10aa1b73f6"
+  uri: "https://github.com/typelevel/cats-mtl.git#c1d698d5a7421c9525270d2aa0ef540062669d41"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-parse.conf
+++ b/proj/cats-parse.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-parse: ${vars.base} {
   name: "cats-parse"
-  uri: "https://github.com/typelevel/cats-parse.git#923a513192f4def98714ea82334001f3b09d92f7"
+  uri: "https://github.com/typelevel/cats-parse.git#e0d122695e434ca7c5f76f86d1aecf21f659fd68"
 
   extra.exclude: ["bench", "docs", "*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-testkit-scalatest.conf
+++ b/proj/cats-testkit-scalatest.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-testkit-scalatest: ${vars.base} {
   name: "cats-testkit-scalatest"
-  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#2eed0f87c1294881563e1c2b4c60da3d15a3a758"
+  uri: "https://github.com/typelevel/cats-testkit-scalatest.git#09b46ef6c43d0119f629f812ad1586bbbbe72082"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/circe-config.conf
+++ b/proj/circe-config.conf
@@ -4,7 +4,7 @@
 
 vars.proj.circe-config: ${vars.base} {
   name: "circe-config"
-  uri: "https://github.com/circe/circe-config.git#5e40f92fa81e3e3abb2c37770f6cffc9db8583c6"
+  uri: "https://github.com/circe/circe-config.git#6d4e8a74a7c0e7841c0854baade04c1524d40c85"
 
   extra.commands: ${vars.default-commands} [
     """set every doctestScalaTestVersion := Some("3.2.1")"""

--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe: ${vars.base} {
   name: "circe"
-  uri: "https://github.com/circe/circe.git#e468385bcb919efdb1881d13263d554385bd1fe9"
+  uri: "https://github.com/circe/circe.git#baf113f49d79310c6cda789c54c31291a1189aee"
 
   extra.projects: [
     // easy

--- a/proj/ciris.conf
+++ b/proj/ciris.conf
@@ -4,7 +4,7 @@
 
 vars.proj.ciris: ${vars.base} {
   name: "ciris"
-  uri: "https://github.com/vlovgr/ciris.git#b6d2d54154a2f40dc5559269c73b105f7efbe213"
+  uri: "https://github.com/vlovgr/ciris.git#c993307251a46dd556f54c47f537e26c9bf68a7e"
 
   extra.exclude: ["docs"]
 }

--- a/proj/claimant.conf
+++ b/proj/claimant.conf
@@ -2,7 +2,7 @@
 
 vars.proj.claimant: ${vars.base} {
   name: "claimant"
-  uri: "https://github.com/typelevel/claimant.git#576bb520f357d6e5dfc157bd7acb474c7bde3677"
+  uri: "https://github.com/typelevel/claimant.git#a5458f7a0498f78c0b4d53de8cbe4c4bdf22567d"
 
   extra.exclude: ["root", "*JS"]
 }

--- a/proj/coulomb.conf
+++ b/proj/coulomb.conf
@@ -5,7 +5,7 @@
 
 vars.proj.coulomb: ${vars.base} {
   name: "coulomb"
-  uri: "https://github.com/erikerlandson/coulomb.git#b5d508ab4a16cedbd5f07298e1a99a7fd5785a77"
+  uri: "https://github.com/erikerlandson/coulomb.git#3602f5233176eb96a0fb031f018327aaf961be4e"
 
   extra.projects: ["coulomb_testsJVM"] // builds & tests everything.... I think
   extra.commands: ${vars.default-commands} [

--- a/proj/discipline-munit.conf
+++ b/proj/discipline-munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-munit: ${vars.base} {
   name: "discipline-munit"
-  uri: "https://github.com/typelevel/discipline-munit.git#e0a3aee65b85bf8d6bb53037e4bc33ebfdeaedff"
+  uri: "https://github.com/typelevel/discipline-munit.git#6b91a8aefac4f94e6bdfcd5c7fea5c4923ecb368"
 
   extra.exclude: ["*JS"]
 }

--- a/proj/discipline-scalatest.conf
+++ b/proj/discipline-scalatest.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-scalatest: ${vars.base} {
   name: "discipline-scalatest"
-  uri: "https://github.com/typelevel/discipline-scalatest.git#9893e9d275f78792516c091e3161dcfd97bc47a2"
+  uri: "https://github.com/typelevel/discipline-scalatest.git#dfec936c6fb225aad79be0d5e0029913bea3d680"
 
   extra.exclude: ["*JS", "docs"]
   extra.commands: ${vars.default-commands} [

--- a/proj/discipline-specs2.conf
+++ b/proj/discipline-specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-specs2: ${vars.base} {
   name: "discipline-specs2"
-  uri: "https://github.com/typelevel/discipline-specs2.git#b2fa931a44eeb6a6afa1343e57f963e73aafff59"
+  uri: "https://github.com/typelevel/discipline-specs2.git#db87e77eff0ea6d6a1ba21acde2d5fe298dea439"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/discipline.conf
+++ b/proj/discipline.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline: ${vars.base} {
   name: "discipline"
-  uri: "https://github.com/typelevel/discipline.git#4e3f9678c84702b079209ae9928d9b6c884a7514"
+  uri: "https://github.com/typelevel/discipline.git#25cee291bdf774ebe53ca4545ed5e122894855c0"
 
   extra.projects: ["coreJVM"]  // no Scala.js please
   extra.commands: ${vars.default-commands} [

--- a/proj/expression-evaluator.conf
+++ b/proj/expression-evaluator.conf
@@ -4,6 +4,6 @@
 
 vars.proj.expression-evaluator: ${vars.base} {
   name: "expression-evaluator"
-  uri: "https://github.com/plokhotnyuk/expression-evaluator.git#2d36b71e6fa074a0f0345ff65b49113ee9c4e0bf"
+  uri: "https://github.com/plokhotnyuk/expression-evaluator.git#c5c00e036abfe013560847b5113263150234804a"
 
 }

--- a/proj/fast-string-interpolator.conf
+++ b/proj/fast-string-interpolator.conf
@@ -2,7 +2,7 @@
 
 vars.proj.fast-string-interpolator: ${vars.base} {
   name: "fast-string-interpolator"
-  uri: "https://github.com/plokhotnyuk/fast-string-interpolator.git#8c7c764a689ced79042780df0bde1ef853677dbd"
+  uri: "https://github.com/plokhotnyuk/fast-string-interpolator.git#a34a7ee6af2083163bfb24a5971c41fa4f8ea8ac"
 
   // Missing dependency: com.dongxiguo#fastring. likely out of scope anyway
   extra.exclude: ["fsi-benchmark", "fsi-benchmark-core"]

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#8bba1c22bae16816e67f5aa70dd1028f1446f48f"
+  uri: "https://github.com/lightbend/genjavadoc.git#c09f215337645ad31bb99248aee4240f77614004"
 
 }

--- a/proj/giter8.conf
+++ b/proj/giter8.conf
@@ -2,7 +2,7 @@
 
 vars.proj.giter8: ${vars.base} {
   name: "giter8"
-  uri: "https://github.com/foundweekends/giter8.git#3c9ab2f3094462865e4464b9791eb7eda2a898a7"
+  uri: "https://github.com/foundweekends/giter8.git#50dbe9ca2640b54fc75d6547a042341b3639bd35"
 
   extra.exclude: [
     // these are sbt plugins

--- a/proj/github4s.conf
+++ b/proj/github4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.github4s: ${vars.base} {
   name: "github4s"
-  uri: "https://github.com/47deg/github4s.git#76a08b4d8e87eb1d53c183980a15b5d9350677c3"
+  uri: "https://github.com/47deg/github4s.git#df1a16f2a76c171e887080364091f78bd6213384"
 
   extra.projects: ["github4s"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/http4s-jwt-auth.conf
+++ b/proj/http4s-jwt-auth.conf
@@ -4,7 +4,7 @@
 
 vars.proj.http4s-jwt-auth: ${vars.base} {
   name: "http4s-jwt-auth"
-  uri: "https://github.com/profunktor/http4s-jwt-auth.git#2ff755fabc8864ce6538aed46bf87bb0b1e56736"
+  uri: "https://github.com/profunktor/http4s-jwt-auth.git#1e16d0f57d478be4673bc5a4c589a7c716549d0a"
 
   extra.projects: ["core"]
   extra.commands: ${vars.default-commands} [

--- a/proj/implicitbox.conf
+++ b/proj/implicitbox.conf
@@ -4,7 +4,7 @@
 
 vars.proj.implicitbox: ${vars.base} {
   name: "implicitbox"
-  uri: "https://github.com/monix/implicitbox.git#5e3a24141d61483433a4205901f73bd335e77633"
+  uri: "https://github.com/monix/implicitbox.git#cd9b48d653793555b135de7972f6c4413038eff7"
 
   extra.projects: ["implicitboxJVM"]
 }

--- a/proj/jackson-module-scala.conf
+++ b/proj/jackson-module-scala.conf
@@ -6,6 +6,9 @@
 // pull in various fixes, some of which may have been merged on the 2.12
 // branch, others maybe only on master?  but it's fine to stay forked
 
+// at unfork time, note that https://github.com/FasterXML/jackson-module-scala/issues/487
+// was merged
+
 vars.proj.jackson-module-scala: ${vars.base} {
   name: "jackson-module-scala"
   uri: "https://github.com/scalacommunitybuild/jackson-module-scala.git#0bd251a8e1039f4a9e0840483d5ee6f83e581649"

--- a/proj/jackson-module-scala.conf
+++ b/proj/jackson-module-scala.conf
@@ -6,8 +6,8 @@
 // pull in various fixes, some of which may have been merged on the 2.12
 // branch, others maybe only on master?  but it's fine to stay forked
 
-// at unfork time, note that https://github.com/FasterXML/jackson-module-scala/issues/487
-// was merged
+// before considering unforking, check the status of
+// https://github.com/FasterXML/jackson-module-scala/issues/431
 
 vars.proj.jackson-module-scala: ${vars.base} {
   name: "jackson-module-scala"

--- a/proj/jsoniter-scala.conf
+++ b/proj/jsoniter-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jsoniter-scala: ${vars.base} {
   name: "jsoniter-scala"
-  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#ec104f32b189713a5bf5e9bb5039de36ce22b88e"
+  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#2929695d616c6d4e47a9b6c1bf830fdcbc76db14"
 
   extra.exclude: ["*JS", "*benchmark*"]
 }

--- a/proj/kamon.conf
+++ b/proj/kamon.conf
@@ -2,7 +2,7 @@
 
 vars.proj.kamon: ${vars.base} {
   name: "kamon"
-  uri: "https://github.com/kamon-io/Kamon.git#bcfc41e129fbe988412d1645e352578d9eaba189"
+  uri: "https://github.com/kamon-io/Kamon.git#f7ae4986529ab33ba323427c149ff3555d62d999"
 
   // just what lila-ws needs, for now anyway
   extra.projects: ["kamon-core", "kamon-influxdb", "kamon-system-metrics"]

--- a/proj/lightbend-emoji.conf
+++ b/proj/lightbend-emoji.conf
@@ -2,7 +2,7 @@
 
 vars.proj.lightbend-emoji: ${vars.base} {
   name: "lightbend-emoji"
-  uri: "https://github.com/lightbend/lightbend-emoji.git#92c83020a0023012c16eb4225e5edefe744aeaf7"
+  uri: "https://github.com/lightbend/lightbend-emoji.git#5f145499e91cb672b0c63c3fc146c2830e4c9a15"
 
   extra.options: ["-Dsbt.sbtbintray=false"]
 }

--- a/proj/lila-ws.conf
+++ b/proj/lila-ws.conf
@@ -2,6 +2,6 @@
 
 vars.proj.lila-ws: ${vars.base} {
   name: "lila-ws"
-  uri: "https://github.com/ornicar/lila-ws.git#8a4d4ff4706883ba6a5a993528bed04deda5029e"
+  uri: "https://github.com/ornicar/lila-ws.git#9d3a6ab6c42b9810e496948e577286fa66adec26"
 
 }

--- a/proj/log4s.conf
+++ b/proj/log4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.log4s: ${vars.base} {
   name: "log4s"
-  uri: "https://github.com/Log4s/log4s.git#804580fcbf682a166ea744b84daf505f24e9a5d0"
+  uri: "https://github.com/Log4s/log4s.git#18c9c20bf5dd6af6d1807cccaf287bb8b2ae6282"
 
   extra.exclude: ["*JS", "testingJS"]
 }

--- a/proj/metrics-scala.conf
+++ b/proj/metrics-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.metrics-scala: ${vars.base} {
   name: "metrics-scala"
-  uri: "https://github.com/erikvanoosten/metrics-scala.git#9c8f81115df266a7655cfec3f21fbbb8cb24e35d"
+  uri: "https://github.com/erikvanoosten/metrics-scala.git#8e68241fd025fb5cc61bd1f8ee4f585a02fd1928"
 
   // our Akka version is 2.6; as of January 2020 there is only a
   // a metricsAkka25 project, no Akka26, but perhaps it will be source-compatible?

--- a/proj/monocle.conf
+++ b/proj/monocle.conf
@@ -2,7 +2,7 @@
 
 vars.proj.monocle: ${vars.base} {
   name: "monocle"
-  uri: "https://github.com/julien-truffaut/Monocle.git#8c46ab105ffad5116845fb031a0fab30b2f50618"
+  uri: "https://github.com/julien-truffaut/Monocle.git#063604930dd1915f93385cfa4146c7a433b1a3b5"
 
   // try to enable more subprojects?
   extra.projects: ["coreJVM", "macrosJVM", "lawJVM", "genericJVM"]

--- a/proj/mouse.conf
+++ b/proj/mouse.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mouse: ${vars.base} {
   name: "mouse"
-  uri: "https://github.com/typelevel/mouse.git#5f5c626119f19e08a93d7f8aae2d5d794be3e817"
+  uri: "https://github.com/typelevel/mouse.git#70d6b6abd200685fdb9ff07cb6dac91ccac845d5"
 
   extra.projects: ["crossJVM"]  // no Scala.js please
 }

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#5f384b548960ee7731649f5f900eb1d854e7827a"
+  uri: "https://github.com/scalameta/munit.git#c44d728beaac6867742004c0847ba6a1ff905a67"
 
   // https://github.com/sbt/sbt/issues/5934
   extra.sbt-version: ${vars.sbt-1-3-version}

--- a/proj/natchez.conf
+++ b/proj/natchez.conf
@@ -4,7 +4,7 @@
 
 vars.proj.natchez: ${vars.base} {
   name: "natchez"
-  uri: "https://github.com/tpolecat/natchez.git#69f427ef185c79766c1cf281b8ace4fecbc05fdd"
+  uri: "https://github.com/tpolecat/natchez.git#072eee7ace84c72abd4722194d4ad8bf237111ae"
 
   // let's try and squeak by with just the minimum, since our present goal is
   // just to get pfps-shopping-cart green

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -4,6 +4,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#6a16b5ab546cc8c348a1c79e1c907b2498a65988"
+  uri: "https://github.com/nscala-time/nscala-time.git#a406f4a5604ca03d6ed978e7fb34a777d46ce338"
 
 }

--- a/proj/paiges.conf
+++ b/proj/paiges.conf
@@ -2,7 +2,7 @@
 
 vars.proj.paiges: ${vars.base} {
   name: "paiges"
-  uri: "https://github.com/typelevel/paiges.git#108ed3ef7bba931e3262928808c63e52ed82fa7c"
+  uri: "https://github.com/typelevel/paiges.git#2bc82ec2b2ccfe1c56e64b4d5db7c03c1b315992"
 
   extra.projects: ["coreJVM", "catsJVM"]  // but not "benchmark"
 }

--- a/proj/parboiled.conf
+++ b/proj/parboiled.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled: ${vars.base} {
   name: "parboiled"
-  uri: "https://github.com/sirthias/parboiled.git#39cb6c5ab47e0d404ad31b3ee2f91ea1b417d86b"
+  uri: "https://github.com/sirthias/parboiled.git#cc701cdd4e0c282f62d423c8f9969348bc4b02e9"
 
   extra.projects: ["parboiled-scala"]
 }

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -2,7 +2,7 @@
 
 vars.proj.playframework: ${vars.base} {
   name: "playframework"
-  uri: "https://github.com/playframework/playframework.git#450edf4c07e37322d1c3e0107972feb2853e86c8"
+  uri: "https://github.com/playframework/playframework.git#ce4dadbd8e46bf15b2f61b6e54d447b3e988d8b1"
 
   // see https://github.com/sbt/sbt/issues/5808 ; we could probably move to 1.4
   // once we have https://github.com/playframework/playframework/pull/10442 but

--- a/proj/reactive-mongo-bson.conf
+++ b/proj/reactive-mongo-bson.conf
@@ -2,7 +2,7 @@
 
 vars.proj.reactive-mongo-bson: ${vars.base} {
   name: "reactive-mongo-bson"
-  uri: "https://github.com/ReactiveMongo/ReactiveMongo-BSON.git#72521305f10d408b76e79674f5d935f8e7fbd940"
+  uri: "https://github.com/ReactiveMongo/ReactiveMongo-BSON.git#3a012aa66165c47d1c2f766ebb796436169c0807"
 
   // present ambition level is: only what lila-ws needs
   extra.projects: ["api"]

--- a/proj/reactive-mongo.conf
+++ b/proj/reactive-mongo.conf
@@ -2,7 +2,7 @@
 
 vars.proj.reactive-mongo: ${vars.base} {
   name: "reactive-mongo"
-  uri: "https://github.com/ReactiveMongo/ReactiveMongo.git#8940710288dc72fbcf9ed6d3c5c1c038d4037592"
+  uri: "https://github.com/ReactiveMongo/ReactiveMongo.git#1c3101d6d3947ed4b29c5fed85353587401f4733"
 
   extra.exclude: ["benchmarks"]
   // this is fine for our present ambitious level (namely, to add lila-ws)

--- a/proj/refined.conf
+++ b/proj/refined.conf
@@ -2,7 +2,7 @@
 
 vars.proj.refined: ${vars.base} {
   name: "refined"
-  uri: "https://github.com/fthomas/refined.git#30791f6e62c2409d0e5b01160927f115df6848a3"
+  uri: "https://github.com/fthomas/refined.git#0e2d5aae446d6ca62d2250f27939fe8762470fa7"
 
   // scodecJVM isn't included because the dependency wasn't found, maybe a version mismatch?
   // it's okay, we don't need to have absolutely every subproject
@@ -11,7 +11,7 @@ vars.proj.refined: ${vars.base} {
 
 vars.proj.refined-more: ${vars.base} {
   name: "refined-more"
-  uri: "https://github.com/fthomas/refined.git#30791f6e62c2409d0e5b01160927f115df6848a3"
+  uri: "https://github.com/fthomas/refined.git#0e2d5aae446d6ca62d2250f27939fe8762470fa7"
 
   extra.exclude: [
     // because we already built them in "refined"

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#52811e6dcea1e3c936d15103b036411eee523d86"
+  uri: "https://github.com/scala/scala-collection-compat.git#a98ec84104b9475d1d43e49ef51df29f68ef289e"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-hedgehog.conf
+++ b/proj/scala-hedgehog.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-hedgehog: ${vars.base} {
   name: "scala-hedgehog"
-  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#b47fe15f7e7a907f1c6203df8c6b7a4f400a4b48"
+  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#7dbe116652a7f941b612d36582bdddf6dcee83a0"
 
   extra.exclude: ["*JS"]
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]

--- a/proj/scala-parser-combinators.conf
+++ b/proj/scala-parser-combinators.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-parser-combinators: ${vars.base} {
   name: "scala-parser-combinators"
-  uri: "https://github.com/scala/scala-parser-combinators.git#14fa7ee66b2f30ea73630e7a82bf6d4f83e2b21f"
+  uri: "https://github.com/scala/scala-parser-combinators.git#0ef509b92dc88720e9c4a634a2693e37987d1909"
 
   extra.exclude: ["*JS", "*Native"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-swing.conf
+++ b/proj/scala-swing.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-swing: ${vars.base} {
   name: "scala-swing"
-  uri: "https://github.com/scala/scala-swing.git#f3effa91e7eeb8283ada5130fa38a4db98a310e6"
+  uri: "https://github.com/scala/scala-swing.git#851d6bd304cafc1a2e8459db7c3cd5adb496f05c"
 
   extra.commands: ${vars.default-commands} [
     // work around https://github.com/scala/community-builds/issues/575

--- a/proj/scala-xml.conf
+++ b/proj/scala-xml.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-xml: ${vars.base} {
   name: "scala-xml"
-  uri: "https://github.com/scala/scala-xml.git#ed1a21eb4fe36ee1c7be26c5c26a8af763586f14"
+  uri: "https://github.com/scala/scala-xml.git#13c3e29f75cbdae81102a3ad5f1966bb5513724c"
 
   extra.projects: ["xml"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck-effect.conf
+++ b/proj/scalacheck-effect.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalacheck-effect: ${vars.base} {
   name: "scalacheck-effect"
-  uri: "https://github.com/typelevel/scalacheck-effect.git#8209e5c511061a0441e349580c55a9c31195d0aa"
+  uri: "https://github.com/typelevel/scalacheck-effect.git#8818f15f5fa11676532883a7d1dbfd8f8e1a9b99"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck.conf
+++ b/proj/scalacheck.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalacheck: ${vars.base} {
   name: "scalacheck"
-  uri: "https://github.com/typelevel/scalacheck.git#58ca72fd11b261a56ca2d370bed382759160d8c1"
+  uri: "https://github.com/typelevel/scalacheck.git#6d423089cd9b6420599b665f462d22411ccbaa3e"
 
   extra.projects: ["jvm"]  // no Scala.js please
 }

--- a/proj/scalafmt.conf
+++ b/proj/scalafmt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#86dbd30b5768f9ecaac27312f1b18c3afe536a5b"
+  uri: "https://github.com/scalameta/scalafmt.git#39c3bf7e93fc4a47ee66d81b5909c2866fdb50aa"
 
   extra.projects: ["coreJVM", "cli", "tests"]
   // not investigated. at first glance they all look environment-dependent

--- a/proj/scalameta.conf
+++ b/proj/scalameta.conf
@@ -1,11 +1,11 @@
-// https://github.com/scalameta/scalameta.git#v4.3.24
+// https://github.com/scalameta/scalameta.git#v4.4.2
 
-// we typically use a tag here rather than track a branch,
-// in the interest of stability.  v4.3.24 is from October 2020
+// we typically use a tag here rather than track a branch, in the
+// interest of stability.  whatever tag scalafmt and/or scalafix expect
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalameta/scalameta.git#33d1801032c9e741398301e68f08b5537ba22028"
+  uri: "https://github.com/scalameta/scalameta.git#738f29b946a3f261404d35a3bfad249c25f3c13a"
 
   extra.projects: ["semanticdbScalacPlugin", "testkit"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#21854da685d0990e205c35a9d5217560e6ba2861"
+  uri: "https://github.com/scalaprops/scalaprops.git#5aaa8a49a19abf32b0f983baaf8a10066f668720"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/scalikejdbc.conf
+++ b/proj/scalikejdbc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalikejdbc: ${vars.base} {
   name: "scalikejdbc"
-  uri: "https://github.com/scalikejdbc/scalikejdbc.git#b6cf121f8160f05999eccec2eedc72145860739e"
+  uri: "https://github.com/scalikejdbc/scalikejdbc.git#5dbf26c236ac257b66d41b4f304a39f7c42850d7"
 
   // don't build sbt plugin
   extra.exclude: ["mapper-generator"]

--- a/proj/scallop.conf
+++ b/proj/scallop.conf
@@ -5,7 +5,7 @@
 
 vars.proj.scallop: ${vars.base} {
   name: "scallop"
-  uri: "https://github.com/scallop/scallop.git#6e05e41ad62ea5073173bec5d1421e5f0a09bc9f"
+  uri: "https://github.com/scallop/scallop.git#9191d86119720c2ab9503b55ad9cfee48d0c0015"
 
   extra.projects: ["scallopJVM"]  // no Scala.js or Scala Native plz
 }

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#4219fe0af428b8abf76cc12ac0d9cb03ad8d31f9"
+  uri: "https://github.com/ekrich/sconfig.git#08d69fc615420283cda8ed7e6f7225f1c1442320"
 
   extra.exclude: ["sconfigNative", "sconfigJS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/shapeless-java-records.conf
+++ b/proj/shapeless-java-records.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless-java-records: ${vars.base} {
   name: "shapeless-java-records"
-  uri: "https://github.com/xuwei-k/shapeless-java-records.git#79d2c0582bcf8924e9593f57a81a3711d7bbd9ef"
+  uri: "https://github.com/xuwei-k/shapeless-java-records.git#8b10ada3ab5d3ce9922b6ed902d0ad8f7cc0ec5f"
 
   extra.options: ["--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions"]
 }

--- a/proj/simulacrum-scalafix.conf
+++ b/proj/simulacrum-scalafix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.simulacrum-scalafix: ${vars.base} {
   name: "simulacrum-scalafix"
-  uri: "https://github.com/typelevel/simulacrum-scalafix.git#75f7e10d30fb1b848b7adaf2a026320ee548b56a"
+  uri: "https://github.com/typelevel/simulacrum-scalafix.git#fa3c7213af8e77aad31d688ce02980e238c6216c"
 
   extra.projects: ["annotation"]
 }
@@ -12,7 +12,7 @@ vars.proj.simulacrum-scalafix: ${vars.base} {
 
 vars.proj.simulacrum-scalafix-more: ${vars.base} {
   name: "simulacrum-scalafix-more"
-  uri: "https://github.com/typelevel/simulacrum-scalafix.git#75f7e10d30fb1b848b7adaf2a026320ee548b56a"
+  uri: "https://github.com/typelevel/simulacrum-scalafix.git#fa3c7213af8e77aad31d688ce02980e238c6216c"
 
   extra.exclude: ["*JS", "annotation"]
 }

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#7ac5802f9b5a2a83767030f759a58b193af1220a"
+  uri: "https://github.com/fthomas/singleton-ops.git#1265076289fe204f9f8064e1e075a78ad0710254"
 
   extra.projects: ["singleton_opsJVM"]
 }

--- a/proj/slick.conf
+++ b/proj/slick.conf
@@ -2,7 +2,7 @@
 
 vars.proj.slick: ${vars.base} {
   name: "slick"
-  uri: "https://github.com/slick/slick.git#f81a69c798b76bb44e16045abddbd9c8922f5f64"
+  uri: "https://github.com/slick/slick.git#e26ccf77c2bcccafbb7ab54730c7c39e1305e1cf"
 
   // some WIP on upgrading to sbt 1 is at https://github.com/SethTisue/slick/tree/sbt-1 ,
   // but it wasn't as easy as I'd hoped when I started

--- a/proj/squants.conf
+++ b/proj/squants.conf
@@ -2,7 +2,7 @@
 
 vars.proj.squants: ${vars.base} {
   name: "squants"
-  uri: "https://github.com/typelevel/squants.git#404b2d6fe66b9ade779c46b11e755537485dab63"
+  uri: "https://github.com/typelevel/squants.git#c5503272682f2fc0d3f5576aa67a624e56466902"
 
   extra.projects: ["squantsJVM"]
 }

--- a/proj/ssl-config.conf
+++ b/proj/ssl-config.conf
@@ -2,7 +2,7 @@
 
 vars.proj.ssl-config: ${vars.base} {
   name: "ssl-config"
-  uri: "https://github.com/lightbend/ssl-config.git#54bc97340eda0e84b2e7102994aa1d4d155dd145"
+  uri: "https://github.com/lightbend/ssl-config.git#449e325d131d12d5e63be330a2a457bb1a06573e"
 
   extra.projects: ["sslConfigCore"]
   // repeated hangs during testing; see

--- a/proj/vault.conf
+++ b/proj/vault.conf
@@ -4,7 +4,7 @@
 
 vars.proj.vault: ${vars.base} {
   name: "vault"
-  uri: "https://github.com/ChristopherDavenport/vault.git#842b933e9e7024c5cd43d84399c8ec25b8212d06"
+  uri: "https://github.com/ChristopherDavenport/vault.git#d99fb50d7a35b8491c6ac0b32e1068d99390933c"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
 }

--- a/proj/wartremover.conf
+++ b/proj/wartremover.conf
@@ -2,7 +2,7 @@
 
 vars.proj.wartremover: ${vars.base} {
   name: "wartremover"
-  uri: "https://github.com/wartremover/wartremover.git#b01586963f5ca40d6df405d7ff87749da0ce6691"
+  uri: "https://github.com/wartremover/wartremover.git#5c6d42b76aafb05141315badcfa1d1d226ed403b"
 
   extra.exclude: [
     "sbt-plugin"

--- a/proj/weaver-test.conf
+++ b/proj/weaver-test.conf
@@ -2,14 +2,14 @@
 
 vars.proj.weaver-test: ${vars.base} {
   name: "weaver-test"
-  uri: "https://github.com/disneystreaming/weaver-test.git#12832a4d5c5a66e2b59c1c365bcdf18394e1d2e0"
+  uri: "https://github.com/disneystreaming/weaver-test.git#fbf0a614116390753b488d16778fc35663e9493f"
 
   extra.projects: ["coreJVM", "frameworkJVM"]
 }
 
 vars.proj.weaver-test-more: ${vars.base} {
   name: "weaver-test-more"
-  uri: "https://github.com/disneystreaming/weaver-test.git#12832a4d5c5a66e2b59c1c365bcdf18394e1d2e0"
+  uri: "https://github.com/disneystreaming/weaver-test.git#fbf0a614116390753b488d16778fc35663e9493f"
 
   extra.projects: ["scalacheckJVM", "specs2JVM"]
   // already built these above
@@ -18,7 +18,7 @@ vars.proj.weaver-test-more: ${vars.base} {
 
 vars.proj.weaver-test-monix: ${vars.base} {
   name: "weaver-test-monix"
-  uri: "https://github.com/disneystreaming/weaver-test.git#12832a4d5c5a66e2b59c1c365bcdf18394e1d2e0"
+  uri: "https://github.com/disneystreaming/weaver-test.git#fbf0a614116390753b488d16778fc35663e9493f"
 
   extra.projects: ["monix*JVM"]
   // already built these above

--- a/proj/zinc.conf
+++ b/proj/zinc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.zinc: ${vars.base} {
   name: "zinc"
-  uri: "https://github.com/sbt/zinc.git#d5594f1b89b6fc5245613e4d92b9d0af58246693"
+  uri: "https://github.com/sbt/zinc.git#bad35ca5112f0b087d21c746f525b6078b5acb5f"
 
   extra.exclude: ["*2_10", "*2_11", "*2_12", "compilerBridgeTest", "*Benchmarks*"]
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]

--- a/report/project/build.properties
+++ b/report/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.4.5


### PR DESCRIPTION
normally I would do these separately but the 1.4.5 changes seem minor, so fingers crossed we can just do it together

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2290/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2291/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2293/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2294/