### PR TITLE
2.12: unfork mdoc

### DIFF
--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -1,8 +1,8 @@
-// https://github.com/scalacommunitybuild/mdoc.git#master
+// https://github.com/scalameta/mdoc.git#master
 
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalacommunitybuild/mdoc.git#069fbf0a01899eeec80a48d99eefaab0caac38ac"
+  uri: "https://github.com/scalameta/mdoc.git#29764af92e2441c78541add48d0d146b63affca7"
 
   extra.exclude: [
     "js", "jsdocs", "docs", "unit", "plugin"

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -10,6 +10,10 @@ vars.proj.mdoc: ${vars.base} {
     // probably not worth tinkering with
     "worksheets"
   ]
+  // use right version-specific source directories regardless of our weird dbuild Scala version numbers
+  extra.commands: ${vars.default-commands} [
+    """set mdoc / Compile / unmanagedSourceDirectories += (mdoc / baseDirectory).value / "src" / "main" / "scala-2.12.13""""
+  ]
   // ignore missing scripted-sbt (https://github.com/sbt/sbt/issues/3917 ?)
   deps.ignore: ["org.scala-sbt#scripted-sbt"]
   check-missing: false

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -1,21 +1,9 @@
-// https://github.com/scalacommunitybuild/mdoc.git#community-build-2.12
-
-// forked (Nov 2020) to the previously frozen commit, with copying the 2.13 Reporter adaptions to the 2.12 sources
-
-// frozen (September 2019) at an August 2019 commit some time before a sbt-coursier
-//     https://github.com/scalameta/mdoc.git#364ebde027114563f2c87464c8885a3ab59a658d
-// version bump that seems to be confusing dbuild during dependency extraction:
-// java.lang.NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project(Llmcoursier/definitions/Project;)Lcoursier/core/Project;
-//   at coursier.sbtcoursier.ResolutionTasks$.$anonfun$resolutionsTask$3(ResolutionTasks.scala:42)
-
-// official uri:
-//     https://github.com/scalameta/mdoc.git#master
+// https://github.com/scalacommunitybuild/mdoc.git#master
 
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalacommunitybuild/mdoc.git#23d958c5c8cbce81d59b889be7198003b39236ad"
+  uri: "https://github.com/scalacommunitybuild/mdoc.git#069fbf0a01899eeec80a48d99eefaab0caac38ac"
 
-  extra.sbt-version: ${vars.sbt-1-2-version} # otherwise "NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project"
   extra.exclude: [
     "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"
     "js", "jsdocs", "docs", "unit"  // no Scala.js plz

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -5,8 +5,10 @@ vars.proj.mdoc: ${vars.base} {
   uri: "https://github.com/scalacommunitybuild/mdoc.git#069fbf0a01899eeec80a48d99eefaab0caac38ac"
 
   extra.exclude: [
-    "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"
-    "js", "jsdocs", "docs", "unit"  // no Scala.js plz
+    "js", "jsdocs", "docs", "unit", "plugin"
+    // tests-only, and it downloads Maven Central artifacts but doesn't use the right Scala binary version.
+    // probably not worth tinkering with
+    "worksheets"
   ]
   // ignore missing scripted-sbt (https://github.com/sbt/sbt/issues/3917 ?)
   deps.ignore: ["org.scala-sbt#scripted-sbt"]

--- a/proj/metaconfig.conf
+++ b/proj/metaconfig.conf
@@ -1,15 +1,10 @@
-// https://github.com/olafurpg/metaconfig.git#549685b5ff1976be6890f4781366252378bab30e  # was master
-
-// frozen (September 2019) at a April 2019 commit just before a sbt-coursier
-// version bump that seems to be confusing dbuild during dependency extraction:
-// java.lang.NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project(Llmcoursier/definitions/Project;)Lcoursier/core/Project;
-//   at coursier.sbtcoursier.ResolutionTasks$.$anonfun$resolutionsTask$3(ResolutionTasks.scala:42)
+// https://github.com/olafurpg/metaconfig.git#master
 
 vars.proj.metaconfig: ${vars.base} {
   name: "metaconfig"
-  uri: "https://github.com/olafurpg/metaconfig.git#549685b5ff1976be6890f4781366252378bab30e"
+  uri: "https://github.com/olafurpg/metaconfig.git#aaab8feb0d7b22f6ae78dda3f291839537e2006b"
 
-  extra.projects: ["hoconJVM", "typesafe"]  // no Scala.js plz
+  extra.exclude: ["docs", "*JS"]
   // I guess dbuild is getting confused by the extra _1.13?
   deps.ignore: ["com.github.alexarchambault#scalacheck-shapeless"]
   deps.inject: ${vars.base.deps.inject} [
@@ -17,10 +12,10 @@ vars.proj.metaconfig: ${vars.base} {
   ]
   check-missing: false
   extra.settings: ${vars.base.extra.settings} [
-    "conflictWarning in ThisBuild := ConflictWarning.disable"
+    "ThisBuild / conflictWarning := ConflictWarning.disable"
   ]
   extra.commands: ${vars.default-commands} [
     // https://github.com/olafurpg/metaconfig/issues/59
-    "set excludeFilter in (Test, unmanagedSources) in coreJVM := HiddenFileFilter || \"CliSuite.scala\""
+    """set coreJVM / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CliSuite.scala""""
   ]
 }


### PR DESCRIPTION
currently mdoc is failing on JDK 15 and 16. I assume it's because it's on sbt 1.2.  let's see if we can unfork.  (on 2.13 it isn't forked.)

if this doesn't pan out, I'll just mark the repo as expected-to-fail on those JDKs

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6551/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6553/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6555/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6563/

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk15-integrate-community-build/1453/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk15-integrate-community-build/1454/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk15-integrate-community-build/1456/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk15-integrate-community-build/1463/