### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# April 26, 2022
-nightly=2.13.9-bin-78376ed
+# May 5, 2022
+nightly=2.13.9-bin-1d51c22


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3676/ queued