### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 1, 2021
-nightly=2.13.8-bin-af79b08
+# November 11, 2021
+nightly=2.13.8-bin-5697b87


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3333/ queued