### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# August 22, 2022
-nightly=2.13.9-bin-8685a46
+# August 24, 2022
+nightly=2.13.9-bin-1d1b6d7


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3908/ queued