### PR TITLE
2.12: advance project SHAs

### DIFF
--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#546f5e1fe085dae03f65698d86bf681aab093241"
+  uri: "https://github.com/lightbend/genjavadoc.git#1ea288a55f548943d4472ce8d33e887b9a7874d8"
 
 }

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -4,6 +4,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#b7cd2f6c7e9bc43b8d8a1d2581eca7a32d99d195"
+  uri: "https://github.com/nscala-time/nscala-time.git#a4427bf8ff5223a95c8150ee4b675ba3f8f8c82e"
 
 }

--- a/proj/parboiled2.conf
+++ b/proj/parboiled2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled2: ${vars.base} {
   name: "parboiled2"
-  uri: "https://github.com/sirthias/parboiled2.git#7502b20f1bf2e18bf043c1741a8c4de4e5e8162b"
+  uri: "https://github.com/sirthias/parboiled2.git#8f842a21368e6b73b720d8b47003a0bee4870e9d"
 
   extra.projects: ["parboiledJVM", "examples"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#10860c85b50f719709603df4772c51fde0bfe042"
+  uri: "https://github.com/scala/scala-collection-compat.git#335ffd4f6da02d6dab76a0d0e688dad304f15fd7"
 
   extra.projects: ["compat212"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-debugger.conf
+++ b/proj/scala-debugger.conf
@@ -1,8 +1,10 @@
-// https://github.com/ensime/scala-debugger.git#master
+// https://github.com/scalacommunitybuild/scala-debugger.git#master
+
+// using fork because the original repository vanished circa Dec 2021
 
 vars.proj.scala-debugger: ${vars.base} {
   name: "scala-debugger"
-  uri: "https://github.com/ensime/scala-debugger.git#f8e69614d71786605b4baa8c62f0968683936d22"
+  uri: "https://github.com/scalacommunitybuild/scala-debugger.git#f8e69614d71786605b4baa8c62f0968683936d22"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.exclude: [

--- a/proj/scala-hedgehog.conf
+++ b/proj/scala-hedgehog.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-hedgehog: ${vars.base} {
   name: "scala-hedgehog"
-  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#52b85b1d51491c02f8f5680c1d822fc6bb13a5a4"
+  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#022c4459194e9f53b03c3e052a02032a8a73b570"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-java8-compat.conf
+++ b/proj/scala-java8-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-java8-compat: ${vars.base} {
   name: "scala-java8-compat"
-  uri: "https://github.com/scala/scala-java8-compat.git#0478d7d411e3d3c21508e113915b46a3aba6d729"
+  uri: "https://github.com/scala/scala-java8-compat.git#ab302d0c3465aed96542c024d986d421f0d669ed"
 
   // as per https://github.com/scala/scala-java8-compat/issues/160
   // genjavadoc is disabled except on JDK 8, but we don't want to

--- a/proj/scala-sculpt.conf
+++ b/proj/scala-sculpt.conf
@@ -5,6 +5,6 @@
 
 vars.proj.scala-sculpt: ${vars.base} {
   name: "scala-sculpt"
-  uri: "https://github.com/lightbend/scala-sculpt.git#e88845435c5925411af336356ac011467cb9b980"
+  uri: "https://github.com/lightbend/scala-sculpt.git#1740ffbda87e26934808a8b521537e628db46c8a"
 
 }

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#551c349ca78a3a9af1586962809b85a146e68aab"
+  uri: "https://github.com/scalaprops/scalaprops.git#189c1888b801b80d1070af6fd2e392608854509b"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#5968a0c2401687dc221842de6f3d0c091bbfbb95"
+  uri: "https://github.com/ekrich/sconfig.git#c911d5bedde6e381f3ff863d6472c2763db842cf"
 
   extra.exclude: [
     "*Native", "*JS"

--- a/proj/shapeless-java-records.conf
+++ b/proj/shapeless-java-records.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless-java-records: ${vars.base} {
   name: "shapeless-java-records"
-  uri: "https://github.com/xuwei-k/shapeless-java-records.git#4eb3d37104efe9f41d9f9295b66a91672c0d16de"
+  uri: "https://github.com/xuwei-k/shapeless-java-records.git#441d6ad4753284a682fc55448bc1df827d8f7536"
 
   extra.options: ["--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions"]
 }

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#3e83aabd8e4e8eeaca673eb0bdd56d149806f527"
+  uri: "https://github.com/fthomas/singleton-ops.git#27e1bcb7afb69c9e2be378e959b830d93063e195"
 
   extra.projects: ["singleton_opsJVM"]
 }

--- a/proj/verify.conf
+++ b/proj/verify.conf
@@ -2,7 +2,7 @@
 
 vars.proj.verify: ${vars.base} {
   name: "verify"
-  uri: "https://github.com/scala/nanotest-strawman.git#0e5e83da3481e5dc58940518aa99ca108186e968"
+  uri: "https://github.com/scala/nanotest-strawman.git#5f07600f83aa5613abbd25167a171b4547625b08"
 
   extra.projects: ["verifyJVM"]
 }


### PR DESCRIPTION
and fork scala-debugger, which vanished

https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7111/