### PR TITLE
advance parboiled

### DIFF
--- a/proj/parboiled.conf
+++ b/proj/parboiled.conf
@@ -1,10 +1,11 @@
-// https://github.com/sirthias/parboiled.git#354945c950ced0a976864b36e6cab69d1a892a26  # was master
-
-// frozen at a known-green commit before a ScalaTest 3.1 upgrade
+// https://github.com/sirthias/parboiled.git#master
 
 vars.proj.parboiled: ${vars.base} {
   name: "parboiled"
-  uri: "https://github.com/sirthias/parboiled.git#354945c950ced0a976864b36e6cab69d1a892a26"
+  uri: "https://github.com/sirthias/parboiled.git#8c0bd6b6c684b0ea2f07492dd16588b62ed9344f"
 
   extra.projects: ["parboiled-scala"]
+  // in order to get JDK 17 support, we have to use a version
+  // that requires ScalaTest 3.2, so we can't compile or run tests
+  extra.run-tests: false
 }

--- a/proj/parboiled.conf
+++ b/proj/parboiled.conf
@@ -8,4 +8,7 @@ vars.proj.parboiled: ${vars.base} {
   // in order to get JDK 17 support, we have to use a version
   // that requires ScalaTest 3.2, so we can't compile or run tests
   extra.run-tests: false
+  extra.commands: ${vars.default-commands} [
+    "removeDependency org.scalatestplus testng-7-5"
+  ]
 }

--- a/report.sc
+++ b/report.sc
@@ -30,6 +30,7 @@ object SuccessReport:
     """\[info\] Project ((?:\w|-(?!-))+)-*: ([^\(]+) \((?:stuck on broken dependencies: )?(.*)\)""".r
 
   val jdk8Failures = Set[String](
+    "parboiled",              // requires JDK 11 (since sirthias/parboiled#195)
     "shapeless-java-records", // requires JDK 15
   )
 


### PR DESCRIPTION
in the hopes it will go green on JDK 17 ~and perhaps unlock some downstream projects? not sure, but let's see~ see below

references https://github.com/sirthias/parboiled/issues/175#issuecomment-1065029743

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7258/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7262/

https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk11-integrate-community-build/2359/

~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk17-integrate-community-build/379/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk17-integrate-community-build/380/