### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 18, 2021
-nightly=2.12.14-bin-21a8a7a
+# May 28, 2021
+nightly=2.12.15-bin-bb80b39

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#478fa689fc2a706a16de9005876a99022b5e7123"
+  uri: "https://github.com/lightbend/genjavadoc.git#b71c0e164d2ca9a61850b6c4c1e691e632a19fc5"
 
 }


### PR DESCRIPTION
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6744/ queued