### PR TITLE
Run all tests for Scapegoat

### DIFF
--- a/proj/scapegoat.conf
+++ b/proj/scapegoat.conf
@@ -6,10 +6,4 @@
 vars.proj.scapegoat: ${vars.base} {
   name: "scapegoat"
   uri: "https://github.com/scalacommunitybuild/scapegoat.git#883d336dab2c93b34e887fa5a4b43fc8a5636f9f"
-
-  // because of https://github.com/scala/scala/pull/9208, is my guess --
-  // we should be able to re-enable after upstream moves to 2.13.4
-  extra.commands: ${vars.default-commands} [
-    """set Test / unmanagedSources / excludeFilter := HiddenFileFilter || "ComparisonToEmptyListTest.scala""""
-  ]
 }


### PR DESCRIPTION
Stumbled upon this in https://github.com/scala/community-build/pull/1677. The tests should be green by now. (Otherwise I'll take another look.)