### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 17, 2021
-nightly=2.13.7-bin-8c3de9d
+# June 2, 2021
+nightly=2.13.7-bin-074cae1


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/2836/ queued