### PR TITLE
unfreeze spire

### DIFF
--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -1,18 +1,15 @@
-// https://github.com/typelevel/spire.git#435e9aff7f7a855933e4bc97f2c72b2c07949418  # was main
-
-// frozen (January 2022) because something changed that confuses
-// dbuild and makes it try to build with Scala 3 (?!). not investigated;
-// probably sbt-typelevel related?
+// https://github.com/typelevel/spire.git#main
 
 vars.proj.spire: ${vars.base} {
   name: "spire"
-  uri: "https://github.com/typelevel/spire.git#435e9aff7f7a855933e4bc97f2c72b2c07949418"
+  uri: "https://github.com/typelevel/spire.git#cb897d2f0ea88ffb00caf96cafaefcceed70b990"
 
   // hopefully avoid intermittent OutOfMemoryErrors during compilation
   extra.options: ["-Xmx3G"]
   extra.projects: ["*JVM"]
-  extra.exclude: ["spireJVM", "benchmark"]
   extra.commands: ${vars.default-commands} [
+    // otherwise sbt-gpg errors on `publish`
+    "set every gpgWarnOnFailure := true"
     // jmh stuff is out of scope
     "removeDependency org.openjdk.jmh jmh-core"
     "removeDependency org.openjdk.jmh jmh-generator-bytecode"

--- a/proj/spire.conf
+++ b/proj/spire.conf
@@ -7,6 +7,7 @@ vars.proj.spire: ${vars.base} {
   // hopefully avoid intermittent OutOfMemoryErrors during compilation
   extra.options: ["-Xmx3G"]
   extra.projects: ["*JVM"]
+  extra.exclude: ["benchmark"]
   extra.commands: ${vars.default-commands} [
     // otherwise sbt-gpg errors on `publish`
     "set every gpgWarnOnFailure := true"


### PR DESCRIPTION
I think at the time I froze spire I hadn't yet discovered that repos that don't explicitly set `scalaVersion` are problematic for dbuild.