### PR TITLE
new Scala 2.13 SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# February 15, 2021
-nightly=2.13.5-bin-bda0115
+# February 18, 2021
+nightly=2.13.5-bin-eb8cb18


### PR DESCRIPTION
~we're not to a 2.13.5 release candidate yet, but I want to test the big 2.12.x-to-2.13.x merge ASAP~

we have a release candidate!

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2504/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2505/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2506/~