### PR TITLE
newer cats

### DIFF
--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -1,16 +1,8 @@
-// https://github.com/typelevel/cats.git#v2.3.1  # was master
-
-// 2.3.x development is on master, they haven't branched
-
-// frozen (December 2020) at a tag, because
-// https://github.com/typelevel/cats/pull/3702
-// caused breakage in several downstream projects,
-// for example:
-//   [cats-testkit-scalatest] [error] /Users/tisue/cb3/target-0.9.17/project-builds/cats-testkit-scalatest-52165c7879e911646e28a61aa1c8986874b11cf7/core/src/main/scala/cats/tests/CatsSuite.scala:61:29: Type parameter has to be specialized at least for the same types as in the overridden method. Missing types: Double, Float, Int, Long
+// https://github.com/typelevel/cats.git#v2.4.2
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#6f1c7c6c0cd5bd92596ef3354e9672b48fd1afff"
+  uri: "https://github.com/typelevel/cats.git#aebf020b6a3c8d9755465026ff0b1b287251a47a"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.
@@ -28,7 +20,7 @@ vars.proj.cats: ${vars.base} {
   // tests are memory-hungry. hard to tell if occasional OutOfMemoryErrors are because
   // some random test input in a generative test hit a real bug, or whether memory needs
   // just fluctuate :-/  I've been gradually increasing this trying to fix an OOM in
-  // ApplicativeSuite.  the repo's own .jvmopts has 6g
+  // ApplicativeSuite.  the repo's own .jvmopts has 5g
   extra.options: ["-Xmx6g"]
   extra.commands: ${vars.default-commands} [
     // intermittent failures

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -1,8 +1,8 @@
-// https://github.com/typelevel/cats.git#v2.4.2
+// https://github.com/typelevel/cats.git#v2.6.1
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#aebf020b6a3c8d9755465026ff0b1b287251a47a"
+  uri: "https://github.com/typelevel/cats.git#2473fcb713a08c42bd9b5a47f35df109916d62d0"
 
   // for some reason, adding the umbrella "catsJVM" project but excluding "bench"
   // (and "docs") doesn't succeed in removing the depending on cats-bench.


### PR DESCRIPTION
let's try 2.4.x first, if that works maybe try 2.5.x or 2.6.x

~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2958/~
~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2966/~
~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2969/~
https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/2972/