### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
 # May 18, 2021
-nightly=2.12.14-bin-df9bb3e
+nightly=2.12.14-bin-21a8a7a

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 10, 2021
-nightly=2.12.14-bin-fd00775
+# May 18, 2021
+nightly=2.12.14-bin-df9bb3e

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -19,6 +19,7 @@ vars.proj.mdoc: ${vars.base} {
   extra.exclude: [
     "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"
     "js", "jsdocs", "docs", "unit"  // no Scala.js plz
+    "plugin"  // out of scope
   ]
   // ignore missing scripted-sbt (https://github.com/sbt/sbt/issues/3917 ?)
   deps.ignore: ["org.scala-sbt#scripted-sbt"]

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -13,9 +13,9 @@
 
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalacommunitybuild/mdoc.git#23d958c5c8cbce81d59b889be7198003b39236ad"
+  uri: "https://github.com/scalacommunitybuild/mdoc.git#b066a62994fe3ab734b588f427b0591f670305e2"
 
-  extra.sbt-version: ${vars.sbt-1-2-version} # otherwise "NoSuchMethodError: lmcoursier.definitions.ToCoursier$.project"
+  extra.sbt-version: ${vars.sbt-1-3-version}  // maybe not necessary? haven't checked lately
   extra.exclude: [
     "lsp"  // Olaf says: "please exclude [...] it's an undocumented and untested module"
     "js", "jsdocs", "docs", "unit"  // no Scala.js plz


### PR DESCRIPTION
fyi @retronym 

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6726/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6730/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6731/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6732/
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6733/