### PR TITLE
2.12: advance project SHAs, Scala SHA too

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -68,6 +68,7 @@ acyclic: cloc-plugin, portable-scala-reflect, scala, utest
 base64: cloc-plugin, portable-scala-reflect, scala, utest
 geny: cloc-plugin, portable-scala-reflect, scala, utest
 scopt: cloc-plugin, scala, scala-parser-combinators, verify
+curryhoward: cloc-plugin, scala, scalacheck, scalatest, wartremover
 grizzled: cloc-plugin, scala, scalacheck, scalatest, wartremover
 mercator: cloc-plugin, scala, scalacheck, scalatest, wartremover
 scribe: cloc-plugin, perfolation, scala, scalacheck, scalatest
@@ -75,7 +76,6 @@ scala-logging: cloc-plugin, mockito-scala, scala, scalacheck, scalatest
 log4s: cloc-plugin, scala, scala-js-stubs, scalacheck, scalatest
 macro-compat: cloc-plugin, macro-paradise, scala, scalacheck, scalatest
 pascal: cloc-plugin, kind-projector, scala, scalacheck, scalatest
-curryhoward: cloc-plugin, scala, scalacheck, scalatest, tut, wartremover
 boopickle: cloc-plugin, portable-scala-reflect, scala, shapeless, utest
 fansi: cloc-plugin, portable-scala-reflect, scala, sourcecode, utest
 scalatags: cloc-plugin, portable-scala-reflect, scala, sourcecode, utest

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# August 25, 2021
-nightly=2.12.15-bin-f9acc3d
+# August 27, 2021
+nightly=2.12.15-bin-23a6d50

