### PR TITLE
2.13: sbt 1.6.0-RC2 (was RC1)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -29,7 +29,7 @@ include file("resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "1.6.0-RC1"
+  sbt-version: "1.6.0-RC2"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3405/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3406/