### PR TITLE
2.13: new Scala SHA (2.13.7 release candidate)

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 20, 2021
-nightly=2.13.7-bin-e020f93
+# October 27, 2021
+nightly=2.13.7-bin-8fde4e3


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3300/