### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 4, 2022
-nightly=2.13.11-bin-4886921
+# November 25, 2022
+nightly=2.13.11-bin-7e2671b

--- a/proj/metals.conf
+++ b/proj/metals.conf
@@ -1,8 +1,11 @@
-// https://github.com/scalameta/metals.git#main
+// https://github.com/scalacommunitybuild/metals.git#community-build-2.13  # was scalameta, main
+
+// temporarily forked (November 2022) to adjust an expected
+// test output -- we should unfork once Scala 2.13.11 is out
 
 vars.proj.metals: ${vars.base} {
   name: "metals"
-  uri: "https://github.com/scalameta/metals.git#aee49242fc384988b9d9a5cd817c4620bd8f4204"
+  uri: "https://github.com/scalacommunitybuild/metals.git#d93d4adaa91de204d83a2f2c8f78372e963d3db3"
 
   // Vadim from Virtus writes:
   //


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4131/