### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# March 4, 2021
-nightly=2.13.6-bin-262f6e9
+# March 25, 2021
+nightly=2.13.6-bin-5d025ac

--- a/proj/blaze.conf
+++ b/proj/blaze.conf
@@ -1,10 +1,11 @@
-// https://github.com/http4s/blaze.git#v0.14.10  # was master
+// https://github.com/scalacommunitybuild/blaze.git#community-build-2.13  # was http4s, v0.14.10
 
 // frozen (January 2020) at v0.14.10 tag since that's the version http4s wants
+// forked (March 2021) from that tag to adapt to scala/scala#9525
 
 vars.proj.blaze: ${vars.base} {
   name: "blaze"
-  uri: "https://github.com/http4s/blaze.git#7e9789e2fd9243e59969576df38811dc8523c4b5"
+  uri: "https://github.com/scalacommunitybuild/blaze.git#12a0e804c862f5caa6795cd9a79144173a566052"
 
   extra.commands: ${vars.default-commands} [
     // fails on JDK 11 only: https://github.com/http4s/blaze/issues/376

--- a/proj/http4s.conf
+++ b/proj/http4s.conf
@@ -11,7 +11,7 @@
 
 vars.proj.http4s: ${vars.base} {
   name: "http4s"
-  uri: "https://github.com/scalacommunitybuild/http4s.git#6709de772946c5e2ac95f1faa60005502e1e25e5"
+  uri: "https://github.com/scalacommunitybuild/http4s.git#876f9effe8e27ffcf4032d0e77c7d55a8ce53817"
 
   // java.lang.NoSuchMethodError: scala.tools.nsc.Settings.bootclasspath()Lscala/tools/nsc/settings/AbsSettings$AbsSetting
   // at play.twirl.compiler.TwirlCompiler$TemplateAsFunctionCompiler$CompilerInstance.compiler$lzycompute(TwirlCompiler.scala:653)

--- a/proj/scalameta.conf
+++ b/proj/scalameta.conf
@@ -15,7 +15,7 @@ vars.proj.scalameta: ${vars.base} {
     // use right version-specific source directories regardless of our weird dbuild Scala version numbers
     """set common.jvm / Compile / unmanagedSourceDirectories += baseDirectory.value / "scalameta" / "common" / "shared" / "src" / "main" / "scala-2.13""""
     """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13""""
-    """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13.4""""
+    """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13.6""""
     // reported upstream at https://github.com/scalameta/scalameta/issues/2246
     """set testkit / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "TraverserOrder.scala""""
   ]

--- a/proj/scalameta.conf
+++ b/proj/scalameta.conf
@@ -1,11 +1,14 @@
-// https://github.com/scalameta/scalameta.git#v4.4.10
+// https://github.com/scalacommunitybuild/scalameta.git#community-build-2.13  # was scalameta, v4.4.10
 
 // we typically use a tag here rather than track a branch, in the
 // interest of stability.  whatever tag scalafmt and/or scalafix expect
 
+// forked (March 2021) from v4.4.10 tag to add 2.13.6 support;
+// presumably we will able to unfork after 2.13.6 is released
+
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalameta/scalameta.git#5341b7d2a9a328abaecb93b1703d881840b07221"
+  uri: "https://github.com/scalacommunitybuild/scalameta.git#f929a701d34bf4b4eeac15ef75e59c454cf27e93"
 
   extra.projects: ["semanticdbScalacPlugin", "testkit"]
   extra.commands: ${vars.default-commands} [


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2615/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2624/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2625/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2627/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2628/