### PR TITLE
get zinc working on JDK 17

### DIFF
--- a/proj/zinc.conf
+++ b/proj/zinc.conf
@@ -1,8 +1,11 @@
-// https://github.com/sbt/zinc.git#develop
+// https://github.com/SethTisue/zinc.git#build-on-jdk17  # was sbt, develop
+
+// temporarily forked pending merge of
+// https://github.com/sbt/zinc/pull/1037
 
 vars.proj.zinc: ${vars.base} {
   name: "zinc"
-  uri: "https://github.com/sbt/zinc.git#d9b738484fe5275914d086c10b7c6c6a841c1ad8"
+  uri: "https://github.com/SethTisue/zinc.git#5ff4545c2258528930a61ccbf9189cd6361024da"
 
   extra.exclude: ["*2_10", "*2_11", "*2_12", "compilerBridgeTest", "*Benchmarks*"]
   extra.commands: ${vars.default-commands} [

--- a/report.sc
+++ b/report.sc
@@ -56,7 +56,6 @@ object SuccessReport:
     "scrooge", // Unrecognized VM option 'AggressiveOpts'
     "sttp", // sttp.client3.SttpBackendOptionsProxyTest2 fails (not investigated)
     "twitter-util", // Unrecognized VM option 'AggressiveOpts'
-    "zinc", // sbt.inc.Doc$JavadocGenerationFailed
   )
 
   val expectedToFail: Set[String] =


### PR DESCRIPTION
we're still not running the integration tests though 🤷 

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/450/