### PR TITLE
2.12: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# July 21, 2022
-nightly=2.12.17-bin-1d34cf5
+# August 1, 2022
+nightly=2.12.17-bin-5ff747f

--- a/proj/scala-ssh.conf
+++ b/proj/scala-ssh.conf
@@ -1,10 +1,11 @@
-// https://github.com/sirthias/scala-ssh.git#0953a0dec6f094a879264343ee166bc02770d712  # was master
+// https://github.com/scalacommunitybuild/scala-ssh.git#community-build-2.12  # was sirthias, master
 
-// frozen at a known-green commit sometime before a ScalaTest 3.1 upgrade
+// forked from a known-green commit sometime before a ScalaTest 3.1 upgrade;
+// fork updated (August 2022) to remove `-target:jvm-1.8` (deprecated in Scala 2.12.17)
 
 vars.proj.scala-ssh: ${vars.base} {
   name: "scala-ssh"
-  uri: "https://github.com/sirthias/scala-ssh.git#0953a0dec6f094a879264343ee166bc02770d712"
+  uri: "https://github.com/scalacommunitybuild/scala-ssh.git#695c7d147df44575b425a29d9960e2536051d3a6"
 
   // compilation errors on 1.3.9?!
   // ScpTransferable.scala:52:33: not enough arguments for constructor LoggingTransferListener: (x$1: net.schmizz.sshj.common.LoggerFactory)net.schmizz.sshj.xfer.LoggingTransferListener.


### PR DESCRIPTION
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7544/~
~https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7545/~
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7548/
https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk8-integrate-community-build/7550/