### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/advance.sc
+++ b/advance.sc
@@ -5,7 +5,7 @@
 // to advance just selected ones:
 //   % ./advance.sc scalacheck scalatest specs2
 
-//> using scala "3.1.3-RC4"
+//> using scala "3.1.3"
 //> using option "-source:future"
 //> using lib "org.scala-lang.modules::scala-parallel-collections:1.0.4"
 //> using lib "com.github.pathikrit:better-files_2.13:3.9.1"

--- a/narrow.sc
+++ b/narrow.sc
@@ -7,7 +7,7 @@
 
 // dependencies.txt is the source of truth for what dependencies to use
 
-//> using scala "3.1.3-RC4"
+//> using scala "3.1.3"
 //> using option "-source:future"
 //> using lib "com.github.pathikrit:better-files_2.13:3.9.1"
 

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# May 10, 2022
-nightly=2.12.16-bin-c850a83
+# June 8, 2022
+nightly=2.12.17-bin-35c6f5d

--- a/proj/genjavadoc.conf
+++ b/proj/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#e869b5528124f12efca4418eb1d7ec0238920fa2"
+  uri: "https://github.com/lightbend/genjavadoc.git#382442b5ced2587724ef0ab460cd6e4356585252"
 
 }

--- a/proj/scalatest.conf
+++ b/proj/scalatest.conf
@@ -6,7 +6,7 @@
 
 vars.proj.scalatest: ${vars.base} {
   name: "scalatest"
-  uri: "https://github.com/scalacommunitybuild/scalatest.git#4941c9fd882c90d6cfd4aa7e467864f63d736e0e"
+  uri: "https://github.com/scalacommunitybuild/scalatest.git#7da63353a8b90c6525ddbb13f2f6032f18147602"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.projects: ["scalatest", "scalactic"]
@@ -18,7 +18,7 @@ vars.proj.scalatest: ${vars.base} {
 
 vars.proj.scalatest-tests: ${vars.base} {
   name: "scalatest-tests"
-  uri: "https://github.com/scalacommunitybuild/scalatest.git#4941c9fd882c90d6cfd4aa7e467864f63d736e0e"
+  uri: "https://github.com/scalacommunitybuild/scalatest.git#7da63353a8b90c6525ddbb13f2f6032f18147602"
 
   extra.sbt-version: ${vars.sbt-0-13-version}
   extra.exclude: [
@@ -35,7 +35,7 @@ vars.proj.scalatest-tests: ${vars.base} {
   extra.options: ["-Xmx3072m"]
   extra.commands: ${vars.default-commands} [
     // prone to intermittent failure
-    """set excludeFilter in (Test, unmanagedSources) in scalatestTest := HiddenFileFilter || "AsyncFunSpecSpec.scala" || "AsyncFunSpecSpec2.scala" || "WaitersSpec.scala" || "ScalaFuturesSpec.scala" || "DispatchReporterSpec.scala" || "AsyncFunSpecLikeSpec2.scala" || "JUnitSuiteSpec.scala" || "AsyncFeatureSpecLikeSpec2.scala" || "ConductorFixtureSuite.scala" || "AsyncAssertionsSpec.scala" || "ConductorFixtureDeprecatedSuite.scala" || "TimeLimitsSpec.scala" || "JavaFuturesSpec.scala" || "TestThreadsStartingCounterSpec.scala" || "ConductorMethodsSuite.scala""""
+    """set excludeFilter in (Test, unmanagedSources) in scalatestTest := HiddenFileFilter || "AsyncFunSpecSpec.scala" || "AsyncFunSpecSpec2.scala" || "WaitersSpec.scala" || "ScalaFuturesSpec.scala" || "DispatchReporterSpec.scala" || "AsyncFunSpecLikeSpec2.scala" || "JUnitSuiteSpec.scala" || "AsyncFeatureSpecLikeSpec2.scala" || "ConductorFixtureSuite.scala" || "AsyncAssertionsSpec.scala" || "ConductorFixtureDeprecatedSuite.scala" || "TimeLimitsSpec.scala" || "JavaFuturesSpec.scala" || "TestThreadsStartingCounterSpec.scala" || "ConductorMethodsSuite.scala" || "DiagrammedAssertionsSpec.scala""""
     """set managedSources in Test in genRegularTests4 ~= (_.filterNot(_.getName == "TimeLimitsSpec.scala").filterNot(_.getName == "AsyncAssertionsSpec.scala").filterNot(_.getName == "WaitersSpec.scala").filterNot(_.getName == "AsyncFeatureSpecSpec.scala").filterNot(_.getName == "ConductorFixtureSuite.scala").filterNot(_.getName == "TestThreadsStartingCounterSpec.scala"))"""
     """set managedSources in Test in genRegularTests5 ~= (_.filterNot(_.getName == "AsyncFunSpecSpec2.scala").filterNot(_.getName == "TimeoutsSpec.scala"))"""
   ]

--- a/report.sc
+++ b/report.sc
@@ -1,6 +1,6 @@
 #!/usr/local/bin/env -S scala-cli -Dlog4j.configurationFile=scripts/log4j.properties shebang
 
-//> using scala "3.1.3-RC4"
+//> using scala "3.1.3"
 //> using option "-source:future"
 
 object ClocReport:


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7441/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7443/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7446/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7447/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7451/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7452/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7454/