### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# December 4, 2020
-nightly=2.13.5-bin-d45a673
+# December 17, 2020
+nightly=2.13.5-bin-0772f76


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2302/ queued