### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 9, 2022
-nightly=2.12.16-bin-5bd9520
+# May 10, 2022
+nightly=2.12.16-bin-c850a83


### PR DESCRIPTION
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7399/ queued

🤞 — if this goes green, it'll be our 2.12.16 release candidate 