### PR TITLE
2.11: advance project SHAs

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,7 +1,6 @@
 scala: 
 cloc-plugin: scala
 shaded-scalajson: scala
-expecty: cloc-plugin, scala
 genjavadoc: cloc-plugin, scala
 kind-projector: cloc-plugin, scala
 machinist: cloc-plugin, scala
@@ -19,6 +18,7 @@ shapeless: cloc-plugin, scala
 sourcecode: cloc-plugin, scala
 tut: cloc-plugin, scala
 verify: cloc-plugin, scala
+expecty: cloc-plugin, scala, verify
 scopt: cloc-plugin, scala, verify
 claimant: cloc-plugin, scala, scalacheck
 munit: cloc-plugin, scala, scalacheck
@@ -62,7 +62,6 @@ geny: cloc-plugin, portable-scala-reflect, scala, utest
 grizzled: cloc-plugin, scala, scalacheck, scalatest, wartremover
 scalastyle: cloc-plugin, scala, scalacheck, scalariform, scalatest
 scribe: cloc-plugin, perfolation, scala, scalacheck, scalatest
-airframe: cloc-plugin, scala, scala-collection-compat, scalacheck
 scala-logging: cloc-plugin, mockito-scala, scala, scalacheck, scalatest
 log4s: cloc-plugin, scala, scala-js-stubs, scalacheck, scalatest
 macro-compat: cloc-plugin, macro-paradise, scala, scalacheck, scalatest
@@ -75,6 +74,7 @@ specs2: cloc-plugin, kind-projector, scala, scala-js-stubs, scalacheck
 scalaj-http: cloc-plugin, jackson-module-scala, scala, scalacheck, scalatest
 giter8: cloc-plugin, sbt-io, scala, scalacheck, scalatest, scopt, verify
 scodec: cloc-plugin, scala, scalacheck, scalatest, scodec-bits, shapeless
+airframe: cloc-plugin, scala, scala-collection-compat, scalacheck, scalatest
 silencer: cloc-plugin, scala, scala-collection-compat, scalacheck, scalatest
 case-app: cloc-plugin, macro-paradise, scala, scalacheck, scalatest, shapeless
 pprint: cloc-plugin, fansi, portable-scala-reflect, scala, sourcecode, utest

--- a/proj/base64.conf
+++ b/proj/base64.conf
@@ -3,7 +3,7 @@
 // dependency of github4s
 vars.proj.base64: ${vars.base} {
   name: "base64"
-  uri: "https://github.com/marklister/base64.git#5e049e828707675400eba7be3b9c88c6e676ee78"
+  uri: "https://github.com/marklister/base64.git#601317bfc3a22f58a7c15a60fa458be565786cde"
 
   extra.projects: ["base64JVM"]  // no Scala.js plz
 }

--- a/proj/claimant.conf
+++ b/proj/claimant.conf
@@ -2,7 +2,7 @@
 
 vars.proj.claimant: ${vars.base} {
   name: "claimant"
-  uri: "https://github.com/typelevel/claimant.git#55d9633dd8759c9080004d67bc6bfa8e6cee1aa7"
+  uri: "https://github.com/typelevel/claimant.git#95dfb985c763b102bff9d79c68b5bc1858394b8e"
 
   extra.exclude: ["root", "mcJS", "coreJS"]  // no Scala.js plz
 }

