### PR TITLE
2.13: sbt 1.6.0-RC1 (was 1.6.0-M1)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -29,7 +29,7 @@ include file("resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "1.6.0-M1"
+  sbt-version: "1.6.0-RC1"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/proj/cats-parse.conf
+++ b/proj/cats-parse.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-parse: ${vars.base} {
   name: "cats-parse"
-  uri: "https://github.com/typelevel/cats-parse.git#eea17fafb73cfde0db8d14e330f034876d6c57f8"
+  uri: "https://github.com/typelevel/cats-parse.git#7a012da08a5f16e15525210280879647b3caa818"
 
   extra.exclude: ["bench", "docs", "*JS"]
   extra.commands: ${vars.default-commands} [


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3353/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3355/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3356/