### PR TITLE
2.13: new Scala SHA (2.13.10 release candidate)

### DIFF
--- a/core/genjavadoc.conf
+++ b/core/genjavadoc.conf
@@ -2,6 +2,6 @@
 
 vars.proj.genjavadoc: ${vars.base} {
   name: "genjavadoc"
-  uri: "https://github.com/lightbend/genjavadoc.git#effbb05d25ed9b337122b50e62ff635109981eb8"
+  uri: "https://github.com/lightbend/genjavadoc.git#28014c3c7e1296f66a6e61e6a08a9142ef3f3d4c"
 
 }

--- a/core/scalafmt.conf
+++ b/core/scalafmt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#c7403c3d09834a5e06e6d1b3aa88d01a6bbaec3c"
+  uri: "https://github.com/scalameta/scalafmt.git#37a5f2cc164e779b08d0996367bd15f771c36fae"
 
   extra.settings: ${vars.base.extra.settings} [
     // don't fail on scala-xml 1.x vs 2.x conflict

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -7,7 +7,7 @@
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalacommunitybuild/scalameta.git#690f7005e12a8fb170bad03b67cba4ade4793332"
+  uri: "https://github.com/scalacommunitybuild/scalameta.git#ea9cf42dbb19cfd32a6bd6c1ca18f53cad936809"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -14,6 +14,6 @@ vars.proj.scalameta: ${vars.base} {
     // use right version-specific source directories regardless of our weird dbuild Scala version numbers
     """set common.jvm / Compile / unmanagedSourceDirectories += baseDirectory.value / "scalameta" / "common" / "shared" / "src" / "main" / "scala-2.13""""
     """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13""""
-    """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13.8""""
+    """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13.9""""
   ]
 }

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# September 13, 2022
-nightly=2.13.9-bin-986dcc1
+# September 19, 2022
+nightly=2.13.10-bin-98972e5

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# September 19, 2022
-nightly=2.13.10-bin-98972e5
+# October 7, 2022
+nightly=2.13.10-bin-cd52542

--- a/proj/cachecontrol.conf
+++ b/proj/cachecontrol.conf
@@ -6,6 +6,6 @@ vars.proj.cachecontrol: ${vars.base} {
 
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/circe-generic-extras.conf
+++ b/proj/circe-generic-extras.conf
@@ -7,6 +7,6 @@ vars.proj.circe-generic-extras: ${vars.base} {
   extra.projects: ["genericExtras"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/discipline.conf
+++ b/proj/discipline.conf
@@ -7,7 +7,7 @@ vars.proj.discipline: ${vars.base} {
   extra.projects: ["coreJVM"]  // no Scala.js please
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     // "Credentials file [...] does not exist"

--- a/proj/http4s-jwt-auth.conf
+++ b/proj/http4s-jwt-auth.conf
@@ -7,7 +7,7 @@ vars.proj.http4s-jwt-auth: ${vars.base} {
   extra.projects: ["core"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     // fails on JDK 11. not investigated or reported

--- a/proj/ip4s.conf
+++ b/proj/ip4s.conf
@@ -7,7 +7,7 @@ vars.proj.ip4s: ${vars.base} {
   extra.exclude: ["*JS"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/jawn.conf
+++ b/proj/jawn.conf
@@ -7,6 +7,6 @@ vars.proj.jawn: ${vars.base} {
   extra.exclude: ["*JS", "*Native", "benchmark", "root"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/mima.conf
+++ b/proj/mima.conf
@@ -7,7 +7,7 @@ vars.proj.mima: ${vars.base} {
   extra.exclude: ["sbtplugin", "*Native"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   // `IntegrationTest/test` doesn't work but `it:test` does. dbuild limitation I guess
   extra.test-tasks: ["test", "it:test"]

--- a/proj/play-file-watch.conf
+++ b/proj/play-file-watch.conf
@@ -6,6 +6,6 @@ vars.proj.play-file-watch: ${vars.base} {
 
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/pureconfig.conf
+++ b/proj/pureconfig.conf
@@ -7,7 +7,7 @@ vars.proj.pureconfig: ${vars.base} {
   extra.exclude: ["scalaz", "docs"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     "set every semanticdbEnabled := false"

--- a/proj/scala-pet-store.conf
+++ b/proj/scala-pet-store.conf
@@ -6,6 +6,6 @@ vars.proj.scala-pet-store: ${vars.base} {
 
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/scalacheck.conf
+++ b/proj/scalacheck.conf
@@ -5,4 +5,7 @@ vars.proj.scalacheck: ${vars.base} {
   uri: "https://github.com/typelevel/scalacheck.git#7bb1a47af2313f7e7935d34cce255f7b7c0b1b31"
 
   extra.exclude: ["root", "bench", "*JS", "*Native"]
+  extra.commands: ${vars.default-commands} [
+    "set every gpgWarnOnFailure := true"
+  ]
 }

--- a/proj/scalikejdbc.conf
+++ b/proj/scalikejdbc.conf
@@ -8,7 +8,7 @@ vars.proj.scalikejdbc: ${vars.base} {
   extra.exclude: ["mapper-generator"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     """set scalikejdbcStreams / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "DatabasePublisherTckTest.scala""""

--- a/proj/scodec-stream.conf
+++ b/proj/scodec-stream.conf
@@ -11,7 +11,7 @@ vars.proj.scodec-stream: ${vars.base} {
   extra.exclude: ["*JS"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     "set every gpgWarnOnFailure := true"

--- a/proj/scodec.conf
+++ b/proj/scodec.conf
@@ -7,7 +7,7 @@ vars.proj.scodec: ${vars.base} {
   extra.projects: ["coreJVM"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
   extra.commands: ${vars.default-commands} [
     // because scodec-build brings in sbt-gpg which errors on `publish`

--- a/proj/treehugger.conf
+++ b/proj/treehugger.conf
@@ -7,6 +7,6 @@ vars.proj.treehugger: ${vars.base} {
   extra.exclude: ["root"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }

--- a/proj/twirl.conf
+++ b/proj/twirl.conf
@@ -7,6 +7,6 @@ vars.proj.twirl: ${vars.base} {
   extra.exclude: ["plugin", "*JS"]
   extra.settings: ${vars.base.extra.settings} [
     // dbuild gets confused if only crossScalaVersions is set?!
-    """ThisBuild / scalaVersion := "2.13.8""""
+    """ThisBuild / scalaVersion := "2.13.9""""
   ]
 }


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3959/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3961/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3962/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3985/