### PR TITLE
Scalameta 4.7.8 (was .6)

### DIFF
--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -1,11 +1,11 @@
-// https://github.com/scalameta/scalameta.git#v4.7.6
+// https://github.com/scalameta/scalameta.git#v4.7.8
 
 // we typically use a tag here rather than track a branch, in the
 // interest of stability.  whatever tag scalafmt and/or scalafix expect
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalameta/scalameta.git#aa5ccfca917bafa28073194cb44cd9effe467553"
+  uri: "https://github.com/scalameta/scalameta.git#733169ecb6758bfbb2de0d2718be620d7c98294e"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/proj/shapeless.conf
+++ b/proj/shapeless.conf
@@ -2,7 +2,7 @@
 
 vars.proj.shapeless: ${vars.base} {
   name: "shapeless"
-  uri: "https://github.com/milessabin/shapeless.git#13225be7d3a3b6b8e39f375007d12621b9aaa0a7"
+  uri: "https://github.com/milessabin/shapeless.git#ac12b5609099805e19bbf495520d126cb5279df2"
 
   extra.projects: ["coreJVM"]
 }


### PR DESCRIPTION
Scalameta 4.8.0 is out. Rather than attempt to go straight there, let's see if we can get on 4.7.8 first

(Shapeless version bump is unrelated, but I'd like to get it in)

https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4594/ queued