### PR TITLE
2.13: new Scala SHA (with ASM 9)

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# January 27, 2021
-nightly=2.13.5-bin-6da2a93
+# February 2, 2021
+nightly=2.13.5-bin-c804289

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -1,8 +1,10 @@
-// https://github.com/ekrich/sconfig.git#master
+// https://github.com/SethTisue/sconfig.git#fix-throws  # was ekrich, master
+
+// temporarily forked pending merge of https://github.com/ekrich/sconfig/pull/146
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#190e34cdbeaf69ab4b79369178ac6ade99bb872b"
+  uri: "https://github.com/SethTisue/sconfig.git#19865a60188addf55e1193ca3b36a0d87125f612"
 
   extra.exclude: ["sconfigNative", "sconfigJS"]
   extra.commands: ${vars.default-commands} [

--- a/scripts/Report.scala
+++ b/scripts/Report.scala
@@ -62,10 +62,8 @@ object SuccessReport:
 
   val jdk16Failures = Set[String](
     "akka",                     // Unable to make field private static java.util.IdentityHashMap java.lang.ApplicationShutdownHooks.hooks accessible: module java.base does not "opens java.lang" to unnamed module @60e89085
-    "log4s",                    // Unsupported class file major version 60"
     "play-doc",                 // Error creating extended parser class: Could not determine whether class 'play.doc.CodeReferenceParser$$parboiled' has already been loaded (Parboiled.java:58)
     "requests-scala",           // requests.RequestTests fails, unclear why
-    "scala-async",              // Unsupported class file major version 60
     "shapeless-java-records",   // value permittedSubclasses is not a member of Class[?0]
     "specs2-more",              // Error creating extended parser class: Could not determine whether class 'org.pegdown.Parser$$parboiled' has already been loaded (Parboiled.java:58)
   )


### PR DESCRIPTION
JDK 11

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2448/

JDK 16

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk16-integrate-community-build/13/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk16-integrate-community-build/15/