### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# February 23, 2022
-nightly=2.13.9-bin-99de462
+# March 11, 2022
+nightly=2.13.9-bin-d26ea64

--- a/proj/expecty.conf
+++ b/proj/expecty.conf
@@ -1,8 +1,12 @@
-// https://github.com/eed3si9n/expecty.git#develop
+// https://github.com/scalacommunitybuild/expecty.git#community-build-2.13  # was eed3si9n/develop
+
+// forked (March 2022) because 2.13.9 optimizes List.apply;
+// we should be able to unfork after 2.13.9 is released
+// and upstream has made the upgrade
 
 vars.proj.expecty: ${vars.base} {
   name: "expecty"
-  uri: "https://github.com/eed3si9n/expecty.git#0af90390eb8d5b7dae31682c0b14efe019b689bc"
+  uri: "https://github.com/scalacommunitybuild/expecty.git#6c6bec95241f1963189e4c5a763210bc9db14b4b"
 
   extra.projects: ["expecty"]  // this is the 2.13 one
   extra.settings: ${vars.base.extra.settings} [


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3575/  failed: expecty