### PR TITLE
unfork akka-management

### DIFF
--- a/proj/akka-management.conf
+++ b/proj/akka-management.conf
@@ -1,13 +1,10 @@
-// https://github.com/raboof/akka-management.git#akka-2.6  # was akka, master
-
-// temporarily using fork, pending merge of
-// https://github.com/akka/akka-management/pull/784
+// https://github.com/akka/akka-management.git#master
 
 // dependency of lagom
 
 vars.proj.akka-management: ${vars.base} {
   name: "akka-management"
-  uri: "https://github.com/raboof/akka-management.git#2dcafdaa8040b8cd4b188c75e787f6ab1c76227e"
+  uri: "https://github.com/akka/akka-management.git#119b3396016578b4744679ed76146f72284ef6d3"
 
   // for now anyway, ambition level is just to include anything lagom needs
   extra.projects: ["akka-management", "cluster-bootstrap", "cluster-http"]


### PR DESCRIPTION
(because https://github.com/akka/akka-management/pull/865 was merged)

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2574/ queued