### PR TITLE
2.13: sbt 1.8.1 (was 1.8.0)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -29,7 +29,7 @@ include file("resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "1.8.0"
+  sbt-version: "1.8.1"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 


### PR DESCRIPTION
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4204/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4205/