### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# August 3, 2021
-nightly=2.13.7-bin-161380e
+# August 27, 2021
+nightly=2.13.7-bin-072e68e


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3137/ queued