### PR TITLE
2.13: sbt 1.9.0-RC1 (was 1.8.2)

### DIFF
--- a/community.conf
+++ b/community.conf
@@ -29,7 +29,7 @@ include file("resolvers.conf")
 
 vars {
   default-commands: []
-  sbt-version: "1.8.2"
+  sbt-version: "1.9.0-RC1"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/community.conf
+++ b/community.conf
@@ -30,6 +30,7 @@ include file("resolvers.conf")
 vars {
   default-commands: []
   sbt-version: "1.9.0-RC1"
+  sbt-1-8-version: "1.8.2"
   sbt-java-options: ["-Xms1536m", "-Xmx1536m", "-Xss2m"]
 }
 

--- a/proj/scastie.conf
+++ b/proj/scastie.conf
@@ -7,6 +7,8 @@ vars.proj.scastie: ${vars.base} {
   name: "scastie"
   uri: "https://github.com/scalacommunitybuild/scastie.git#01e23b20c0f6deacfa661064a937806194c91808"
 
+  // May 2023: This version of the ScalablyTyped plugin only supports 1.8.x
+  extra.sbt-version: ${vars.sbt-1-8-version}
   extra.exclude: [
     "*2_10", "*2_11", "*2_12", "*3", "*JS", "client", "sbtScastie"
     // ???, not investigated


### PR DESCRIPTION
fyi @eed3si9n 

~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4458/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4459/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4461/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4462/