### PR TITLE
move to Scalameta 4.10.x

### DIFF
--- a/core/scalafix.conf
+++ b/core/scalafix.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#2722e5d04f21eb90f75f6e649dd02e43c95fb435"
+  uri: "https://github.com/scalacenter/scalafix.git#24078c391ae1f9e823489afe008318bcc13ae90d"
 
   extra.options: ["-Dscala213.nightly="${vars.scala-version}]
   extra.projects: ["*2_13"]

--- a/core/scalafix.conf
+++ b/core/scalafix.conf
@@ -9,13 +9,5 @@ vars.proj.scalafix: ${vars.base} {
   extra.exclude: ["docs2_13"]
   extra.commands: ${vars.default-commands} [
     "removeScalacOptions -release 8"
-    // CliGitDiffSuite: CommandLineError=4 did not equal Ok=0 error: 'master' unknown revision or path not in the working tree.
-    // SymbolInformationSuite: awaiting https://github.com/scalacenter/scalafix/pull/1774
-    """set unit.allProjects.map(_._1).find(_.id == "unit2_13").get / unmanagedSources / excludeFilter := HiddenFileFilter || "CliGitDiffSuite.scala" || "SymbolInformationSuite.scala""""
-    // most of these fail because they're fetching dbuild-built dependencies
-    // (Scalameta and Scalafix itself) at runtime. I didn't dig into it.
-    // PrettyExpectSuite: awaiting https://github.com/scalacenter/scalafix/pull/1774
-    // SaveExpect: depends on PrettyExpectSuite
-    """set integration.allProjects.map(_._1).find(_.id == "integration2_13").get / unmanagedSources / excludeFilter := HiddenFileFilter || "ScalafixSuite.scala" || "ScalafixImplSuite.scala" || "ScalafixArgumentsSuite.scala" || "PrettyExpectSuite.scala" || "SaveExpect.scala""""
   ]
 }

--- a/core/scalafix.conf
+++ b/core/scalafix.conf
@@ -1,8 +1,11 @@
-// https://github.com/scalacenter/scalafix.git#main
+// https://github.com/scalacenter/scalafix.git#8f0de249869f8744123ff69fb875ea5afddae140  # was main
+
+// frozen (September 2024) at an August 2024 before a dependency
+// was added on a snapshot -- perhaps that's only temporary
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#24078c391ae1f9e823489afe008318bcc13ae90d"
+  uri: "https://github.com/scalacenter/scalafix.git#8f0de249869f8744123ff69fb875ea5afddae140"
 
   extra.options: ["-Dscala213.nightly="${vars.scala-version}]
   extra.projects: ["*2_13"]

