### PR TITLE
2.13: sbt 1.8 (requiring new dbuild)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -29,7 +29,7 @@ include file("resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "1.7.3"
+  sbt-version: "1.8.0"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -4,6 +4,9 @@ vars.proj.circe: ${vars.base} {
   name: "circe"
   uri: "https://github.com/circe/circe.git#b2b7d49e9883a6c69e1e960be459d5e24b9f2446"
 
+  // "module name circe-scalafix/internal/rules_2.13 contains invalid '/'"
+  // -- reproducible outside dbuild with sbt 1.8.0 (repo is on 1.7.3)
+  extra.sbt-version: "1.7.3"
   extra.exclude: [
     "*JS", "*Native", "benchmark*", "scalajs*", "docs"
     "scalafixInternalTests"  // TODO needs scalafix-testkit

--- a/proj/scastie.conf
+++ b/proj/scastie.conf
@@ -7,6 +7,8 @@ vars.proj.scastie: ${vars.base} {
   name: "scastie"
   uri: "https://github.com/scalacommunitybuild/scastie.git#146c6fee62968d992f5f8fed3441177c7b06a9ad"
 
+  // "This version of the ScalablyTyped plugin only supports 1.7.x. You're currently using 1.8.0"
+  extra.sbt-version: "1.7.3"
   extra.exclude: [
     "*2_10", "*2_11", "*2_12", "*3", "*JS", "client", "sbtScastie"
     // ???, not investigated

--- a/run.sh
+++ b/run.sh
@@ -136,7 +136,7 @@ else
 fi
 
 # Set dbuild version and config file
-DBUILDVERSION=0.9.17
+DBUILDVERSION=0.9.20
 echo "dbuild version: $DBUILDVERSION"
 
 DBUILDCONFIG=$dbuild_file
@@ -151,7 +151,7 @@ fi
 # Download and extract dbuild if we haven't already got it
 if [ ! -d "dbuild-${DBUILDVERSION}" ]
 then
-  curl -LO "https://repo.lightbend.com/typesafe/ivy-releases/com.typesafe.dbuild/dbuild/${DBUILDVERSION}/tgzs/dbuild-${DBUILDVERSION}.tgz"
+  curl -LO "https://github.com/lightbend-labs/dbuild/releases/download/v${DBUILDVERSION}/dbuild-${DBUILDVERSION}.tgz"
   tar xfz "dbuild-${DBUILDVERSION}.tgz"
   rm "dbuild-${DBUILDVERSION}.tgz"
 fi


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4139/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4141/