### PR TITLE
adjustments now that Scala 2.12.13 is out

### DIFF
--- a/proj/sbt.conf
+++ b/proj/sbt.conf
@@ -9,7 +9,7 @@
 
 vars.proj.sbt: ${vars.base} {
   name: "sbt"
-  uri: "https://github.com/scalacommunitybuild/sbt.git#de31feddf57066038e2aa54a894c66e269ac68de"
+  uri: "https://github.com/scalacommunitybuild/sbt.git#57bb8d403287ba19686401c7da06a588ae07be1e"
 
   extra.sbt-version: "1.2.0"  // yup, 1.2.1 is built with 1.2.0
   extra.options: [

--- a/proj/scala-rewrites.conf
+++ b/proj/scala-rewrites.conf
@@ -18,7 +18,7 @@
 // upstream that we changed something in Scala that's going to require
 // changes to Scalafix.)
 //
-// Note the hardcoded version numbers below (2.12.11, 4.3.7, 0.9.13).
+// Note the many hardcoded version numbers below.
 // They may need bumping when a new Scala 2.12.x release is published
 // or when we advance the scala-rewrites SHA.  Maybe it's possible to
 // somehow avoid that by computing the version numbers, but meh.
@@ -30,10 +30,10 @@ vars.proj.scala-rewrites: ${vars.base} {
   extra.commands: ${vars.base.extra.commands} [
     "removeDependency org.scalameta semanticdb-scalac"
     "removeDependency ch.epfl.scala scalafix-testkit"
-    """set rewrites / libraryDependencies += "ch.epfl.scala" % "scalafix-core_2.12" % "0.9.13""""
-    """set input / libraryDependencies += compilerPlugin("org.scalameta" % "semanticdb-scalac_2.12.11" % "4.3.7")"""
+    """set rewrites / libraryDependencies += "ch.epfl.scala" % "scalafix-core_2.12" % "0.9.24""""
+    """set input / libraryDependencies += compilerPlugin("org.scalameta" % "semanticdb-scalac_2.12.13" % "4.4.6")"""
     // we have to be careful with transitive dependencies or the CrossVersion.full ones will come back
-    """set tests / libraryDependencies += "ch.epfl.scala" % "scalafix-testkit_2.12.11" % "0.9.13" % Test excludeAll(ExclusionRule(organization = "org.scalameta"), ExclusionRule(organization = "ch.epfl.scala"))"""
-    """set tests / libraryDependencies += "ch.epfl.scala" % "scalafix-reflect_2.12.11" % "0.9.13" % Test excludeAll(ExclusionRule(organization = "org.scalameta"), ExclusionRule(organization = "ch.epfl.scala"))"""
+    """set tests / libraryDependencies += "ch.epfl.scala" % "scalafix-testkit_2.12.12" % "0.9.24" % Test excludeAll(ExclusionRule(organization = "org.scalameta"), ExclusionRule(organization = "ch.epfl.scala"))"""
+    """set tests / libraryDependencies += "ch.epfl.scala" % "scalafix-reflect_2.12.12" % "0.9.24" % Test excludeAll(ExclusionRule(organization = "org.scalameta"), ExclusionRule(organization = "ch.epfl.scala"))"""
   ]
 }

--- a/report/Report.scala
+++ b/report/Report.scala
@@ -61,24 +61,14 @@ object SuccessReport:
     "twitter-util",  // Unrecognized VM option 'AggressiveOpts'
   )
 
-  val scala_2_12_13_Failures = Set[String](
-    // The following 2 projects get:
-    //     java.lang.NoSuchMethodError: scala.tools.nsc.Global.reporter()Lscala/tools/nsc/reporters/Reporter;
-    // scala-rewrites depends on scalafix/scalameta which is in a state in the 2.12 CB,
-    //   so it uses binary dependencies instead of rebuilding from source, which is why it hits this
-    // sbt hits this via its use of kind-projector - didn't look why that isn't a just-compiled kind-projector
-    "scala-rewrites", // Global#reporter https://scala-ci.typesafe.com/job/scala-2.12.x-jdk8-integrate-community-build/6206/artifact/logs/scala-rewrites-build.log
-    "sbt",            // Global#reporter https://scala-ci.typesafe.com/job/scala-2.12.x-jdk8-integrate-community-build/6206/artifact/logs/sbt-build.log
-  )
-
   val expectedToFail: Set[String] =
     System.getProperty("java.specification.version") match
       case "1.8" =>
-        jdk8Failures ++ scala_2_12_13_Failures
+        jdk8Failures
       case "11" =>
-        jdk8Failures ++ jdk11Failures ++ scala_2_12_13_Failures
+        jdk8Failures ++ jdk11Failures
       case _ =>
-        jdk11Failures ++ jdk15Failures ++ scala_2_12_13_Failures
+        jdk11Failures ++ jdk15Failures
 
   def apply(log: io.Source): Option[Int] =
     val lines = log.getLines.dropWhile(!_.contains("---==  Execution Report ==---"))


### PR DESCRIPTION
Not sure if this will lead to actual changes, or whether I'll just want to update comments about where things stand.

https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6402/