### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# January 13, 2021
-nightly=2.12.14-bin-ff03e5a
+# January 26, 2021
+nightly=2.12.14-bin-a9b6d67

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# January 26, 2021
-nightly=2.12.14-bin-a9b6d67
+# January 28, 2021
+nightly=2.12.14-bin-5f6e5a1

--- a/proj/doobie.conf
+++ b/proj/doobie.conf
@@ -1,21 +1,21 @@
-// https://github.com/tpolecat/doobie.git#series/0.6.x
+// https://github.com/scalacommunitybuild/doobie.git#community-build-2.12  # was tpolecat, series/0.6.x
 
 // dependency of scala-pet-store
 
+// forked (January 2021) to align versions of things with community build
+// in order to faciliate reproducing errors outside dbuild
+
 vars.proj.doobie: ${vars.base} {
   name: "doobie"
-  uri: "https://github.com/tpolecat/doobie.git#6eb0fd53c237b13d3fb5d705d6b0bc52a6d0e0ca"
+  uri: "https://github.com/scalacommunitybuild/doobie.git#8d12d531250d671ef7c95cb2f1fff0cad055debc"
 
   extra.options: ["-Xss16m"]  // prevent stack overflow when compiling build definition
   extra.exclude: ["docs", "doobie", "bench"]  // out of scope ("doobie" is just an aggregation, and causes missing-tut error)
-  deps.inject: ${vars.base.deps.inject} ["org.typelevel#kind-projector"]
   extra.commands: ${vars.default-commands} [
-    "removeDependency org.spire-math kind-projector"
-    """set libraryDependencies in ThisBuild += compilerPlugin("org.typelevel" %% "kind-projector" % "0.0.0")"""
     // as per https://github.com/scala/community-builds/pull/835#issuecomment-455729365,
     // these subprojects require a Postgres instance for the tests to run
-    "set executeTests in postgres in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-    "set executeTests in `postgres-circe` in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
-    "set executeTests in example in Test := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    "set postgres         / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    "set `postgres-circe` / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
+    "set example          / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"
   ]
 }

--- a/proj/wartremover.conf
+++ b/proj/wartremover.conf
@@ -1,10 +1,14 @@
-// https://github.com/wartremover/wartremover.git#d2c6e4671da00cec37e0fb85e428d16b3916da5e  # was master
+// https://github.com/scalacommunitybuild/wartremover.git#community-build-2.12  # was wartremover, master
 
 // frozen (January 2020) at a November 2019 commit just before a ScalaTest 3.1 upgrade
+//   (https://github.com/scala/community-build/pull/1349)
+// forked (January 2021) from that freeze point
+//   to cherry-pick https://github.com/wartremover/wartremover/pull/469 ;
+//   see https://github.com/scala/community-build/pull/1349 for context
 
 vars.proj.wartremover: ${vars.base} {
   name: "wartremover"
-  uri: "https://github.com/wartremover/wartremover.git#d2c6e4671da00cec37e0fb85e428d16b3916da5e"
+  uri: "https://github.com/scalacommunitybuild/wartremover.git#5b94fac91f797df919d1bf922c902ff94c865223"
 
   extra.exclude: ["sbt-plugin"]
   deps.ignore: ["org.scala-sbt#scripted-plugin"]


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6442/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6443/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6445/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6447/
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6448/