### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# November 25, 2022
-nightly=2.13.11-bin-7e2671b
+# December 16, 2022
+nightly=2.13.11-bin-429d72d

--- a/proj/macwire.conf
+++ b/proj/macwire.conf
@@ -1,8 +1,11 @@
-// https://github.com/softwaremill/macwire.git#master
+// https://github.com/scalacommunitybuild/macwire.git#community-build-2.13  # was softwaremill, master
+
+// temporarily forked pending merge of
+// https://github.com/scala/community-build/pull/1623
 
 vars.proj.macwire: ${vars.base} {
   name: "macwire"
-  uri: "https://github.com/softwaremill/macwire.git#431daa3846456e35ec78b606fed8dcc0853ba340"
+  uri: "https://github.com/scalacommunitybuild/macwire.git#856f10a46bfa0fde281a4e8217b09a3af6f39dc5"
 
   extra.exclude: ["*2_12", "*JS", "*3"]
 }

--- a/proj/macwire.conf
+++ b/proj/macwire.conf
@@ -1,11 +1,8 @@
-// https://github.com/scalacommunitybuild/macwire.git#community-build-2.13  # was softwaremill, master
-
-// temporarily forked pending merge of
-// https://github.com/scala/community-build/pull/1623
+// https://github.com/softwaremill/macwire.git#master
 
 vars.proj.macwire: ${vars.base} {
   name: "macwire"
-  uri: "https://github.com/scalacommunitybuild/macwire.git#856f10a46bfa0fde281a4e8217b09a3af6f39dc5"
+  uri: "https://github.com/softwaremill/macwire.git#f1d176f9bbc97390c7a59212957b820cc5627aff"
 
   extra.exclude: ["*2_12", "*JS", "*3"]
 }

--- a/proj/scala-collection-laws.conf
+++ b/proj/scala-collection-laws.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scala-collection-laws: ${vars.base} {
   name: "scala-collection-laws"
-  uri: "https://github.com/scala/scala-collection-laws.git#646eebd617329a35eb132b02980dd8d6bd9c0ad9"
+  uri: "https://github.com/scala/scala-collection-laws.git#e215d0309560c593deb67351e93b5a9daeadb961"
 
   // as per the repo readme
   extra.options: ["-XX:MaxMetaspaceSize=1G", "-Xmx6G"]


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4178/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4182/