### PR TITLE
ScalaTest: flaky tests are now disabled by default

### DIFF
--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -32,5 +32,8 @@ vars.proj.scalatest-tests: ${vars.base} {
   ]
   // needs extra heap to even compile
   extra.options: ["-Xmx4000m"]
-
+  extra.commands: ${vars.default-commands} [
+    // not investigated
+    """set scalatestTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "FrameworkSuite.scala""""
+  ]
 }

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -34,7 +34,7 @@ vars.proj.scalatest-tests: ${vars.base} {
   extra.options: ["-Xmx4000m"]
   extra.commands: ${vars.default-commands} [
     // not investigated
-    """set scalatestTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "FrameworkSuite.scala""""
-    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(_.getName == "FrameworkSuite.scala"))"""
+    """set scalatestTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "FrameworkSuite.scala" || "CommonGeneratorsSpec.scala""""
+    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(_.getName == "FrameworkSuite.scala").filterNot(_.getName == "CommonGeneratorsSpec.scala"))"""
   ]
 }

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"
-  uri: "https://github.com/scalatest/scalatest.git#e6e656bac6e54be2a9ae4f286a3727714ac09d1e"
+  uri: "https://github.com/scalatest/scalatest.git#96ef4cc5f9ac809a64cae5d1d8d390f4ebaf9f35"
 
   extra.projects: ["scalatest", "scalactic", "scalatestFunSuite"]
 }
@@ -12,7 +12,7 @@ vars.proj.scalatest: ${vars.base} {
 
 vars.proj.scalatest-tests: ${vars.base} {
   name: "scalatest-tests"
-  uri: "https://github.com/scalatest/scalatest.git#e6e656bac6e54be2a9ae4f286a3727714ac09d1e"
+  uri: "https://github.com/scalatest/scalatest.git#96ef4cc5f9ac809a64cae5d1d8d390f4ebaf9f35"
 
   extra.exclude: [
     // we already built these above
@@ -33,10 +33,4 @@ vars.proj.scalatest-tests: ${vars.base} {
   // needs extra heap to even compile
   extra.options: ["-Xmx4000m"]
 
-  extra.commands: ${vars.default-commands} [
-    // not investigated
-    """set scalatestTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "GeneratorSpec.scala" || "FrameworkSuite.scala" || "WaitersSpec.scala" || "TestSortingReporterSpec.scala" || "JavaFuturesSpec.scala" || "ParallelTestExecutionSpec.scala" || "TimeLimitsSpec.scala" || "TestThreadsStartingCounterSpec.scala" || "SuiteSortingReporterSpec.scala" || "CommonGeneratorsSpec.scala" || "PropCheckerAssertingSpec.scala" || "ConductorMethodsSuite.scala""""
-    """set scalacticTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "NonEmptyArraySpec.scala""""
-    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(_.getName == "FrameworkSuite.scala").filterNot(_.getName == "GeneratorSpec.scala").filterNot(_.getName == "CommonGeneratorsSpec.scala").filterNot(_.getName == "ParallelTestExecutionSpec.scala").filterNot(_.getName == "DispatchReporterSpec.scala").filterNot(_.getName == "TestThreadsStartingCounterSpec.scala").filterNot(_.getName == "EventuallySpec.scala"))"""
-  ]
 }

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -35,5 +35,6 @@ vars.proj.scalatest-tests: ${vars.base} {
   extra.commands: ${vars.default-commands} [
     // not investigated
     """set scalatestTest / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "FrameworkSuite.scala""""
+    """set genRegularTests4 / Test / managedSources ~= (_.filterNot(_.getName == "FrameworkSuite.scala"))"""
   ]
 }


### PR DESCRIPTION
thanks to https://github.com/scalatest/scalatest/pull/2051
we shouldn't need to exclude tests anymore... time will tell

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3020/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3021/