### PR TITLE
2.13: new Scala SHA

### DIFF
--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -1,11 +1,13 @@
-// https://github.com/scalameta/scalameta.git#v4.8.3
+// https://github.com/scalacommunitybuild/scalameta.git#community-build-2.13  # was scalameta, v4.8.3
 
 // we typically use a tag here rather than track a branch, in the
 // interest of stability.  whatever tag scalafmt and/or scalafix expect
 
+// temporarily forked (July 2023) for 2.13.12 change (scala/scala#10406)
+
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalameta/scalameta.git#5d32d25e3c51fec63be0d54c9e513e1e6f226582"
+  uri: "https://github.com/scalacommunitybuild/scalameta.git#4e53fe054ce99965a5a3d3bb021ffd9feb725346"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# July 3, 2023
-nightly=2.13.12-bin-7c63166
+# July 13, 2023
+nightly=2.13.12-bin-dd33bd3

--- a/nightly.properties
+++ b/nightly.properties
@@ -1,2 +1,2 @@
-# July 13, 2023
-nightly=2.13.12-bin-dd33bd3
+# July 14, 2023
+nightly=2.13.12-bin-a11bacd


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4623/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4628/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4629/
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/4630/