--- a/proj/data-class.conf
+++ b/proj/data-class.conf
@@ -2,7 +2,7 @@
 
 vars.proj.data-class: ${vars.base} {
   name: "data-class"
-  uri: "https://github.com/alexarchambault/data-class.git#c2f6bbef44b022cc0b7851aa03e0dac436202e7c"
+  uri: "https://github.com/alexarchambault/data-class.git#797de5dd0cd5cf8804bca2088ceaa1c7b96f6815"
 
   // the repo's .travis.yml does the following:
   //   test test-proj-v1/publishLocal test-proj-v2/mimaReportBinaryIssues proj-v1-user/compile

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -6,9 +6,9 @@ vars.proj.expecty: ${vars.base} {
   name: "expecty"
   uri: "https://github.com/eed3si9n/expecty.git#a0c8657d1b8041132aa2a6bdd84b490c9253f177"
 
-  extra.projects: ["expectyJVM"]
+  extra.projects: ["expecty2_11"]
   // use right version-specific source directories (not sure why existing stuff in build.sbt doesn't work)
   extra.commands: ${vars.default-commands} [
-    """set expectyJVM / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
+    """set expecty2_11 / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
   ]
 }

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -1,13 +1,14 @@
-// https://github.com/eed3si9n/expecty.git#master
+// https://github.com/eed3si9n/expecty.git#develop
 
 // dependency of scopt
+
 vars.proj.expecty: ${vars.base} {
   name: "expecty"
-  uri: "https://github.com/eed3si9n/expecty.git#e86c1f5c805151b982fb4d5f435881e2702c8dd6"
+  uri: "https://github.com/eed3si9n/expecty.git#a0c8657d1b8041132aa2a6bdd84b490c9253f177"
 
   extra.projects: ["expectyJVM"]
   // use right version-specific source directories (not sure why existing stuff in build.sbt doesn't work)
   extra.commands: ${vars.default-commands} [
-    "set unmanagedSourceDirectories in (expectyJVM, Compile) += (baseDirectory in ThisBuild).value / \"shared\" / \"src\" / \"main\" / \"scala-2.11\""
+    """set expectyJVM / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
   ]
 }

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -9,6 +9,6 @@ vars.proj.expecty: ${vars.base} {
   extra.projects: ["expecty2_11"]
   // use right version-specific source directories (not sure why existing stuff in build.sbt doesn't work)
   extra.commands: ${vars.default-commands} [
-    """set expecty2_11 / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
+    """set expecty.jvm("2.11.12") / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
   ]
 }

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -7,8 +7,11 @@ vars.proj.expecty: ${vars.base} {
   uri: "https://github.com/eed3si9n/expecty.git#a0c8657d1b8041132aa2a6bdd84b490c9253f177"
 
   extra.projects: ["expecty2_11"]
-  // use right version-specific source directories (not sure why existing stuff in build.sbt doesn't work)
+  extra.settings: ${vars.base.extra.settings} [
+    "Global / semanticdbEnabled := false"
+  ]
   extra.commands: ${vars.default-commands} [
-    """set expecty.jvm("2.11.12") / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "shared" / "src" / "main" / "scala-2.11""""
+    // use right version-specific source directories (not sure why existing stuff in build.sbt doesn't work)
+    """set expecty.jvm("2.11.12") / Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "src" / "main" / "scala-2.11""""
   ]
 }

--- a/proj/kind-projector.conf
+++ b/proj/kind-projector.conf
@@ -2,6 +2,6 @@
 
 vars.proj.kind-projector: ${vars.base} {
   name: "kind-projector"
-  uri: "https://github.com/typelevel/kind-projector.git#83f2c586b2dd079d1a53940e3f28aacb6786e7ec"
+  uri: "https://github.com/typelevel/kind-projector.git#ce5c6f396dff20ffdf0bc1f0e4387ff4ba729e5c"
 
 }

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#d893869d48ea3fa03811a94312b34d3927c3d8a9"
+  uri: "https://github.com/scalameta/munit.git#005bb941b6d2b594f85f0cf469efb50b042f3e4b"
 
   // https://github.com/sbt/sbt/issues/5934
   extra.sbt-version: ${vars.sbt-1-3-version}

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -4,6 +4,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#19b897fdf8feb688e6622b6ddc86a6df55d91586"
+  uri: "https://github.com/nscala-time/nscala-time.git#0c8bc1d7ae2eb6ba3850c5f14d5e40ef47b10d48"
 
 }

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#a4e0dd3e245fb1599cb094802dc191b48aaa119e"
+  uri: "https://github.com/scala/scala-collection-compat.git#da38329a5b2e42e6711dd27f4c6109e05c75e74d"
 
   extra.projects: ["compat211"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-hedgehog.conf
+++ b/proj/scala-hedgehog.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-hedgehog: ${vars.base} {
   name: "scala-hedgehog"
-  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#7dbe116652a7f941b612d36582bdddf6dcee83a0"
+  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#f6139169375836149f2e3bfeef85c350c92bd01f"
 
   extra.exclude: ["*JS", "docs"]
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]

--- a/proj/scala-java8-compat.conf
+++ b/proj/scala-java8-compat.conf
@@ -2,6 +2,6 @@
 
 vars.proj.scala-java8-compat: ${vars.base} {
   name: "scala-java8-compat"
-  uri: "https://github.com/scala/scala-java8-compat.git#c344af4a3e6409070e87087eadd21c287ad973cc"
+  uri: "https://github.com/scala/scala-java8-compat.git#584577ef21255e458001b94e531ca8eeec295af9"
 
 }

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#2bcb3de5e19119d71949710134e10b520a30ee5b"
+  uri: "https://github.com/scalaprops/scalaprops.git#63575719da186d53c710cb5422ace955996697ca"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#f1edca53dbef16f7d8edfa9a610c1f3ca9f717fb"
+  uri: "https://github.com/ekrich/sconfig.git#b2de121e1e2a80a793ff90cb970e92cfa80b5c2f"
 
   extra.exclude: ["sconfigNative", "sconfigJS"]
   // use right version-specific source directories regardless of our weird dbuild Scala version numbers

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#107c532f9a8b47891b59fa03b93534b47d8f6fd6"
+  uri: "https://github.com/fthomas/singleton-ops.git#ca5551d34ed87227d289c490259eca7708c13d70"
 
   extra.projects: ["singleton_opsJVM"]
 }

--- a/proj/slick.conf
+++ b/proj/slick.conf
@@ -2,7 +2,7 @@
 
 vars.proj.slick: ${vars.base} {
   name: "slick"
-  uri: "https://github.com/slick/slick.git#bdd55e8c4d18dbac4c8830a2786df0829349cf29"
+  uri: "https://github.com/slick/slick.git#304b14b64e8214c282e0d07d5e403cca2b9be8ec"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   deps.inject: ${vars.base.deps.inject} [

--- a/proj/verify.conf
+++ b/proj/verify.conf
@@ -2,7 +2,7 @@
 
 vars.proj.verify: ${vars.base} {
   name: "verify"
-  uri: "https://github.com/scala/nanotest-strawman.git#7d1391b7b811a4f80c37cbf6825ab4a70ad51564"
+  uri: "https://github.com/scala/nanotest-strawman.git#fee5aa6ee9b54a9b86ef28585af1e075e01852b8"
 
   extra.projects: ["verifyJVM"]
 }


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2269/~
~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2270/~
~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2272/~
~https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2273/~
https://scala-ci.typesafe.com/view/scala-2.11.x/job/scala-2.11.x-jdk8-integrate-community-build/2278/