--- a/core/scalafix.conf
+++ b/core/scalafix.conf
@@ -1,11 +1,8 @@
-// https://github.com/scalacenter/scalafix.git#8f0de249869f8744123ff69fb875ea5afddae140  # was main
-
-// frozen (September 2024) at an August 2024 before a dependency
-// was added on a snapshot -- perhaps that's only temporary
+// https://github.com/scalacenter/scalafix.git#main
 
 vars.proj.scalafix: ${vars.base} {
   name: "scalafix"
-  uri: "https://github.com/scalacenter/scalafix.git#8f0de249869f8744123ff69fb875ea5afddae140"
+  uri: "https://github.com/scalacenter/scalafix.git#9c282a551d8b50fb98feaa1335adc6b53f1e7a4c"
 
   extra.options: ["-Dscala213.nightly="${vars.scala-version}]
   extra.projects: ["*2_13"]

--- a/core/scalafmt.conf
+++ b/core/scalafmt.conf
@@ -1,10 +1,8 @@
-// https://github.com/scalameta/scalafmt.git#760de95fbf0be61cd6e91616e2e680efb2d5e24d  # was main
-
-// frozen (September 2024) until we are on newer Scalameta
+// https://github.com/scalameta/scalafmt.git#main
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#760de95fbf0be61cd6e91616e2e680efb2d5e24d"
+  uri: "https://github.com/scalameta/scalafmt.git#73e2831e646b763f58e625a2f7ad509b7d632fc8"
 
   extra.settings: ${vars.base.extra.settings} [
     // don't fail on scala-xml 1.x vs 2.x conflict

--- a/core/scalafmt.conf
+++ b/core/scalafmt.conf
@@ -2,7 +2,7 @@
 
 vars.proj.scalafmt: ${vars.base} {
   name: "scalafmt"
-  uri: "https://github.com/scalameta/scalafmt.git#73e2831e646b763f58e625a2f7ad509b7d632fc8"
+  uri: "https://github.com/scalameta/scalafmt.git#2559975e2d8d30a42807f5438c75de24179c524b"
 
   extra.settings: ${vars.base.extra.settings} [
     // don't fail on scala-xml 1.x vs 2.x conflict

--- a/core/scalafmt.conf
+++ b/core/scalafmt.conf
@@ -11,7 +11,7 @@ vars.proj.scalafmt: ${vars.base} {
   ]
   extra.projects: ["coreJVM", "cli", "tests", "dynamic"]
   extra.commands: ${vars.default-commands} [
-    """set tests / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CliTest.scala" || "GitOpsTest.scala""""
-    """set dynamic / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "DynamicSuite.scala""""
+    """set tests.jvm / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "CliTest.scala" || "GitOpsTest.scala""""
+    """set dynamic.jvm / Test / unmanagedSources / excludeFilter := HiddenFileFilter || "DynamicSuite.scala""""
   ]
 }

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -12,6 +12,5 @@ vars.proj.scalameta: ${vars.base} {
     // use right version-specific source directories regardless of our weird dbuild Scala version numbers
     """set common.jvm / Compile / unmanagedSourceDirectories += baseDirectory.value / "scalameta" / "common" / "shared" / "src" / "main" / "scala-2.13""""
     """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13""""
-    """set semanticdbScalacCore / Compile / unmanagedSourceDirectories += baseDirectory.value / "semanticdb" / "scalac" / "library" / "src" / "main" / "scala-2.13.12""""
   ]
 }

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -1,11 +1,11 @@
-// https://github.com/scalameta/scalameta.git#v4.9.9
+// https://github.com/scalameta/scalameta.git#v4.10.2
 
 // we often use a tag here rather than track a branch, in the
 // interest of stability.  whatever tag scalafmt and/or scalafix and/or metals expect
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalameta/scalameta.git#b76d04bdad1e8c47048ab4e57ac56b7d7e21a921"
+  uri: "https://github.com/scalameta/scalameta.git#1bdb267be311d528e31ad01a2aa06cbe2e8f879b"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/core/scalameta.conf
+++ b/core/scalameta.conf
@@ -1,13 +1,11 @@
-// https://github.com/scalacommunitybuild/scalameta.git#community-build-2.13  # was scalameta, v4.9.3
+// https://github.com/scalameta/scalameta.git#v4.9.9
 
 // we often use a tag here rather than track a branch, in the
-// interest of stability.  whatever tag scalafmt and/or scalafix expect
-
-// forked (August 2024) to make a source tweak for JDK 23
+// interest of stability.  whatever tag scalafmt and/or scalafix and/or metals expect
 
 vars.proj.scalameta: ${vars.base} {
   name: "scalameta"
-  uri: "https://github.com/scalacommunitybuild/scalameta.git#e18d7479288bf0d64d8414bf862a969058ce587b"
+  uri: "https://github.com/scalameta/scalameta.git#b76d04bdad1e8c47048ab4e57ac56b7d7e21a921"
 
   extra.projects: ["semanticdbScalacPlugin", "testkitJVM"]
   extra.commands: ${vars.default-commands} [

--- a/proj/metals.conf
+++ b/proj/metals.conf
@@ -5,7 +5,7 @@
 
 vars.proj.metals: ${vars.base} {
   name: "metals"
-  uri: "https://github.com/scalameta/metals.git#8e729b2b0e88423524a76fe3f6d34862eab77bb8"
+  uri: "https://github.com/scalameta/metals.git#b77fedf0a154cf8a53f1479542a5ce744e97e5cc"
 
   extra.options: ["-Xmx3g"]
   // Vadim from Virtus writes:
@@ -27,8 +27,5 @@ vars.proj.metals: ${vars.base} {
   extra.commands: ${vars.default-commands} [
     // HoverTermSuite: https://github.com/scalameta/metals/issues/5318
     """set javapc / unmanagedSources / excludeFilter := HiddenFileFilter || "HoverTermSuite.scala""""
-    // SHDS: too-fragile test -- we can re-enable once they take the 2.13.13 upgrade
-    // CSCS: started failing September 2024, maybe un-freezing might fix it?
-    """set cross / unmanagedSources / excludeFilter := HiddenFileFilter || "SignatureHelpDocSuite.scala" || "CompletionScalaCliSuite.scala""""
   ]
 }

--- a/proj/metals.conf
+++ b/proj/metals.conf
@@ -1,13 +1,11 @@
-// https://github.com/scalameta/metals.git#df8c825badfff428708bf59b8e01f0d805cc193c  # was main
+// https://github.com/scalameta/metals.git#main
 
 // note that there are always test failures when we run on a PR validation
 // snapshot. (we could probably fix it by adding a resolver in the repo?)
 
-// frozen (September 2024) until we are on newer scalameta
-
 vars.proj.metals: ${vars.base} {
   name: "metals"
-  uri: "https://github.com/scalameta/metals.git#df8c825badfff428708bf59b8e01f0d805cc193c"
+  uri: "https://github.com/scalameta/metals.git#8e729b2b0e88423524a76fe3f6d34862eab77bb8"
 
   extra.options: ["-Xmx3g"]
   // Vadim from Virtus writes:

--- a/proj/metals.conf
+++ b/proj/metals.conf
@@ -27,5 +27,8 @@ vars.proj.metals: ${vars.base} {
   extra.commands: ${vars.default-commands} [
     // HoverTermSuite: https://github.com/scalameta/metals/issues/5318
     """set javapc / unmanagedSources / excludeFilter := HiddenFileFilter || "HoverTermSuite.scala""""
+    // SHDS: too-fragile test -- thought we could re-enable once they'd taken the 2.13.13 upgrade, but no?
+    // needs investigation
+    """set cross / unmanagedSources / excludeFilter := HiddenFileFilter || "SignatureHelpDocSuite.scala""""
   ]
 }


### PR DESCRIPTION
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/2119/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/2122/~
~https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/2167/~
https://scala-ci.typesafe.com/job/scala-2.13.x-jdk17-integrate-community-build/2169/