### PR TITLE
unfreeze play-json

### DIFF
--- a/proj/play-json.conf
+++ b/proj/play-json.conf
@@ -1,17 +1,8 @@
-// https://github.com/playframework/play-json.git#2.8.0-M7
-
-// pinned at version play-ws currently (Nov 2019) expects
+// https://github.com/playframework/play-json.git#master
 
 vars.proj.play-json: ${vars.base} {
   name: "play-json"
-  uri: "https://github.com/playframework/play-json.git#ef4ba16d862522bac2736b2ba00dcee5f689a1c0"
+  uri: "https://github.com/playframework/play-json.git#64c78f30eff9aec24e6be2f9cf89d4a4f1553904"
 
   extra.projects: ["play-jsonJVM"]  // no Scala.js plz
-  // ScalaTest 3.0, not 3.2
-  deps.inject: ${vars.base.deps.inject} ["scalacommunitybuild#scalatest"]
-  extra.commands: ${vars.default-commands} [
-    // ScalaTest 3.0, not 3.2
-    "removeDependency org.scalatest scalatest"
-    """set libraryDependencies in ThisBuild += "scalacommunitybuild" %% "scalatest" % "0" % Test"""
-  ]
 }

--- a/proj/play-json.conf
+++ b/proj/play-json.conf
@@ -5,4 +5,8 @@ vars.proj.play-json: ${vars.base} {
   uri: "https://github.com/playframework/play-json.git#64c78f30eff9aec24e6be2f9cf89d4a4f1553904"
 
   extra.projects: ["play-jsonJVM"]  // no Scala.js plz
+  extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
+  extra.commands: ${vars.default-commands} [
+    "set every bintrayReleaseOnPublish := false"
+  ]
 }

--- a/proj/play-ws.conf
+++ b/proj/play-ws.conf
@@ -1,12 +1,12 @@
-// https://github.com/playframework/play-ws.git#v2.1.0-RC2
+// https://github.com/playframework/play-ws.git#v2.1.2
 
 // playframework and play-ws tend to get a bit out of sync with each other so it may be better
 // to have play-ws frozen at tag, unless it's forked.
-// currently (Nov 2019) frozen at version playframework expects
+// currently (February 2021) frozen at version playframework expects
 
 vars.proj.play-ws: ${vars.base} {
   name: "play-ws"
-  uri: "https://github.com/playframework/play-ws.git#a776a939f196f22a3298fec2e1b1ca119be9ab7f"
+  uri: "https://github.com/playframework/play-ws.git#735b38213011d4905426709205335a515a0333d7"
 
   // NullPointerException in CachingSpec
   // (https://github.com/scala/community-builds/issues/564)


### PR DESCRIPTION
specifically prompted by #1371, but regardless, it would be really be better not to be stuck on the old version

~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2511/~
https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2512/