### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# September 9, 2021
-nightly=2.13.7-bin-7247dfe
+# October 4, 2021
+nightly=2.13.7-bin-0a8b8b9


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3248/ queued