### PR TITLE
2.13: new Scala SHA (re-STARR on 2.13.7)

### DIFF
--- a/core/genjavadoc.conf
+++ b/core/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#c6da20352b0cfe419adbc6395a558866ce3a6a51"
+  uri: "https://github.com/lightbend/genjavadoc.git#546f5e1fe085dae03f65698d86bf681aab093241"
 
 }

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# October 28, 2021
-nightly=2.13.7-bin-fe0df69
+# November 1, 2021
+nightly=2.13.8-bin-af79b08


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3311/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3312/