### PR TITLE
advance Akka SHA

### DIFF
--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -7,7 +7,7 @@
 
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/scalacommunitybuild/akka.git#f1423152c98461bb8d0ad28bf0be3d7771b3c2f2"
+  uri: "https://github.com/scalacommunitybuild/akka.git#bf18b54db627605f5e4d801a9b87984c8b807dfc"
 
   extra.options: [
     // as per their own .sbtopts file
@@ -34,7 +34,7 @@ vars.proj.akka: ${vars.base} {
 
 vars.proj.akka-stream: ${vars.base} {
   name: "akka-stream"
-  uri: "https://github.com/scalacommunitybuild/akka.git#f1423152c98461bb8d0ad28bf0be3d7771b3c2f2"
+  uri: "https://github.com/scalacommunitybuild/akka.git#bf18b54db627605f5e4d801a9b87984c8b807dfc"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     // repo readme recommended
@@ -73,7 +73,7 @@ vars.proj.akka-stream: ${vars.base} {
 // tests, and so failures in obscure subprojects don't take out too much of the build
 vars.proj.akka-more: ${vars.base} {
   name: "akka-more"
-  uri: "https://github.com/scalacommunitybuild/akka.git#f1423152c98461bb8d0ad28bf0be3d7771b3c2f2"
+  uri: "https://github.com/scalacommunitybuild/akka.git#bf18b54db627605f5e4d801a9b87984c8b807dfc"
 
   extra.options: ["-Dakka.genjavadoc.enabled=false", "-Dakka.scaladoc.diagrams=false", "-Dakka.build.aggregateSamples=false", "-Dakka.test.tags.exclude=performance,timing,long-running", "-Dakka.test.multi-in-test=false", "-Dakka.fail-mixed-versions=false"
     // repo readme recommended


### PR DESCRIPTION
because I want to pull in https://github.com/akka/akka/pull/30490 since it's supposed to fix a test that frequently fails for us

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3084/ queued