### PR TITLE
JDK 21 fixes

### DIFF
--- a/proj/circe.conf
+++ b/proj/circe.conf
@@ -4,9 +4,6 @@ vars.proj.circe: ${vars.base} {
   name: "circe"
   uri: "https://github.com/circe/circe.git#172c9a4d9e14270bab59700d9ffe439462c23db7"
 
-  // "module name circe-scalafix/internal/rules_2.13 contains invalid '/'"
-  // -- reproducible outside dbuild with sbt 1.8.0 (repo is on 1.7.3)
-  extra.sbt-version: "1.7.3"
   extra.exclude: [
     "*JS", "*Native", "benchmark*", "scalajs*", "docs"
     "scalafixInternalTests"  // TODO needs scalafix-testkit

--- a/proj/scastie.conf
+++ b/proj/scastie.conf
@@ -1,14 +1,16 @@
 // https://github.com/scalacommunitybuild/scastie.git#community-build-2.13  # was scalacenter, master
 
 // forked (November 2022) to remove a weird build thing that was
-// confusing dbuild
+// confusing dbuild; fork updated June 2023
 
 vars.proj.scastie: ${vars.base} {
   name: "scastie"
-  uri: "https://github.com/scalacommunitybuild/scastie.git#01e23b20c0f6deacfa661064a937806194c91808"
+  uri: "https://github.com/scalacommunitybuild/scastie.git#413db2e5b02eabb63adddca6c47a4a1bd54c1179"
 
   // May 2023: This version of the ScalablyTyped plugin only supports 1.8.x
+  // waiting on https://github.com/ScalablyTyped/Converter/issues/541
   extra.sbt-version: ${vars.sbt-1-8-version}
+  extra.options: ["-Dsbt.scala.version=2.12.18"]  // for JDK 21
   extra.exclude: [
     "*2_10", "*2_11", "*2_12", "*3", "*JS", "client", "sbtScastie"
     // ???, not investigated


### PR DESCRIPTION
context: #1666

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk21-integrate-community-build/31/