--- a/proj/curryhoward.conf
+++ b/proj/curryhoward.conf
@@ -2,9 +2,8 @@
 
 vars.proj.curryhoward: ${vars.base} {
   name: "curryhoward"
-  uri: "https://github.com/Chymyst/curryhoward.git#f1262bc38b540fd08125c799a02fe4f45e0f3d68"
+  uri: "https://github.com/Chymyst/curryhoward.git#8b5b0fe463bcb76f891f9d5af6df7b640dd14be5"
 
-  extra.sbt-version: ${vars.sbt-0-13-version}
   // I guess dbuild is getting confused by the extra _1.13?
   deps.ignore: ["com.github.alexarchambault#scalacheck-shapeless"]
   deps.inject: ${vars.base.deps.inject} [

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -1,4 +1,7 @@
-// https://github.com/lightbend/mima.git#main
+// https://github.com/lightbend/mima.git#3218a441ff27df266cf332b0493d99a6cf71413a  # was main
+
+// frozen (August 2021) at a known-green commit before a dependency on
+// coursier was added
 
 vars.proj.mima: ${vars.base} {
   name: "mima"

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#61da0113769bc9188f96741d5e8d49d70ecafcdf"
+  uri: "https://github.com/scalameta/munit.git#9cfd8b1def94d1dc107c2d1fb5143f419ef9df04"
 
   extra.exclude: ["docs", "plugin", "*JS", "*Native"]
   // ignore missing org.scala-sbt#scripted-plugin

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -4,6 +4,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#3f4d36c7bfb1712ad5071a23848fa3dd4a08f210"
+  uri: "https://github.com/nscala-time/nscala-time.git#f7c20caacd7933212b4496d31b4e3c605e35f4e5"
 
 }

--- a/proj/parboiled2.conf
+++ b/proj/parboiled2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled2: ${vars.base} {
   name: "parboiled2"
-  uri: "https://github.com/sirthias/parboiled2.git#c150c92b24bc3a8b8f28d4e69f4027e789bb8b34"
+  uri: "https://github.com/sirthias/parboiled2.git#ddff95174360342a50a8a68bd9c5c45566080ff4"
 
   extra.projects: ["parboiledJVM", "examples"]
   extra.commands: ${vars.default-commands} [

--- a/proj/play-file-watch.conf
+++ b/proj/play-file-watch.conf
@@ -4,7 +4,7 @@
 
 vars.proj.play-file-watch: ${vars.base} {
   name: "play-file-watch"
-  uri: "https://github.com/playframework/play-file-watch.git#36fad546344f0ad1b6beaeee9a1d39b8b5867afe"
+  uri: "https://github.com/playframework/play-file-watch.git#80fbbd588ba8ba90b84103ea814d55d39d1fd588"
 
   extra.commands: ${vars.default-commands} [
     // tends to fail on MacOS;

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#f7d60c0563717596a46e0780807db070863b6199"
+  uri: "https://github.com/scala/scala-collection-compat.git#56d83284e90ab79fea2b2c59fe4c6b5e9978298b"
 
   extra.projects: ["compat212"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-java8-compat.conf
+++ b/proj/scala-java8-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-java8-compat: ${vars.base} {
   name: "scala-java8-compat"
-  uri: "https://github.com/scala/scala-java8-compat.git#57e1f7ccaa67dcac2b4227ab1a6ee0fcb5f42023"
+  uri: "https://github.com/scala/scala-java8-compat.git#fdc2b8a031bc898b2fd2551d106bc0e113e575d3"
 
   // as per https://github.com/scala/scala-java8-compat/issues/160
   // genjavadoc is disabled except on JDK 8, but we don't want to

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#299799d9fb27b23ac069d8f454207b5d1baf20cd"
+  uri: "https://github.com/scalaprops/scalaprops.git#785a39162817b179afc4a474ab74ddc8a04cbe0b"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,9 +2,13 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#7c59d6d072fbac284e0336975435192437839430"
+  uri: "https://github.com/ekrich/sconfig.git#14ed60ab32ee44ba8f04a427a0fa0b4f1ad8d2b5"
 
-  extra.exclude: ["sconfigNative", "sconfigJS"]
+  extra.exclude: [
+    "*Native", "*JS"
+    // we don't have the right Scalafix version for these
+    "scalafix*"
+  ]
   // use right version-specific source directories regardless of our weird dbuild Scala version numbers
   extra.commands: ${vars.default-commands} [
     "set unmanagedSourceDirectories in (sconfigJVM, Compile) += (baseDirectory in ThisBuild).value / \"sconfig\" / \"shared\" / \"src\" / \"main\" / \"scala-2.12\""

--- a/proj/shapeless-java-records.conf
+++ b/proj/shapeless-java-records.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless-java-records: ${vars.base} {
   name: "shapeless-java-records"
-  uri: "https://github.com/xuwei-k/shapeless-java-records.git#9f1fd457640f2a227c8c36fa523b7de0247f8678"
+  uri: "https://github.com/xuwei-k/shapeless-java-records.git#be3784bd3e648d0184dcb1250643684265f16bbe"
 
   extra.options: ["--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions"]
 }

--- a/proj/sksamuel-exts.conf
+++ b/proj/sksamuel-exts.conf
@@ -1,6 +1,8 @@
-// https://github.com/sksamuel/exts.git#master
+// https://github.com/sksamuel/exts.git#012500e8e9d4b093b8fb191d128b37b9f75e7624  # was master
 
 // dependency of elastic4s
+
+// frozen (August 2021) at a known-green commit before a ScalaTest 3.2 upgrade
 
 vars.proj.sksamuel-exts: ${vars.base} {
   name: "sksamuel-exts"
@@ -9,6 +11,6 @@ vars.proj.sksamuel-exts: ${vars.base} {
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.commands: ${vars.default-commands} [
     // reported upstream at https://github.com/sksamuel/exts/commit/5f69f7254d9ad58a94dd304a0e1cdb560486d6c2#r29458859
-    "set excludeFilter in (Test, unmanagedSources) := HiddenFileFilter || \"FileWatcherTest.scala\""
+    """set excludeFilter in (Test, unmanagedSources) := HiddenFileFilter || "FileWatcherTest.scala""""
   ]
 }


### PR DESCRIPTION
(normally I would advance these separately but 2.12.15 is imminent and the chances of anything breaking — and the cause being unclear — are low)

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6920/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/6926/