### PR TITLE
Akka: re-enable CoordinatedShutdownSpec

### DIFF
--- a/proj/akka.conf
+++ b/proj/akka.conf
@@ -2,7 +2,7 @@
 
 vars.proj.akka: ${vars.base} {
   name: "akka"
-  uri: "https://github.com/akka/akka.git#799255ef6c8b430bbc8c05b12b87b3fdd56e08d7"
+  uri: "https://github.com/akka/akka.git#9b97614b959a37dbffb3b4579b258d3e0d2e7055"
 
   extra.projects: ["akka-scala-nightly"]
   extra.exclude: [
@@ -26,8 +26,7 @@ vars.proj.akka: ${vars.base} {
     "removeScalacOptions -Wconf:cat=unused-nowarn:s,any:e"
     // prone to intermittent failure
     // ForkJoinPoolStarvationSpec (fails on JDK 13 only, I think?) reported upstream: https://github.com/akka/akka/issues/28505
-    // CoordinatedShutdownSpec (fails on JDK 17) reported upstream: https://github.com/akka/akka/issues/30339
-    """set actorTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "BackoffSupervisorSpec.scala" || "MetricsBasedResizerSpec.scala" || "EventStreamSpec.scala" || "ForkJoinPoolStarvationSpec.scala" || "CoordinatedShutdownSpec.scala" || "ConfigSpec.scala""""
+    """set actorTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "BackoffSupervisorSpec.scala" || "MetricsBasedResizerSpec.scala" || "EventStreamSpec.scala" || "ForkJoinPoolStarvationSpec.scala" || "ConfigSpec.scala""""
     """set testkit / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CoronerSpec.scala""""
     // intermittent failure (and, TcpSpec consistently fails on JDK 14, and TcpHelper depends on it)
     // DeprecatedTlsSpec: started failing every time on JDK 8 only?!

--- a/report.sc
+++ b/report.sc
@@ -47,6 +47,7 @@ object SuccessReport:
   )
 
   val jdk17Failures = Set[String](
+    "akka", // needs newer sbt-osgi; not sure about status w/r/t JEP 403
     "akka-http", // runs afoul of JEP 403
     "classutil", // runs afoul of JEP 403
     "finagle", // Unrecognized VM option 'AggressiveOpts'

--- a/report.sc
+++ b/report.sc
@@ -47,7 +47,6 @@ object SuccessReport:
   )
 
   val jdk17Failures = Set[String](
-    "akka", // runs afoul of JEP 403 (https://github.com/akka/akka/issues/30341); also needs newer sbt-osgi?
     "akka-http", // runs afoul of JEP 403
     "classutil", // runs afoul of JEP 403
     "finagle", // Unrecognized VM option 'AggressiveOpts'


### PR DESCRIPTION
JDK 11 https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3464/ queued

JDK 17 https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/414/ queued