### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 4, 2021
-nightly=2.13.7-bin-0a8b8b9
+# October 20, 2021
+nightly=2.13.7-bin-e020f93

--- a/proj/discipline-specs2.conf
+++ b/proj/discipline-specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-specs2: ${vars.base} {
   name: "discipline-specs2"
-  uri: "https://github.com/typelevel/discipline-specs2.git#adf7975777c64cbe35154ae274c0c58a1a533ff5"
+  uri: "https://github.com/typelevel/discipline-specs2.git#a8635fcd449a76ab2035715c1277a8299d75b496"
 
   extra.exclude: ["*JS", "docs"]
   extra.commands: ${vars.default-commands} [


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3287/