### PR TITLE
2.13: advance project SHAs (and move to scala-cli 0.1.0)

### DIFF
--- a/core/scalafix.conf
+++ b/core/scalafix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#1981d2a86570aab9b08f3dc38e3f6df9d86d2d3a"
+  uri: "https://github.com/scalacenter/scalafix.git#0f41fde9c4a00b388ec5f1e569dda76329b6aa8c"
 
   extra.exclude: [
     // out of scope

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -8,7 +8,7 @@
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalacommunitybuild/scalameta.git#99db6d5710bc9e36c9800ff4e64658ca051cb94c"
+  uri: "https://github.com/scalacommunitybuild/scalameta.git#3c9e08c2a4daf265c5510a52547860a1fd6834ef"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/core/silencer.conf
+++ b/core/silencer.conf
@@ -2,6 +2,6 @@
 
 vars.proj.silencer: ${vars.base} {
   name: "silencer"
-  uri: "https://github.com/ghik/silencer.git#c980440f9eba7c7272c65c6a34448ab1be207227"
+  uri: "https://github.com/ghik/silencer.git#0a920508164ed63fd06f3adfff78a3eae13eef29"
 
 }

--- a/core/wartremover.conf
+++ b/core/wartremover.conf
@@ -2,7 +2,7 @@
 
 vars.proj.wartremover: ${vars.base} {
   name: "wartremover"
-  uri: "https://github.com/wartremover/wartremover.git#92df10fd34607d78063d5473760833c2538f6508"
+  uri: "https://github.com/wartremover/wartremover.git#e63069b80054f635c99a904e969a785d96715fb3"
 
   extra.exclude: [
     "sbt-plugin"

--- a/proj/advxml.conf
+++ b/proj/advxml.conf
@@ -2,6 +2,6 @@
 
 vars.proj.advxml: ${vars.base} {
   name: "advxml"
-  uri: "https://github.com/geirolz/advxml.git#478ff45d737384d526ee2e364e4e05b9fecbc505"
+  uri: "https://github.com/geirolz/advxml.git#285c07a3fa26b5677e66e7f68b32ad0279bb1151"
 
 }

--- a/proj/airframe.conf
+++ b/proj/airframe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.airframe: ${vars.base} {
   name: "airframe"
-  uri: "https://github.com/wvlet/airframe.git#c252839da83dd11d837501ee00e36ac996e41ce6"
+  uri: "https://github.com/wvlet/airframe.git#0734f2da13e909434338245ef94bead4f6e49752"
 
   extra.projects: ["communityBuild"]  // no Scala.js plz
   extra.commands: ${vars.default-commands} [

--- a/proj/akka-http-cors.conf
+++ b/proj/akka-http-cors.conf
@@ -4,7 +4,7 @@
 
 vars.proj.akka-http-cors: ${vars.base} {
   name: "akka-http-cors"
-  uri: "https://github.com/lomigmegard/akka-http-cors.git#a4327a87da2a828024e9c7be25888ee64bba2d3f"
+  uri: "https://github.com/lomigmegard/akka-http-cors.git#d968ec252a2f747153845de59aab153f47a3b55e"
 
   extra.options: ["-Dakka.fail-mixed-versions=false"]
   extra.projects: ["akka-http-cors"]

--- a/proj/akka-http-json.conf
+++ b/proj/akka-http-json.conf
@@ -5,7 +5,7 @@
 
 vars.proj.akka-http-json: ${vars.base} {
   name: "akka-http-json"
-  uri: "https://github.com/hseeberger/akka-http-json.git#72e4e7c2da9bfdfdceff086c5a006a8f4bf4cecf"
+  uri: "https://github.com/hseeberger/akka-http-json.git#d056afb58fe6b5f365a1d986c6363e0e023f9d03"
 
   // we might try to re-enable this when we have newer akka-http; right now
   // the tests don't compile and it looks like an akka-http version problem

--- a/proj/akka-http.conf
+++ b/proj/akka-http.conf
@@ -2,7 +2,7 @@
 
 vars.proj.akka-http: ${vars.base} {
   name: "akka-http"
-  uri: "https://github.com/akka/akka-http.git#e8c35c2bb2e201d095523581f1cee8c62c93af8f"
+  uri: "https://github.com/akka/akka-http.git#70ac853eb43e5a97e5b586820b60e88fd21cd563"
 
   extra.exclude: ["docs", "akka-http-bench-jmh"]
   extra.options: [

--- a/proj/akka-management.conf
+++ b/proj/akka-management.conf
@@ -2,7 +2,7 @@
 
 vars.proj.akka-management: ${vars.base} {
   name: "akka-management"
-  uri: "https://github.com/akka/akka-management.git#b806bbfc39358f9933d1271e9b30454e6053a024"
+  uri: "https://github.com/akka/akka-management.git#b5aeaa19df864f26a6fa05aa0fc721ace2c65c4c"
 
   // for now anyway, ambition level is just to include anything lagom needs
   extra.projects: ["akka-management", "cluster-bootstrap", "cluster-http"]

--- a/proj/akka-persistence-jdbc.conf
+++ b/proj/akka-persistence-jdbc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.akka-persistence-jdbc: ${vars.base} {
   name: "akka-persistence-jdbc"
-  uri: "https://github.com/akka/akka-persistence-jdbc.git#43282e545c9cd77b47decd955ec7c43c68f641e0"
+  uri: "https://github.com/akka/akka-persistence-jdbc.git#b3347f0c8aa6c9cb9ae2ab1e245e534dd6517272"
 
   // it isn't clear to me that there are any tests we can run without
   // doing the Docker stuff in their test.sh script.  we might ask the

--- a/proj/alpakka-kafka.conf
+++ b/proj/alpakka-kafka.conf
@@ -2,7 +2,7 @@
 
 vars.proj.alpakka-kafka: ${vars.base} {
   name: "alpakka-kafka"
-  uri: "https://github.com/akka/alpakka-kafka.git#afc84ee058b970f843c45fea3052c3b95acffaaa"
+  uri: "https://github.com/akka/alpakka-kafka.git#aad6a1ccbd4f549b3053988c85cbbe9b11d51542"
 
   extra.exclude: [
     // out of scope

--- a/proj/better-tostring.conf
+++ b/proj/better-tostring.conf
@@ -2,6 +2,6 @@
 
 vars.proj.better-tostring: ${vars.base} {
   name: "better-tostring"
-  uri: "https://github.com/polyvariant/better-tostring.git#44bff39c0823733bb66e2b808289b002edf9d520"
+  uri: "https://github.com/polyvariant/better-tostring.git#e233a879f64602cbc39775e6731dfa233b9dc4ba"
 
 }

--- a/proj/bijection.conf
+++ b/proj/bijection.conf
@@ -2,7 +2,7 @@
 
 vars.proj.bijection: ${vars.base} {
   name: "bijection"
-  uri: "https://github.com/twitter/bijection.git#59c3c28cccefa7bd7df136bee1d304972b0b557e"
+  uri: "https://github.com/twitter/bijection.git#63c87e5a70e5ca54999f326dd162a848ebdcc9c0"
 
   // at the moment let's just do the part scalafix needs. there are a bunch
   // of integration modules, but my hunch is they are likelier to cause

--- a/proj/blaze.conf
+++ b/proj/blaze.conf
@@ -2,7 +2,7 @@
 
 vars.proj.blaze: ${vars.base} {
   name: "blaze"
-  uri: "https://github.com/http4s/blaze.git#8c14988474a7c358afe545f8ac3908870d4a3de4"
+  uri: "https://github.com/http4s/blaze.git#14f4bce1260066b1e33294e8422a49bcf2e84d22"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/breeze.conf
+++ b/proj/breeze.conf
@@ -2,7 +2,7 @@
 
 vars.proj.breeze: ${vars.base} {
   name: "breeze"
-  uri: "https://github.com/scalanlp/breeze.git#7852a3488e9aa48e87d6cf0b53ac03c5154d5b4a"
+  uri: "https://github.com/scalanlp/breeze.git#666a312dc69c6146638ed3b1d6d818029ce3ce32"
 
   extra.exclude: ["benchmark"]
   // compilation is slow, maybe more heap would help?

--- a/proj/cachecontrol.conf
+++ b/proj/cachecontrol.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cachecontrol: ${vars.base} {
   name: "cachecontrol"
-  uri: "https://github.com/playframework/cachecontrol.git#7d94dffda7384c830d78d14d816c4c8d960a7351"
+  uri: "https://github.com/playframework/cachecontrol.git#355f1bc51eec415c06d4c99ab744260397ba7d60"
 
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!

--- a/proj/case-app.conf
+++ b/proj/case-app.conf
@@ -2,7 +2,7 @@
 
 vars.proj.case-app: ${vars.base} {
   name: "case-app"
-  uri: "https://github.com/alexarchambault/case-app.git#81ae633d1ebde4b00d84627db677536370d6e35b"
+  uri: "https://github.com/alexarchambault/case-app.git#d1d62b537dbc9dc71b0e37806a53862b42a6e31e"
 
   // this is enough for scalafix, I didn't even try adding the rest
   extra.projects: ["coreJVM"]

--- a/proj/cats-effect-testing.conf
+++ b/proj/cats-effect-testing.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect-testing: ${vars.base} {
   name: "cats-effect-testing"
-  uri: "https://github.com/djspiewak/cats-effect-testing.git#f38959bef87a335b15ef5171bfe4582d13d33133"
+  uri: "https://github.com/djspiewak/cats-effect-testing.git#8fde67d2c34c10ce49ed77141b857f301b5394ce"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/cats-effect.conf
+++ b/proj/cats-effect.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-effect: ${vars.base} {
   name: "cats-effect"
-  uri: "https://github.com/typelevel/cats-effect.git#614e98982602263d1447f3a9975be84bb4c23a67"
+  uri: "https://github.com/typelevel/cats-effect.git#1df408d34ab1f7e254c73a39036a720475554195"
 
   extra.exclude: ["*JS", "benchmarks", "docs"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-parse.conf
+++ b/proj/cats-parse.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-parse: ${vars.base} {
   name: "cats-parse"
-  uri: "https://github.com/typelevel/cats-parse.git#c8b5519e3589448c0d7f7d20a4af209761f1b556"
+  uri: "https://github.com/typelevel/cats-parse.git#828ff4bdab6146a8a9b1d85e8daf0ae222a0e29b"
 
   extra.exclude: ["bench", "docs", "*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/cats-time.conf
+++ b/proj/cats-time.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats-time: ${vars.base} {
   name: "cats-time"
-  uri: "https://github.com/ChristopherDavenport/cats-time.git#926e9afedf6a368e78831ba1520d5903615de223"
+  uri: "https://github.com/ChristopherDavenport/cats-time.git#1c50a3709b134f47c2d18c96b3d61bbff949caf4"
 
   extra.exclude: ["*JS", "docs"]
 }

--- a/proj/cats.conf
+++ b/proj/cats.conf
@@ -2,7 +2,7 @@
 
 vars.proj.cats: ${vars.base} {
   name: "cats"
-  uri: "https://github.com/typelevel/cats.git#7ce35f50ced2ceb5747ec643333e38f0af866c1e"
+  uri: "https://github.com/typelevel/cats.git#9ab4a6e00737d074339e0b2c124c832aebc47c88"
 
   extra.exclude: ["bench", "docs", "*JS", "*Native", "js", "binCompatTest", "native", "cats"]
   // tests are memory-hungry. hard to tell if occasional OutOfMemoryErrors are because

--- a/proj/circe-config.conf
+++ b/proj/circe-config.conf
@@ -2,6 +2,6 @@
 
 vars.proj.circe-config: ${vars.base} {
   name: "circe-config"
-  uri: "https://github.com/circe/circe-config.git#a45d03ff455d6d6a1c4b59cb32869760ad0cdc4f"
+  uri: "https://github.com/circe/circe-config.git#c3b2fae39ee2721ab4bbcb1f0c149d88e00c4863"
 
 }

--- a/proj/circe-generic-extras.conf
+++ b/proj/circe-generic-extras.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-generic-extras: ${vars.base} {
   name: "circe-generic-extras"
-  uri: "https://github.com/circe/circe-generic-extras.git#50402a8560a3982c801d0e13a9cccaa58703ab2f"
+  uri: "https://github.com/circe/circe-generic-extras.git#577e58c57dbf2abab1fd9e94886f42fac07e646b"
 
   extra.projects: ["genericExtras"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/circe-jackson.conf
+++ b/proj/circe-jackson.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe-jackson: ${vars.base} {
   name: "circe-jackson"
-  uri: "https://github.com/circe/circe-jackson.git#0fc69cedc6ab59220eb515e9281b6ceb8358f180"
+  uri: "https://github.com/circe/circe-jackson.git#7bf0a6fe3b92f1b67c3bb581e0645c1bd9e309af"
 
   // there are some others, but leaving it at this for now
   extra.projects: ["jackson28"]

--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -1,8 +1,11 @@
-// https://github.com/circe/circe.git#main
+// https://github.com/circe/circe.git#2ab4fec4906f0b090af2c9016fda88ac55706200  # was main
+
+// frozen (January 2022) until
+// https://github.com/circe/circe/issues/1912 is addressed
 
 vars.proj.circe: ${vars.base} {
   name: "circe"
-  uri: "https://github.com/circe/circe.git#827794b2ce4c73eae8cdc57386a2e98f2bfe7ed6"
+  uri: "https://github.com/circe/circe.git#2ab4fec4906f0b090af2c9016fda88ac55706200"
 
   extra.exclude: ["*JS", "benchmark*", "scalajs*", "docs"]
 }

--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -2,7 +2,7 @@
 
 vars.proj.circe: ${vars.base} {
   name: "circe"
-  uri: "https://github.com/circe/circe.git#2ab4fec4906f0b090af2c9016fda88ac55706200"
+  uri: "https://github.com/circe/circe.git#827794b2ce4c73eae8cdc57386a2e98f2bfe7ed6"
 
   extra.exclude: ["*JS", "benchmark*", "scalajs*", "docs"]
 }

--- a/proj/ciris.conf
+++ b/proj/ciris.conf
@@ -2,7 +2,7 @@
 
 vars.proj.ciris: ${vars.base} {
   name: "ciris"
-  uri: "https://github.com/vlovgr/ciris.git#ac346953c5d6e10d1a63d8b4661064577a3ed02a"
+  uri: "https://github.com/vlovgr/ciris.git#449f637c09140a392e9c8b5c55db4a7d9b1cf4f1"
 
   extra.exclude: ["docs"]
 }

--- a/proj/discipline-specs2.conf
+++ b/proj/discipline-specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline-specs2: ${vars.base} {
   name: "discipline-specs2"
-  uri: "https://github.com/typelevel/discipline-specs2.git#6f4ae432112cc2add63e491d72a5065061d823f8"
+  uri: "https://github.com/typelevel/discipline-specs2.git#e689c3e809a89a03cdbbb3a1771e33148715f6c7"
 
   extra.exclude: ["*JS", "docs"]
   extra.commands: ${vars.default-commands} [

--- a/proj/discipline.conf
+++ b/proj/discipline.conf
@@ -2,7 +2,7 @@
 
 vars.proj.discipline: ${vars.base} {
   name: "discipline"
-  uri: "https://github.com/typelevel/discipline.git#8d0bfc0bb485d5ce48a3709a20a860f15d850285"
+  uri: "https://github.com/typelevel/discipline.git#afd00132678985341db210b56f3b2ead1a8405c2"
 
   extra.projects: ["coreJVM"]  // no Scala.js please
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/doobie.conf
+++ b/proj/doobie.conf
@@ -2,7 +2,7 @@
 
 vars.proj.doobie: ${vars.base} {
   name: "doobie"
-  uri: "https://github.com/tpolecat/doobie.git#1c929ed645d56b034381598dfb132b317a1b8970"
+  uri: "https://github.com/tpolecat/doobie.git#dbc93d98a4eca412ba9daa697d5db292ed14f434"
 
   extra.options: ["-Xss16m"]  // prevent stack overflow when compiling build definition
   extra.exclude: [

--- a/proj/doodle.conf
+++ b/proj/doodle.conf
@@ -2,7 +2,7 @@
 
 vars.proj.doodle: ${vars.base} {
   name: "doodle"
-  uri: "https://github.com/underscoreio/doodle.git#8d3fc625d5bd35511cd2e061234376676934fe04"
+  uri: "https://github.com/underscoreio/doodle.git#0d955d275db1b848a24063166049f9ffaa0db609"
 
   extra.exclude: ["*JS", "docs"]
   extra.commands: ${vars.default-commands} [

--- a/proj/droste.conf
+++ b/proj/droste.conf
@@ -2,7 +2,7 @@
 
 vars.proj.droste: ${vars.base} {
   name: "droste"
-  uri: "https://github.com/higherkindness/droste.git#a939c0dc6fc374b45ea074857904f129fde2a44f"
+  uri: "https://github.com/higherkindness/droste.git#918490412b4f3d10888d6afbb585c590714c5b72"
 
   extra.exclude: [
     // out of scope

--- a/proj/eff.conf
+++ b/proj/eff.conf
@@ -2,7 +2,7 @@
 
 vars.proj.eff: ${vars.base} {
   name: "eff"
-  uri: "https://github.com/atnos-org/eff.git#6ee351dffd3efbc4908737934d49cf33014eddd1"
+  uri: "https://github.com/atnos-org/eff.git#8010d9fe3ce6c5b2ad8590762b92f13a03e29d02"
 
   extra.exclude: ["scalazJVM", "*JS", "*Native"]
 }

--- a/proj/fast-string-interpolator.conf
+++ b/proj/fast-string-interpolator.conf
@@ -2,7 +2,7 @@
 
 vars.proj.fast-string-interpolator: ${vars.base} {
   name: "fast-string-interpolator"
-  uri: "https://github.com/plokhotnyuk/fast-string-interpolator.git#9950805e85da20dd930531a39164198c6a27eba9"
+  uri: "https://github.com/plokhotnyuk/fast-string-interpolator.git#d122024bacab20852273c4b671283cc6fb543766"
 
   // Missing dependency: com.dongxiguo#fastring. likely out of scope anyway
   extra.exclude: ["fsi-benchmark", "fsi-benchmark-core"]

--- a/proj/fetch.conf
+++ b/proj/fetch.conf
@@ -2,7 +2,7 @@
 
 vars.proj.fetch: ${vars.base} {
   name: "fetch"
-  uri: "https://github.com/47degrees/fetch.git#a53b32c577a8b72ec04c42ceee46486adbf861c2"
+  uri: "https://github.com/47degrees/fetch.git#7d304ee3864ab68fefa507111f0b452e05e24d01"
 
   extra.exclude: ["documentation", "microsite", "*JS"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/giter8.conf
+++ b/proj/giter8.conf
@@ -2,7 +2,7 @@
 
 vars.proj.giter8: ${vars.base} {
   name: "giter8"
-  uri: "https://github.com/foundweekends/giter8.git#2497b466790726eeb7d3cb25b4aa800bc2c1655b"
+  uri: "https://github.com/foundweekends/giter8.git#e731128b1f3e4c938d9fb984e4f5dc56f23ee069"
 
   extra.exclude: [
     // these are sbt plugins

--- a/proj/github4s.conf
+++ b/proj/github4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.github4s: ${vars.base} {
   name: "github4s"
-  uri: "https://github.com/47deg/github4s.git#7829ac22b86848cb3b003fb8e0c74a7e8e679884"
+  uri: "https://github.com/47deg/github4s.git#0b86f46ff72ae073872692b87a8874c4320b0697"
 
   extra.projects: ["github4s"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/http4s.conf
+++ b/proj/http4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.http4s: ${vars.base} {
   name: "http4s"
-  uri: "https://github.com/http4s/http4s.git#6a790397f9f6db71f6496d3dac8d46daafc18d42"
+  uri: "https://github.com/http4s/http4s.git#fc0a18dd0a8091f0b2cdc87b58953e76efa47426"
 
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/ip4s.conf
+++ b/proj/ip4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.ip4s: ${vars.base} {
   name: "ip4s"
-  uri: "https://github.com/Comcast/ip4s.git#3a88ca7bab903488a53a9f1b672565fafb068122"
+  uri: "https://github.com/Comcast/ip4s.git#892d0305d89326d88fabe96dcb6b046c3571859a"
 
   extra.exclude: ["*JS"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/jawn-fs2.conf
+++ b/proj/jawn-fs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jawn-fs2: ${vars.base} {
   name: "jawn-fs2"
-  uri: "https://github.com/typelevel/jawn-fs2.git#4d1372fc15ec875026a05effb92ded2610c55ae4"
+  uri: "https://github.com/typelevel/jawn-fs2.git#614ef67249f9d34d4bf7172174d00ca22cb94287"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/jawn.conf
+++ b/proj/jawn.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jawn: ${vars.base} {
   name: "jawn"
-  uri: "https://github.com/typelevel/jawn.git#1c55ba787cbec65f7c90474ac46eea3b896069b1"
+  uri: "https://github.com/typelevel/jawn.git#804088bfe4c75db1106d82555749981a8494e9a0"
 
   extra.exclude: ["*JS", "*Native", "benchmark", "root"]
 }

--- a/proj/jawn.conf
+++ b/proj/jawn.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jawn: ${vars.base} {
   name: "jawn"
-  uri: "https://github.com/typelevel/jawn.git#804088bfe4c75db1106d82555749981a8494e9a0"
+  uri: "https://github.com/typelevel/jawn.git#1c55ba787cbec65f7c90474ac46eea3b896069b1"
 
   extra.exclude: ["*JS", "*Native", "benchmark", "root"]
 }

--- a/proj/json4s.conf
+++ b/proj/json4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.json4s: ${vars.base} {
   name: "json4s"
-  uri: "https://github.com/json4s/json4s.git#628a34adc26e1dbac1cc40620fbd3579cbae90d6"
+  uri: "https://github.com/json4s/json4s.git#8d03ac5e7a94f632cb4dbef96b445b7ffc1ae0bf"
 
   extra.exclude: ["*JS", "*Native"]
   extra.commands: ${vars.default-commands} [

--- a/proj/jsoniter-scala.conf
+++ b/proj/jsoniter-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.jsoniter-scala: ${vars.base} {
   name: "jsoniter-scala"
-  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#005e85f2cd074c285e9b80e51fbde669fbcba52b"
+  uri: "https://github.com/plokhotnyuk/jsoniter-scala.git#59b7aabf5b161519712177da9c895ac99cba4ad6"
 
   extra.exclude: ["*JS", "*benchmark*"]
 }

--- a/proj/kamon.conf
+++ b/proj/kamon.conf
@@ -2,7 +2,7 @@
 
 vars.proj.kamon: ${vars.base} {
   name: "kamon"
-  uri: "https://github.com/kamon-io/Kamon.git#d8a57912fe9a6a56c6b589311caec9554148dcec"
+  uri: "https://github.com/kamon-io/Kamon.git#2235b79def2f3ed97c7f282fa2b90a9d0d5c4b0c"
 
   // just what lila-ws needs, for now anyway
   extra.projects: ["kamon-core", "kamon-influxdb", "kamon-system-metrics"]

--- a/proj/kittens.conf
+++ b/proj/kittens.conf
@@ -2,7 +2,7 @@
 
 vars.proj.kittens: ${vars.base} {
   name: "kittens"
-  uri: "https://github.com/typelevel/kittens.git#0db7d4934a8e9fe1f856e76fac0a9fe506357974"
+  uri: "https://github.com/typelevel/kittens.git#70e0073af6c91f0baa1e8df0174f9fdc2115c850"
 
   extra.projects: ["coreJVM"]  // sorry, Scala.js
 }

--- a/proj/lightbend-emoji.conf
+++ b/proj/lightbend-emoji.conf
@@ -2,7 +2,7 @@
 
 vars.proj.lightbend-emoji: ${vars.base} {
   name: "lightbend-emoji"
-  uri: "https://github.com/lightbend/lightbend-emoji.git#f417f563913c7aacf54b6d5375853c6ab92f7fe7"
+  uri: "https://github.com/lightbend/lightbend-emoji.git#f4a64590f4dd739cd0e2ec46d13f65d4723891e7"
 
   extra.options: ["-Dsbt.sbtbintray=false"]
 }

--- a/proj/lila-ws.conf
+++ b/proj/lila-ws.conf
@@ -2,6 +2,6 @@
 
 vars.proj.lila-ws: ${vars.base} {
   name: "lila-ws"
-  uri: "https://github.com/ornicar/lila-ws.git#7186881f9a8ea5f740200e23e8b319f0e2653c5a"
+  uri: "https://github.com/ornicar/lila-ws.git#f263951b37de472b44365a7c6dc2089d91019c2f"
 
 }

--- a/proj/log4cats.conf
+++ b/proj/log4cats.conf
@@ -2,7 +2,7 @@
 
 vars.proj.log4cats: ${vars.base} {
   name: "log4cats"
-  uri: "https://github.com/ChristopherDavenport/log4cats.git#9abc56df4734379bdff27a1d49001fea707312e9"
+  uri: "https://github.com/ChristopherDavenport/log4cats.git#96b316ae1ee0b5b2d6ff297f45e5c2ac0b8988b7"
 
   // for now, only adding the modules http4s needs
   extra.projects: ["coreJVM", "testingJVM", "slf4j"]

--- a/proj/log4s.conf
+++ b/proj/log4s.conf
@@ -2,7 +2,7 @@
 
 vars.proj.log4s: ${vars.base} {
   name: "log4s"
-  uri: "https://github.com/Log4s/log4s.git#ffd9939211b1d3809204fe92c27fac26bd2e6150"
+  uri: "https://github.com/Log4s/log4s.git#d3e926f132b5c519eb7695398fea4c225036f9ba"
 
   extra.exclude: ["*JS", "testingJS"]
 }

--- a/proj/macwire.conf
+++ b/proj/macwire.conf
@@ -2,7 +2,7 @@
 
 vars.proj.macwire: ${vars.base} {
   name: "macwire"
-  uri: "https://github.com/softwaremill/macwire.git#93e4fc8196523452da07b2e9dce33761ab18ba5f"
+  uri: "https://github.com/softwaremill/macwire.git#a32fe1526d45d6418f86cc6a689c9d4d969a5a0d"
 
   extra.exclude: ["*2_12", "*JS", "*3"]
 }

--- a/proj/magnolia.conf
+++ b/proj/magnolia.conf
@@ -2,7 +2,7 @@
 
 vars.proj.magnolia: ${vars.base} {
   name: "magnolia"
-  uri: "https://github.com/softwaremill/magnolia.git#450e44bd016c4416cd9c28212d68d90fc33d644e"
+  uri: "https://github.com/softwaremill/magnolia.git#59c0b8ac0a7bb76c9d1770d34ea876406ce18122"
 
   extra.exclude: ["*2_12", "*JS"]
 }

--- a/proj/mdoc.conf
+++ b/proj/mdoc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mdoc: ${vars.base} {
   name: "mdoc"
-  uri: "https://github.com/scalameta/mdoc.git#979b8f48b23a80519b7ffd3a3d343d9bfaa00d4b"
+  uri: "https://github.com/scalameta/mdoc.git#fea72d3c5111127660caafae22644c41ce3d5178"
 
   extra.exclude: [
     "js", "jsdocs", "docs", "unit", "plugin", "*JS"

--- a/proj/metaconfig.conf
+++ b/proj/metaconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.metaconfig: ${vars.base} {
   name: "metaconfig"
-  uri: "https://github.com/scalameta/metaconfig.git#5a5097aeb9c0a8231cfa620a02ce8d75de9d4142"
+  uri: "https://github.com/scalameta/metaconfig.git#3238d741cb12f972f35f7f55413ee8e7a720416b"
 
   extra.exclude: [
     "*JS", "*Native"

--- a/proj/metrics-scala.conf
+++ b/proj/metrics-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.metrics-scala: ${vars.base} {
   name: "metrics-scala"
-  uri: "https://github.com/erikvanoosten/metrics-scala.git#75a2d5b1489416acc2e716f5a234dcc657e2ba6d"
+  uri: "https://github.com/erikvanoosten/metrics-scala.git#61f958acb6b63367471784c791c21971144ff7f7"
 
   // our Akka version is 2.6; as of January 2020 there is only a
   // a metricsAkka25 project, no Akka26, but perhaps it will be source-compatible?

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mima: ${vars.base} {
   name: "mima"
-  uri: "https://github.com/lightbend/mima.git#ebabee13bb94543ee164cd7166231c3e88e69a7c"
+  uri: "https://github.com/lightbend/mima.git#2a95829d8c1d34e8e06282845f4952240170906d"
 
   extra.exclude: ["sbtplugin"]  // out of scope
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/mockito-scala.conf
+++ b/proj/mockito-scala.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mockito-scala: ${vars.base} {
   name: "mockito-scala"
-  uri: "https://github.com/mockito/mockito-scala.git#7593b214a0a52687b30f17bbe601cf2bbf708d36"
+  uri: "https://github.com/mockito/mockito-scala.git#46bdaab11968c4c4691e2cad9f40aaaab4c911fb"
 
   extra.exclude: ["scalaz"]
 }

--- a/proj/monocle.conf
+++ b/proj/monocle.conf
@@ -2,7 +2,7 @@
 
 vars.proj.monocle: ${vars.base} {
   name: "monocle"
-  uri: "https://github.com/julien-truffaut/Monocle.git#27867d844122d71b0aadc52a68d534b78ee09ce5"
+  uri: "https://github.com/julien-truffaut/Monocle.git#389657152cf6eb80c52513251d821f357adb915a"
 
   // try to enable more subprojects?
   extra.projects: ["coreJVM", "macrosJVM", "lawJVM", "genericJVM"]

--- a/proj/mouse.conf
+++ b/proj/mouse.conf
@@ -2,7 +2,7 @@
 
 vars.proj.mouse: ${vars.base} {
   name: "mouse"
-  uri: "https://github.com/typelevel/mouse.git#a383969f7468b4e1eca29fbe3d970b9a4f4b951d"
+  uri: "https://github.com/typelevel/mouse.git#de53c526089e90bdbe3aab936b5be23d36a80254"
 
   extra.projects: ["crossJVM"]  // no Scala.js please
 }

--- a/proj/munit-cats-effect.conf
+++ b/proj/munit-cats-effect.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit-cats-effect: ${vars.base} {
   name: "munit-cats-effect"
-  uri: "https://github.com/typelevel/munit-cats-effect.git#291bf8558cae801a5c3d375f47bc3b9458d5bab7"
+  uri: "https://github.com/typelevel/munit-cats-effect.git#248187bec8dc540e06950b7faf8d0e0be1ad31b1"
 
   extra.projects: ["ce2JVM"]  // we don't have Cats Effect 3 yet
   extra.exclude: ["*JS"]

--- a/proj/munit.conf
+++ b/proj/munit.conf
@@ -2,7 +2,7 @@
 
 vars.proj.munit: ${vars.base} {
   name: "munit"
-  uri: "https://github.com/scalameta/munit.git#dd5d392143c463d58c0d9ca06917169ec772d959"
+  uri: "https://github.com/scalameta/munit.git#9653a0eb383889b96acd1b773cee5f9a7d8252c3"
 
   extra.exclude: ["docs", "plugin", "*JS", "*Native"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/natchez.conf
+++ b/proj/natchez.conf
@@ -2,7 +2,7 @@
 
 vars.proj.natchez: ${vars.base} {
   name: "natchez"
-  uri: "https://github.com/tpolecat/natchez.git#18d7095b731d013fc2d76fbd0e0cd6fe7ff6d368"
+  uri: "https://github.com/tpolecat/natchez.git#6cc9b223e4be15a72b2bd9be7f362a5ff8f0d6b6"
 
   // let's try and squeak by with just the minimum, since our present goal is
   // just to get pfps-shopping-cart green

--- a/proj/nscala-time.conf
+++ b/proj/nscala-time.conf
@@ -2,6 +2,6 @@
 
 vars.proj.nscala-time: ${vars.base} {
   name: "nscala-time"
-  uri: "https://github.com/nscala-time/nscala-time.git#a90bc7ed91f5ca138c416880b6d7da4804c4593e"
+  uri: "https://github.com/nscala-time/nscala-time.git#251c8c95250299d2e6ba9c26ffbadf54e8cfca6e"
 
 }

--- a/proj/paiges.conf
+++ b/proj/paiges.conf
@@ -2,7 +2,7 @@
 
 vars.proj.paiges: ${vars.base} {
   name: "paiges"
-  uri: "https://github.com/typelevel/paiges.git#4f1b2541c1dac9f76a832e9d22948b2d73fc34bf"
+  uri: "https://github.com/typelevel/paiges.git#afafde7ccc7955a8dece03563705c6ed3cc7afc6"
 
   extra.projects: ["coreJVM", "catsJVM"]  // but not "benchmark"
   extra.commands: ${vars.default-commands} [

--- a/proj/parboiled.conf
+++ b/proj/parboiled.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled: ${vars.base} {
   name: "parboiled"
-  uri: "https://github.com/sirthias/parboiled.git#7158efbd7b151085591a848833d513fcd9c7aefb"
+  uri: "https://github.com/sirthias/parboiled.git#4446bdbe4afccf8904f7ec483f9302128bbd0b7e"
 
   extra.projects: ["parboiled-scala"]
   extra.commands: ${vars.default-commands} [

--- a/proj/parboiled2.conf
+++ b/proj/parboiled2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.parboiled2: ${vars.base} {
   name: "parboiled2"
-  uri: "https://github.com/sirthias/parboiled2.git#4e8d7dd83740c98c431d77d0c4e4ab7d012c3ad1"
+  uri: "https://github.com/sirthias/parboiled2.git#25bfe9fbdadb115658cf904b5709c2d98eac5d52"
 
   extra.projects: ["parboiledJVM", "examples"]
   extra.commands: ${vars.default-commands} [

--- a/proj/play-file-watch.conf
+++ b/proj/play-file-watch.conf
@@ -2,7 +2,7 @@
 
 vars.proj.play-file-watch: ${vars.base} {
   name: "play-file-watch"
-  uri: "https://github.com/playframework/play-file-watch.git#2c8dfc46bc9077b8bfcca2f1a5c5040f48b268ac"
+  uri: "https://github.com/playframework/play-file-watch.git#076671d60ebc5d3153488ca9d43a25ad6b25f73b"
 
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!

--- a/proj/play-json.conf
+++ b/proj/play-json.conf
@@ -2,7 +2,7 @@
 
 vars.proj.play-json: ${vars.base} {
   name: "play-json"
-  uri: "https://github.com/playframework/play-json.git#516655356f9055f151e36e8102f9d9a54c04b9be"
+  uri: "https://github.com/playframework/play-json.git#e97ecb9100c9eec7ba3445c78de283083d72408c"
 
   extra.projects: ["play-jsonJVM"]  // no Scala.js plz
 }

--- a/proj/play-ws.conf
+++ b/proj/play-ws.conf
@@ -2,7 +2,7 @@
 
 vars.proj.play-ws: ${vars.base} {
   name: "play-ws"
-  uri: "https://github.com/playframework/play-ws.git#91e4bf83436778961a6bb31d441f6e480cc816ab"
+  uri: "https://github.com/playframework/play-ws.git#f2fd36e87f92b8a373a76bdfb065c95145f3c1f4"
 
   // NullPointerException in CachingSpec
   // (https://github.com/scala/community-builds/issues/564)

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -1,8 +1,11 @@
-// https://github.com/playframework/playframework.git#master
+// https://github.com/playframework/playframework.git#ed266ca082ef33b36ab5d1d057fe3a8790160f15  # was main
+
+// frozen (Janary 2022) because a recent commit uses an Akka snapshot;
+// we should be able to unfreeze before very long
 
 vars.proj.playframework: ${vars.base} {
   name: "playframework"
-  uri: "https://github.com/playframework/playframework.git#47fea8d8feec6cffa7ec822f81ae0114c698003e"
+  uri: "https://github.com/playframework/playframework.git#ed266ca082ef33b36ab5d1d057fe3a8790160f15"
 
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin", "Sbt-Scripted-Tools"  // out of scope

--- a/proj/playframework.conf
+++ b/proj/playframework.conf
@@ -2,7 +2,7 @@
 
 vars.proj.playframework: ${vars.base} {
   name: "playframework"
-  uri: "https://github.com/playframework/playframework.git#05cb03ff1d8ed37c98f1968a1bd4b4dfcf3a6250"
+  uri: "https://github.com/playframework/playframework.git#47fea8d8feec6cffa7ec822f81ae0114c698003e"
 
   extra.exclude: [
     "Play-Docs", "Sbt-Plugin", "Play-Docs-Sbt-Plugin", "Sbt-Scripted-Tools"  // out of scope

--- a/proj/pureconfig.conf
+++ b/proj/pureconfig.conf
@@ -7,6 +7,6 @@ vars.proj.pureconfig: ${vars.base} {
   extra.exclude: ["scalaz", "docs"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.7""""
+    """ThisBuild / scalaVersion := "2.13.8""""
   ]
 }

--- a/proj/pureconfig.conf
+++ b/proj/pureconfig.conf
@@ -2,11 +2,11 @@
 
 vars.proj.pureconfig: ${vars.base} {
   name: "pureconfig"
-  uri: "https://github.com/pureconfig/pureconfig.git#358528b5f8ba4a7016aa127c299a8c767f26fbbd"
+  uri: "https://github.com/pureconfig/pureconfig.git#b60f7e870e48e2854e386a246a4f94ae3e15dee5"
 
   extra.exclude: ["scalaz", "docs"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.7""""
   ]
 }

--- a/proj/pureconfig.conf
+++ b/proj/pureconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.pureconfig: ${vars.base} {
   name: "pureconfig"
-  uri: "https://github.com/pureconfig/pureconfig.git#b60f7e870e48e2854e386a246a4f94ae3e15dee5"
+  uri: "https://github.com/pureconfig/pureconfig.git#358528b5f8ba4a7016aa127c299a8c767f26fbbd"
 
   extra.exclude: ["scalaz", "docs"]
   extra.settings: ${vars.base.extra.settings} [

--- a/proj/redis4cats.conf
+++ b/proj/redis4cats.conf
@@ -2,7 +2,7 @@
 
 vars.proj.redis4cats: ${vars.base} {
   name: "redis4cats"
-  uri: "https://github.com/profunktor/redis4cats.git#4b9fe7052399051f382466e00f3a358b36fe8b5e"
+  uri: "https://github.com/profunktor/redis4cats.git#3d55677f6ea2ee0942f87fc3185b8516c3176dcf"
 
   // just whatever pfps-shopping-cart needs
   extra.projects: ["redis4cats-core", "redis4cats-effects", "redis4cats-log4cats"]

--- a/proj/refined.conf
+++ b/proj/refined.conf
@@ -2,7 +2,7 @@
 
 vars.proj.refined: ${vars.base} {
   name: "refined"
-  uri: "https://github.com/fthomas/refined.git#4d628345b8f52b074a1c48f115df74afca49c1b1"
+  uri: "https://github.com/fthomas/refined.git#bae238392ecd46e10ba22b215fe994218b2c846a"
 
   extra.exclude: ["*JS", "benchmark", "docs"]
 }

--- a/proj/sbinary.conf
+++ b/proj/sbinary.conf
@@ -4,8 +4,4 @@ vars.proj.sbinary: ${vars.base} {
   name: "sbinary"
   uri: "https://github.com/sbt/sbinary.git#3fa46b6b012c28e3faf796abb4670be3c42293fd"
 
-  extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
-  extra.commands: ${vars.default-commands} [
-    "set every bintrayReleaseOnPublish := false"
-  ]
 }

--- a/proj/sbinary.conf
+++ b/proj/sbinary.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sbinary: ${vars.base} {
   name: "sbinary"
-  uri: "https://github.com/sbt/sbinary.git#cab149fe4d7046d75befd27e1190ce2ab90f39fc"
+  uri: "https://github.com/sbt/sbinary.git#3fa46b6b012c28e3faf796abb4670be3c42293fd"
 
   extra.options: ["-Dbintray.user=dummy", "-Dbintray.pass=dummy"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scaffeine.conf
+++ b/proj/scaffeine.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scaffeine: ${vars.base} {
   name: "scaffeine"
-  uri: "https://github.com/blemale/scaffeine.git#36e332b53c1d4fa9d358fb5a61b66f14946135e7"
+  uri: "https://github.com/blemale/scaffeine.git#7303ffb1a0294e61d8fb9ae099c84ec86d470557"
 
   extra.commands: ${vars.default-commands} [
     // otherwise build fails on JDK 11+

--- a/proj/scala-async.conf
+++ b/proj/scala-async.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-async: ${vars.base} {
   name: "scala-async"
-  uri: "https://github.com/scala/scala-async.git#900a6aaca7344aa7046ade795bcf11ca85fcced9"
+  uri: "https://github.com/scala/scala-async.git#0b3007060d991bd3f4c7bb5b686b65350fe5036c"
 
   extra.exclude: ["*JS", "root"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-compat.conf
+++ b/proj/scala-collection-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-compat: ${vars.base} {
   name: "scala-collection-compat"
-  uri: "https://github.com/scala/scala-collection-compat.git#c31d4a0142fb407f1d7e89f9385501baf103b6e5"
+  uri: "https://github.com/scala/scala-collection-compat.git#b39b4b64732d9dd5e0f065e4180f656237ac4444"
 
   extra.projects: ["compat213"]  // no Scala.js or Scalafix rules plz
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-contrib.conf
+++ b/proj/scala-collection-contrib.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-contrib: ${vars.base} {
   name: "scala-collection-contrib"
-  uri: "https://github.com/scala/scala-collection-contrib.git#fba8a2f62fda5de13d799c81e5b89acb0afd3d6e"
+  uri: "https://github.com/scala/scala-collection-contrib.git#898582289d5595bd8da8d394714992a9305e0f10"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-collection-laws.conf
+++ b/proj/scala-collection-laws.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-laws: ${vars.base} {
   name: "scala-collection-laws"
-  uri: "https://github.com/scala/scala-collection-laws.git#f42e47f8f46663f53142ab3b88bd722d5137bbec"
+  uri: "https://github.com/scala/scala-collection-laws.git#db30012890c7f408962378d21033b2c21227df19"
 
   // as per the repo readme
   extra.options: ["-XX:MaxMetaspaceSize=1G", "-Xmx6G"]

--- a/proj/scala-hedgehog.conf
+++ b/proj/scala-hedgehog.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-hedgehog: ${vars.base} {
   name: "scala-hedgehog"
-  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#01508a2299ed713865e02ca7f2db704bb4d5953a"
+  uri: "https://github.com/hedgehogqa/scala-hedgehog.git#5377c40bc867c5a4c659d8bba029eeca7b82b239"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-java8-compat.conf
+++ b/proj/scala-java8-compat.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-java8-compat: ${vars.base} {
   name: "scala-java8-compat"
-  uri: "https://github.com/scala/scala-java8-compat.git#cfe6278cd9a516d02f50059e638484e0399d45c1"
+  uri: "https://github.com/scala/scala-java8-compat.git#372fe5a1a0461767e40c6956b0d2d90d709af21a"
 
   // as per https://github.com/scala/scala-java8-compat/issues/160
   // genjavadoc is disabled except on JDK 8, but we don't want to

--- a/proj/scala-library-next.conf
+++ b/proj/scala-library-next.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-library-next: ${vars.base} {
   name: "scala-library-next"
-  uri: "https://github.com/scala/scala-library-next.git#bce554f49742a534aaa8b53faa544c2f037a68ff"
+  uri: "https://github.com/scala/scala-library-next.git#b950cc485c81cb7918e5b284d52690813122d174"
 
   extra.exclude: ["*JS"]
 }

--- a/proj/scala-logging.conf
+++ b/proj/scala-logging.conf
@@ -2,6 +2,6 @@
 
 vars.proj.scala-logging: ${vars.base} {
   name: "scala-logging"
-  uri: "https://github.com/lightbend/scala-logging.git#b0f79a6498a8c640d7f2abcb34ca3eddb94e72f7"
+  uri: "https://github.com/lightbend/scala-logging.git#3fb3dfd3bc0061ee5e0d62cbe37951dd83f9e900"
 
 }

--- a/proj/scala-parallel-collections.conf
+++ b/proj/scala-parallel-collections.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-parallel-collections: ${vars.base} {
   name: "scala-parallel-collections"
-  uri: "https://github.com/scala/scala-parallel-collections.git#23e089fe5b40403c2bf90494627689ee4a3c5c11"
+  uri: "https://github.com/scala/scala-parallel-collections.git#b26e74437f0cadc3c92e9378e69197f3494b1811"
 
   extra.commands: ${vars.default-commands} [
     "set every mimaPreviousArtifacts := Set()"

--- a/proj/scala-parser-combinators.conf
+++ b/proj/scala-parser-combinators.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-parser-combinators: ${vars.base} {
   name: "scala-parser-combinators"
-  uri: "https://github.com/scala/scala-parser-combinators.git#3bb17fada6bcd405dc6f91d22d9a31eeb53a20fb"
+  uri: "https://github.com/scala/scala-parser-combinators.git#f2f0b4f89e1fc0ffb67bbc3f93567b866880a01b"
 
   extra.exclude: ["*JS", "*Native"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scala-sculpt.conf
+++ b/proj/scala-sculpt.conf
@@ -2,6 +2,6 @@
 
 vars.proj.scala-sculpt: ${vars.base} {
   name: "scala-sculpt"
-  uri: "https://github.com/lightbend/scala-sculpt.git#f454679f5f224618b3fa23fca409e928180d9bc8"
+  uri: "https://github.com/lightbend/scala-sculpt.git#3529102217ca937674f0863aad307822e77f9f25"
 
 }

--- a/proj/scala-xml.conf
+++ b/proj/scala-xml.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-xml: ${vars.base} {
   name: "scala-xml"
-  uri: "https://github.com/scala/scala-xml.git#92f4d42f74a875f9f5f8ba1b347a0fafd2073cb1"
+  uri: "https://github.com/scala/scala-xml.git#302309d11c22c34e4182ddda8e15962d9f07747d"
 
   extra.projects: ["xml"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck-shapeless.conf
+++ b/proj/scalacheck-shapeless.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalacheck-shapeless: ${vars.base} {
   name: "scalacheck-shapeless"
-  uri: "https://github.com/alexarchambault/scalacheck-shapeless.git#b02eeb082fd2fbe329c585f0fda9ee570032dae6"
+  uri: "https://github.com/alexarchambault/scalacheck-shapeless.git#e2395167fbfbdcaa5826e7820060e04effe8a44d"
 
   extra.projects: ["*JVM"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scalacheck.conf
+++ b/proj/scalacheck.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalacheck: ${vars.base} {
   name: "scalacheck"
-  uri: "https://github.com/typelevel/scalacheck.git#01a3d2cd52fd15ba4cabce8ab5ad1757c1734aa5"
+  uri: "https://github.com/typelevel/scalacheck.git#ae799c7a204332216ee4ee30597a6f1d8197647a"
 
   extra.projects: ["jvm"]  // no Scala.js please
 }

--- a/proj/scalachess.conf
+++ b/proj/scalachess.conf
@@ -2,6 +2,6 @@
 
 vars.proj.scalachess: ${vars.base} {
   name: "scalachess"
-  uri: "https://github.com/ornicar/scalachess.git#c68b7071d47ae3fdca46effde197183d4aa5cb36"
+  uri: "https://github.com/ornicar/scalachess.git#4e850d701a26d4aefffb76da985c78b805d161aa"
 
 }

--- a/proj/scalafmt.conf
+++ b/proj/scalafmt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#a5ad0241e29a0fa2f4a74a52e9a66585046ed1e5"
+  uri: "https://github.com/scalameta/scalafmt.git#403289cdb086c4beb36684bc2b788e56b1c3e51e"
 
   extra.projects: ["coreJVM", "cli", "tests"]
   // not investigated. at first glance they look environment-dependent

--- a/proj/scalafx.conf
+++ b/proj/scalafx.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafx: ${vars.base} {
   name: "scalafx"
-  uri: "https://github.com/scalafx/scalafx.git#5b7fb90c06aeec70baa49c4826071dfbd98910b5"
+  uri: "https://github.com/scalafx/scalafx.git#36194509913f239f00bca5846588f04058545077"
 
   // tests fail on our Jenkins for lack of xfvb or equivalent;
   // see https://github.com/scala/community-build/pull/1174

--- a/proj/scalamock.conf
+++ b/proj/scalamock.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalamock: ${vars.base} {
   name: "scalamock"
-  uri: "https://github.com/paulbutcher/ScalaMock.git#ed2204dff176f031e04c7d94b81cadd9f72c7ebb"
+  uri: "https://github.com/paulbutcher/ScalaMock.git#cdc6897b69055b8322dd4458496b78e2fe0c2fac"
 
   extra.projects: ["scalamockJVM", "examples"]
 }

--- a/proj/scalapb.conf
+++ b/proj/scalapb.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalapb: ${vars.base} {
   name: "scalapb"
-  uri: "https://github.com/scalapb/ScalaPB.git#1e60b4235c5c243eeb3b85c68e3560032ec5c2d6"
+  uri: "https://github.com/scalapb/ScalaPB.git#11cddb6f5ac34ae977395ce7c730d24ea236c40a"
 
   // just what scalameta needs, for now
   extra.projects: ["runtimeJVM2_13"]

--- a/proj/scalaprops.conf
+++ b/proj/scalaprops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalaprops: ${vars.base} {
   name: "scalaprops"
-  uri: "https://github.com/scalaprops/scalaprops.git#ccf48411d228c01ca3b552fed3d4d9fa1ad9f07b"
+  uri: "https://github.com/scalaprops/scalaprops.git#44b7d476f1a1175355713101eb61985c2125ff86"
 
   extra.projects: ["scalapropsJVM"]  // no Scala.js please
 }

--- a/proj/scalikejdbc.conf
+++ b/proj/scalikejdbc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalikejdbc: ${vars.base} {
   name: "scalikejdbc"
-  uri: "https://github.com/scalikejdbc/scalikejdbc.git#e1541c9cf6b7d7785b536dc46163a15700c64f5e"
+  uri: "https://github.com/scalikejdbc/scalikejdbc.git#272f48f568eb5d1f14b66660e6213ac91bbaf17f"
 
   // don't build sbt plugin
   extra.exclude: ["mapper-generator"]

--- a/proj/sconfig.conf
+++ b/proj/sconfig.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sconfig: ${vars.base} {
   name: "sconfig"
-  uri: "https://github.com/ekrich/sconfig.git#d78e7c24a3a76f6cd6154702109e65b6c64a679f"
+  uri: "https://github.com/ekrich/sconfig.git#25a0e5f7e3bf9ef0351f1a851a568b84fabec506"
 
   extra.exclude: ["sconfigNative", "sconfigJS"]
 }

--- a/proj/scopt.conf
+++ b/proj/scopt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scopt: ${vars.base} {
   name: "scopt"
-  uri: "https://github.com/scopt/scopt.git#93ae6db7835da639c3b5612b6127d276a05765f1"
+  uri: "https://github.com/scopt/scopt.git#c8a8d103617ed08d1289e68a3b58e2eb8cc1d3af"
 
   extra.projects: ["scoptJVM"]
 }

--- a/proj/scoverage.conf
+++ b/proj/scoverage.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scoverage: ${vars.base} {
   name: "scoverage"
-  uri: "https://github.com/scoverage/scalac-scoverage-plugin.git#630e3c7d15d86c855fe12145294e819b75b3c202"
+  uri: "https://github.com/scoverage/scalac-scoverage-plugin.git#f32201baa588ef1581596c0da0930d8ec61739d9"
 
   extra.exclude: ["*JS"]
   extra.commands: ${vars.default-commands} [

--- a/proj/scrooge.conf
+++ b/proj/scrooge.conf
@@ -5,7 +5,7 @@
 
 vars.proj.scrooge: ${vars.base} {
   name: "scrooge"
-  uri: "https://github.com/twitter/scrooge.git#13f101ac0c5c11c785e73f7e2a3d4aad43654f83"
+  uri: "https://github.com/twitter/scrooge.git#9517d6662dcd879ec4265e52e57ca88a3861c4ee"
 
   extra.projects: ["scrooge-core"]
   extra.commands: ${vars.default-commands} [

--- a/proj/shapeless-java-records.conf
+++ b/proj/shapeless-java-records.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless-java-records: ${vars.base} {
   name: "shapeless-java-records"
-  uri: "https://github.com/xuwei-k/shapeless-java-records.git#8db4e836626ae5c26754b316a61a535a611ff552"
+  uri: "https://github.com/xuwei-k/shapeless-java-records.git#2ba429cf1ea5671ee14bf08d8d4deeb334c4b10c"
 
   extra.options: ["--enable-preview", "-XX:+IgnoreUnrecognizedVMOptions"]
 }

--- a/proj/shapeless.conf
+++ b/proj/shapeless.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless: ${vars.base} {
   name: "shapeless"
-  uri: "https://github.com/milessabin/shapeless.git#c64b3afbf9cad217683d6f7fef379bcf01d886aa"
+  uri: "https://github.com/milessabin/shapeless.git#f303b6e6a153d924b0b0a02cc114007d371c1f06"
 
   extra.projects: ["coreJVM"]
 }

--- a/proj/simulacrum-scalafix.conf
+++ b/proj/simulacrum-scalafix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.simulacrum-scalafix: ${vars.base} {
   name: "simulacrum-scalafix"
-  uri: "https://github.com/typelevel/simulacrum-scalafix.git#1e550eeb2d924722cc2e5b688cc1eab90d802aed"
+  uri: "https://github.com/typelevel/simulacrum-scalafix.git#d08513b9d1709ce7441c01dfcc184d33c03bd380"
 
   extra.exclude: ["*JS"]
 }

--- a/proj/singleton-ops.conf
+++ b/proj/singleton-ops.conf
@@ -2,7 +2,7 @@
 
 vars.proj.singleton-ops: ${vars.base} {
   name: "singleton-ops"
-  uri: "https://github.com/fthomas/singleton-ops.git#2e9a840a2159ed2d0a3c5914c8af2610f5221e83"
+  uri: "https://github.com/fthomas/singleton-ops.git#bb7331ebfe1c4ca05d7a2e1087f12b222530aeeb"
 
   extra.projects: ["singleton_opsJVM"]
 }

--- a/proj/skunk.conf
+++ b/proj/skunk.conf
@@ -2,7 +2,7 @@
 
 vars.proj.skunk: ${vars.base} {
   name: "skunk"
-  uri: "https://github.com/tpolecat/skunk.git#708497e3ae99f5f0a39733ed295b5fec4f384b79"
+  uri: "https://github.com/tpolecat/skunk.git#5d08b445220329aea86a5dad894675e2dee4c724"
 
   extra.exclude: [
     "docs"  // out of scope

--- a/proj/slick.conf
+++ b/proj/slick.conf
@@ -2,7 +2,7 @@
 
 vars.proj.slick: ${vars.base} {
   name: "slick"
-  uri: "https://github.com/slick/slick.git#38e1a7aadd3a1dca2837cd6498ebbc0f335d3561"
+  uri: "https://github.com/slick/slick.git#3d4c928f8b1a3ab0e89c9b02b72ea8d983573bcf"
 
   extra.exclude: [
     // unless we exclude, it looks for an Ornate dependency here

--- a/proj/specs2.conf
+++ b/proj/specs2.conf
@@ -2,7 +2,7 @@
 
 vars.proj.specs2: ${vars.base} {
   name: "specs2"
-  uri: "https://github.com/etorreborre/specs2.git#a7666f37ee4dbbd6455c7c0c55e6baa411174f8b"
+  uri: "https://github.com/etorreborre/specs2.git#2772dacc84723c4635e193d0552d3dabe9716383"
 
   extra.exclude: ["*JS", "*Native", "scalaz*", "guide"]
 }

--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -1,4 +1,8 @@
-// https://github.com/typelevel/spire.git#main
+// https://github.com/typelevel/spire.git#435e9aff7f7a855933e4bc97f2c72b2c07949418  # was main
+
+// frozen (January 2022) because something changed that confuses
+// dbuild and makes it try to build with Scala 3 (?!). not investigated;
+// probably sbt-typelevel related?
 
 vars.proj.spire: ${vars.base} {
   name: "spire"

--- a/proj/squants.conf
+++ b/proj/squants.conf
@@ -2,7 +2,7 @@
 
 vars.proj.squants: ${vars.base} {
   name: "squants"
-  uri: "https://github.com/typelevel/squants.git#e8b871298d70a5976a3ef24be902c34c4350dce4"
+  uri: "https://github.com/typelevel/squants.git#dee7d0f749be649b6da5ee9cc8449ca4572336b2"
 
   extra.projects: ["squantsJVM"]
 }

--- a/proj/sttp-model.conf
+++ b/proj/sttp-model.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp-model: ${vars.base} {
   name: "sttp-model"
-  uri: "https://github.com/softwaremill/sttp-model.git#76555bd8b38e131e74a192654ab7925b622e7ec6"
+  uri: "https://github.com/softwaremill/sttp-model.git#d43a4837982c4d0962230aa200dbf213eb29ed2c"
 
   extra.projects: ["core"]
 }

--- a/proj/sttp-shared.conf
+++ b/proj/sttp-shared.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp-shared: ${vars.base} {
   name: "sttp-shared"
-  uri: "https://github.com/softwaremill/sttp-shared.git#7ff004be6596f06d6854c24bf238327a0f9c6e0e"
+  uri: "https://github.com/softwaremill/sttp-shared.git#a6ce637ab36015775d2df9755cc2162a13df74fb"
 
   extra.projects: [
     // needed by sttp's core

--- a/proj/sttp.conf
+++ b/proj/sttp.conf
@@ -2,7 +2,7 @@
 
 vars.proj.sttp: ${vars.base} {
   name: "sttp"
-  uri: "https://github.com/softwaremill/sttp.git#9dec1621f80f90b36ae4d2cbf565b31f32de0091"
+  uri: "https://github.com/softwaremill/sttp.git#781462e458eaf6c4c0a0a3a1c91c13056cb046db"
 
   extra.exclude: [
     "*JS", "*Native", "*2_11", "*2_12", "*3"

--- a/proj/twitter-util.conf
+++ b/proj/twitter-util.conf
@@ -2,7 +2,7 @@
 
 vars.proj.twitter-util: ${vars.base} {
   name: "twitter-util"
-  uri: "https://github.com/twitter/util.git#78e3aa30d065f5b29403fa49d47404b9d7a5945c"
+  uri: "https://github.com/twitter/util.git#62ddb5010885a1d244813bba089452ff01a1cf5e"
 
   extra.exclude: [
     // this isn't really necessary and would pull in a JMH dependency

--- a/proj/unfiltered.conf
+++ b/proj/unfiltered.conf
@@ -2,6 +2,6 @@
 
 vars.proj.unfiltered: ${vars.base} {
   name: "unfiltered"
-  uri: "https://github.com/unfiltered/unfiltered.git#e070636f6bf821891b94b4d919685e0af94e3486"
+  uri: "https://github.com/unfiltered/unfiltered.git#8483c3b1c2fb0b9babe2600ea91b8ca00b62ce08"
 
 }

--- a/proj/unique.conf
+++ b/proj/unique.conf
@@ -2,7 +2,7 @@
 
 vars.proj.unique: ${vars.base} {
   name: "unique"
-  uri: "https://github.com/ChristopherDavenport/unique.git#810b7466f9cc7abcbff6396db842eef2ee5bc5d3"
+  uri: "https://github.com/ChristopherDavenport/unique.git#6191dda68142951b52379827b09988e7b3edf9a8"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
   extra.commands: ${vars.default-commands} [

--- a/proj/vault.conf
+++ b/proj/vault.conf
@@ -2,7 +2,7 @@
 
 vars.proj.vault: ${vars.base} {
   name: "vault"
-  uri: "https://github.com/typelevel/vault.git#6f93a5728a313cd359cab143ea7444ad0b596e27"
+  uri: "https://github.com/typelevel/vault.git#2ca09579d9185f53c613ca3ad8076ad03038981e"
 
   extra.projects: ["coreJVM"]  // no docs, no Scala.js
   extra.commands: ${vars.default-commands} [

--- a/proj/verify.conf
+++ b/proj/verify.conf
@@ -2,7 +2,7 @@
 
 vars.proj.verify: ${vars.base} {
   name: "verify"
-  uri: "https://github.com/scala/nanotest-strawman.git#516198d4b27c671e0bdc2139a5c737ee04043879"
+  uri: "https://github.com/scala/nanotest-strawman.git#073921a373e05bcfdc863769f676089ab889a002"
 
   extra.projects: ["verifyJVM"]
 }

--- a/proj/weaver-test.conf
+++ b/proj/weaver-test.conf
@@ -2,7 +2,7 @@
 
 vars.proj.weaver-test: ${vars.base} {
   name: "weaver-test"
-  uri: "https://github.com/disneystreaming/weaver-test.git#fb71ca44ce8599baec5a7df6e25c2c0d54bafafd"
+  uri: "https://github.com/disneystreaming/weaver-test.git#59f609867dab318ab6e98bfc8eef3410f76abd48"
 
   extra.exclude: [
     "docs", "*JS", "zio*", "*2_12"

--- a/proj/zinc.conf
+++ b/proj/zinc.conf
@@ -2,7 +2,7 @@
 
 vars.proj.zinc: ${vars.base} {
   name: "zinc"
-  uri: "https://github.com/sbt/zinc.git#939b12defb271fa24a2ae3cfdacf87a42314c275"
+  uri: "https://github.com/sbt/zinc.git#d9b738484fe5275914d086c10b7c6c6a841c1ad8"
 
   extra.exclude: ["*2_10", "*2_11", "*2_12", "compilerBridgeTest", "*Benchmarks*"]
   extra.commands: ${vars.default-commands} [
@@ -13,6 +13,6 @@ vars.proj.zinc: ${vars.base} {
     // don't run these integration tests; they fail and it's not clear how much work it would be to fix;
     // see https://github.com/scala/community-build/pull/1280
     // (the version here must match whatever the repo is currently declaring, before dbuild overrides it.)
-    """set zinc.jvm("2.13.6") / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"""
+    """set zinc.jvm("2.13.8") / Test / executeTests := Tests.Output(TestResult.Passed, Map(), Iterable())"""
   ]
 }


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/3465/~
~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/3466/~
~https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/3469/~
https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/3472/