### PR TITLE
2.12: sbt 1.6.0-RC2 (was RC1)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -50,7 +50,7 @@ vars {
   sbt-1-3-version: "1.3.13"
   sbt-1-4-version: "1.4.9"
   sbt-1-5-version: "1.5.7"
-  sbt-version: "1.6.0-RC1"
+  sbt-version: "1.6.0-RC2"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/proj/paradox.conf
+++ b/proj/paradox.conf
@@ -1,10 +1,11 @@
-// https://github.com/lightbend/paradox.git#949d45c4ff393a61645bf74f2ad457089e9e7df1  # master
+// https://github.com/scalacommunitybuild/paradox.git#community-build-2.12  # was lightbend, master
 
-// frozen at a known-green commit sometime before a ScalaTest 3.1 upgrade
+// frozen at a known-green commit (949d45c4) from before a ScalaTest 3.1 upgrade;
+// then forked (December 2021) to tweak it to work with sbt 1.6
 
 vars.proj.paradox: ${vars.base} {
   name: "paradox"
-  uri: "https://github.com/lightbend/paradox.git#949d45c4ff393a61645bf74f2ad457089e9e7df1"
+  uri: "https://github.com/scalacommunitybuild/paradox.git#8d868d518df417255e35d97917d8fb19e1b5d4bb"
 
   extra.exclude: ["plugin", "themePlugin", "genericTheme"]
   check-missing: false  // ignore missing scripted-sbt


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7114/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7117/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7119/