### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 14, 2021
-nightly=2.13.6-bin-9468b9a
+# May 17, 2021
+nightly=2.13.7-bin-8c3de9d

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -1,10 +1,7 @@
-// https://github.com/SethTisue/genjavadoc.git#scala-2.13.7
-
-// temporarily forked pending merge of
-// https://github.com/lightbend/genjavadoc/pull/279
+// https://github.com/lightbend/genjavadoc.git#main
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/SethTisue/genjavadoc.git#cdd3e9b9d3417d6782f2191fd0d44300afc2e348"
+  uri: "https://github.com/lightbend/genjavadoc.git#1372c5d268f206c0333757d4b67451a97be479d4"
 
 }

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -1,7 +1,10 @@
-// https://github.com/lightbend/genjavadoc.git#main
+// https://github.com/SethTisue/genjavadoc.git#scala-2.13.7
+
+// temporarily forked pending merge of
+// https://github.com/lightbend/genjavadoc/pull/279
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#478fa689fc2a706a16de9005876a99022b5e7123"
+  uri: "https://github.com/SethTisue/genjavadoc.git#cdd3e9b9d3417d6782f2191fd0d44300afc2e348"
 
 }


### PR DESCRIPTION
restarred on 2.13.6

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2760/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2761/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2762/