### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# August 3, 2021
-nightly=2.13.7-bin-161380e
+# August 25, 2021
+nightly=2.13.7-bin-8bbc323

--- a/proj/twitter-util.conf
+++ b/proj/twitter-util.conf
@@ -25,6 +25,8 @@ vars.proj.twitter-util: ${vars.base} {
     """set utilApp / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "GlobalFlagTest.scala" || "JavaGlobalFlagTest.java" || "FlagsTest.scala" || "FlagTest.scala""""
     // 2.13: failing test; not investigated or reported upstream. it seems to be a GC-based test, those are typically fragile
     """set utilStats / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CumulativeGaugeTest.scala""""
+    // TODO post-2.13.6 regression: https://github.com/scala/scala/pull/9727#issuecomment-906652954
+    """set utilLogging / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ThrottledHandlerTest.scala""""
     // not supported on JDK 11+
     "removeJavaOptions -XX:+UseParNewGC"
   ]


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3125/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3128/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3132/