### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# March 25, 2021
-nightly=2.13.6-bin-5d025ac
+# April 8, 2021
+nightly=2.13.6-bin-6c68c28


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2652/ queued