### PR TITLE
2.13: new Scala SHA (new 2.13.9 release candidate)

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# September 1, 2022
-nightly=2.13.9-bin-d578a02
+# September 13, 2022
+nightly=2.13.9-bin-986dcc1


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3946/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3947/