### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# June 3, 2023
-nightly=2.13.12-bin-1a2373b
+# June 20, 2023
+nightly=2.13.12-bin-7db02fe

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# June 20, 2023
-nightly=2.13.12-bin-7db02fe
+# July 3, 2023
+nightly=2.13.12-bin-7c63166

--- a/proj/scapegoat.conf
+++ b/proj/scapegoat.conf
@@ -5,6 +5,11 @@
 
 vars.proj.scapegoat: ${vars.base} {
   name: "scapegoat"
-  uri: "https://github.com/scalacommunitybuild/scapegoat.git#882d1fb2d8e804b1af4d0731df079142479eb218"
+  uri: "https://github.com/scalacommunitybuild/scapegoat.git#8178323da1228d68dea056a59133ada7b0189173"
 
+  extra.commands: ${vars.default-commands} [
+    // test started failing on 2.13.12; see my remarks at
+    // https://github.com/scala/community-build/pull/1677#issuecomment-1614721682
+    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "UnnecessaryConversionTest.scala""""
+  ]
 }

--- a/proj/scapegoat.conf
+++ b/proj/scapegoat.conf
@@ -5,7 +5,7 @@
 
 vars.proj.scapegoat: ${vars.base} {
   name: "scapegoat"
-  uri: "https://github.com/scalacommunitybuild/scapegoat.git#883d336dab2c93b34e887fa5a4b43fc8a5636f9f"
+  uri: "https://github.com/scalacommunitybuild/scapegoat.git#882d1fb2d8e804b1af4d0731df079142479eb218"
 
   // because of https://github.com/scala/scala/pull/9208, is my guess --
   // we should be able to re-enable after upstream moves to 2.13.4

--- a/proj/scapegoat.conf
+++ b/proj/scapegoat.conf
@@ -1,15 +1,10 @@
-// https://github.com/scalacommunitybuild/scapegoat.git#community-build-2.13  # was sksamuel, master
+// https://github.com/scalacommunitybuild/scapegoat.git#community-build-2.13  # was scapegoat-scala, master
 
-// forked (August 2019; refreshed July 2020) because some
+// forked (August 2019; refreshed June 2023) because some
 // classpath-handling code didn't work under dbuild
 
 vars.proj.scapegoat: ${vars.base} {
   name: "scapegoat"
   uri: "https://github.com/scalacommunitybuild/scapegoat.git#882d1fb2d8e804b1af4d0731df079142479eb218"
 
-  // because of https://github.com/scala/scala/pull/9208, is my guess --
-  // we should be able to re-enable after upstream moves to 2.13.4
-  extra.commands: ${vars.default-commands} [
-    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ComparisonToEmptyListTest.scala""""
-  ]
 }

--- a/proj/scapegoat.conf
+++ b/proj/scapegoat.conf
@@ -5,7 +5,7 @@
 
 vars.proj.scapegoat: ${vars.base} {
   name: "scapegoat"
-  uri: "https://github.com/scalacommunitybuild/scapegoat.git#8178323da1228d68dea056a59133ada7b0189173"
+  uri: "https://github.com/scalacommunitybuild/scapegoat.git#ecd064439af8f3ca447d6656c513eded477031c9"
 
   extra.commands: ${vars.default-commands} [
     // test started failing on 2.13.12; see my remarks at


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4574/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4576/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4577/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4599/