### PR TITLE
re-enable all akka-http tests

### DIFF
--- a/proj/akka-http.conf
+++ b/proj/akka-http.conf
@@ -14,12 +14,6 @@ vars.proj.akka-http: ${vars.base} {
     "-Dakka.fail-mixed-versions=false"
   ]
   extra.commands: ${vars.default-commands} [
-    """set http2Support / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "WithPriorKnowledgeSpec.scala""""
-    // these were found to be flaky at some point
-    """set httpCore / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "GracefulTerminationSpec.scala" || "EntityDiscardingSpec.scala" || "WebSocketIntegrationSpec.scala""""
-    """set httpTests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CodingDirectivesSpec.scala" || "HttpAppSpec.scala""""
-    // consistently failing
-    """set http2Support / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "H2SpecIntegrationSpec.scala" || "Http2ServerSpec.scala""""
     // ...and this is for the tests that run forked
     """set ThisBuild / javaOptions += "-Dakka.fail-mixed-versions=false""""
   ]

--- a/proj/akka-http.conf
+++ b/proj/akka-http.conf
@@ -2,7 +2,7 @@
 
 vars.proj.akka-http: ${vars.base} {
   name: "akka-http"
-  uri: "https://github.com/akka/akka-http.git#6e9e97678a6c8890864f9421e712238c221a3e30"
+  uri: "https://github.com/akka/akka-http.git#15dc84972cfe13199dc34ca2542cb067a127c1f1"
 
   extra.exclude: ["docs", "akka-http-bench-jmh"]
   extra.options: [


### PR DESCRIPTION
let's find out which test exclusions are still needed, if any. cc @jrudolph 

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk8-integrate-community-build/4883/ 🟢

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3576/~
https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk11-integrate-community-build/3577/ 🟢

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/509/ 🟢

